### PR TITLE
Move towards clap-based CLI tool with explicit metapac extract and generate commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bare-metal"
@@ -103,12 +103,12 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "chiptool"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/chiptool.git?rev=e32df6ff54b4520692452e6f4432039336be40a6#e32df6ff54b4520692452e6f4432039336be40a6"
+source = "git+https://github.com/embassy-rs/chiptool.git?rev=be1bff3e9e1b27b090e69bd9ac753c66fdcce678#be1bff3e9e1b27b090e69bd9ac753c66fdcce678"
 dependencies = [
  "anyhow",
  "clap",
+ "convert_case",
  "env_logger",
- "inflections",
  "log",
  "proc-macro2",
  "quote",
@@ -163,6 +163,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cortex-m"
@@ -259,7 +268,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -280,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -333,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -345,9 +354,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -378,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -429,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nb"
@@ -469,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -481,9 +490,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -542,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -552,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -591,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "roxmltree"
@@ -612,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "semver"
@@ -663,15 +672,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -780,11 +789,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -800,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -863,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -881,9 +890,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -938,3 +953,9 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,27 +13,12 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -46,15 +31,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -144,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -154,11 +130,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -166,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -318,7 +294,7 @@ version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "env_filter",
  "jiff",
@@ -337,6 +313,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chiptool",
+ "clap",
  "indexmap",
  "inflections",
  "proc-macro2",
@@ -535,18 +512,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -765,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "chiptool"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/chiptool.git?rev=fe4d3b069d778b9e1872759b78be6e569745464d#fe4d3b069d778b9e1872759b78be6e569745464d"
+source = "git+https://github.com/embassy-rs/chiptool.git?rev=e32df6ff54b4520692452e6f4432039336be40a6#e32df6ff54b4520692452e6f4432039336be40a6"
 dependencies = [
  "anyhow",
  "clap",
@@ -323,6 +323,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_yaml",
  "svd-parser 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "temp-dir",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "clap",
  "indexmap",
  "inflections",
+ "itertools",
  "proc-macro2",
  "quote",
  "rayon",
@@ -365,6 +366,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "chiptool"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/chiptool.git?rev=2fd28c5825998008a1a2ab8bab18555c2e314334#2fd28c5825998008a1a2ab8bab18555c2e314334"
+source = "git+https://github.com/embassy-rs/chiptool.git?rev=fe4d3b069d778b9e1872759b78be6e569745464d#fe4d3b069d778b9e1872759b78be6e569745464d"
 dependencies = [
  "anyhow",
  "clap",
@@ -320,6 +320,7 @@ dependencies = [
  "quote",
  "rayon",
  "read-dir-all",
+ "regex",
  "serde",
  "serde_json",
  "svd-parser 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -556,9 +557,9 @@ checksum = "e8375ddee477bd7ddd795a17f4448cfc2600cd649318cc5e542635cefd0c438c"
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -568,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/README.md
+++ b/README.md
@@ -8,28 +8,38 @@ If you want to regenerate the pac, you need to clone with `--recursive`.
 
 If you forgot this, you can use `git submodule update --checkout --init` to fetch the submodules.
 
+## PAC vs MetaPAC
+
+This crate is in transition from generating the PAC from the NXP provided SVD files, to a metapac approach where the SVD is only used to extract general peripheral definition files.
+A metapac definition file then specifies which peripherals are included in the chip.
+This is very useful when a vendor has used similar peripheral IPs across their portfolio.
+This allows HAL authors to write drivers for these peripheral IPs, instead of having to copy-paste them for each supported chipset.
+
+Because the crate is in transition, some of them use the PAC method, and some of them are part of the metapac.
+
+## Supported chips
+
+| Chip | Type |
+|------|------|
+| MIMXRT1011 | PAC |
+| MIMXRT1062 | PAC |
+| MIMXRT1064 | PAC |
+| MIMXRT685S | PAC |
+| LPC55S16 | PAC |
+| LPC55S69 | PAC |
+| MCXN947 | PAC |
+| MCXA256 | MetaPAC |
+| MCXA577 | MetaPAC |
+
 ## Tour
 
-The `data` directory contains the SVD files, board metadata, and chiptool transformations needed to
+The [`data`](/data) directory contains the SVD files, board metadata, and chiptool transformations needed to
 generate the nxp-pac crate. This data is used by the code generation tool.
 
-The `generator` directory contains the code generation tool for generating the code in the `nxp-pac` crate.
-If you want change the way the `nxp-pac` crate is generated please see this directory.
-Run it using `cargo run -p generator -- -h`.
+The [`generator`](/generator) directory contains the code generation tool for generating the code in the [`nxp-pac`](/nxp-pac) crate.
+If you want change the way the [`nxp-pac`](/nxp-pac) crate is generated please see this directory.
 
-```
-Usage: generator <COMMAND>
-
-Commands:
-  generate  Generate the nxp-pac Rust code for a single chip or all the chips
-  extract   Extract all metadata information from the SVD and apply any transforms
-  help      Print this message or the help of the given subcommand(s)
-
-Options:
-  -h, --help  Print help
-```
-
-The `nxp-pac` directory contains the nxp-pac crate. If you are looking for a peripheral access crate for
+The [`nxp-pac`](/nxp-pac) directory contains the nxp-pac crate. If you are looking for a peripheral access crate for
 an NXP microcontroller, please see this directory. You should never need to manually edit the source
 code in this directory. The metadata will need to be updated to support new microcontrollers.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,19 @@ generate the nxp-pac crate. This data is used by the code generation tool.
 
 The `generator` directory contains the code generation tool for generating the code in the `nxp-pac` crate.
 If you want change the way the `nxp-pac` crate is generated please see this directory.
-Run it using `cargo run -p generator -- <CHIP>`.
+Run it using `cargo run -p generator -- -h`.
+
+```
+Usage: generator <COMMAND>
+
+Commands:
+  generate  Generate the nxp-pac Rust code for a single chip or all the chips
+  extract   Extract all metadata information from the SVD and apply any transforms
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+```
 
 The `nxp-pac` directory contains the nxp-pac crate. If you are looking for a peripheral access crate for
 an NXP microcontroller, please see this directory. You should never need to manually edit the source

--- a/data/metadata/peripherals/README.md
+++ b/data/metadata/peripherals/README.md
@@ -1,12 +1,33 @@
-The generator when using the extract command will put transformed SVD data into the `raw` folder.
-This is not used for anything later on, but serves for debugging purposes.
+# Metapac peripherals
+This directory contains the register and type definitions for peripheral IPs that are included in NXP chipsets.
+
+NXP does not give us the internal name of these peripheral IPs. (for example: Synopsis USB-OTG rev. 2)
+It's up to us to create some sort of consistency there.
+
+These files are manually curated and considered to be the 'source of truth' when generating the metapac Rust source code.
+Even though they are assembled by hand, they are derived from the SVD files provided by the vendor.
+
+This derivation ideally happens through chiptool transforms, but manual changes to these files are also allowed.
+When adding manual changes, please note them with appropriate comments in the YAML files.
+
+
+
+## Updating
+The generator when using the `extract` command will put transformed SVD data into the `raw` folder.
+Anything in this folder is not used directly, but can be used by you as a start to define metapac peripherals and chips.
+
 This is per device:
 
-- A YAML per peripheral, with transforms applied and namespaces stripped. In order to develop transforms, refer to everything in the `raw/original` folder, which are the same files but without the namespaces stripped.
-  These files are suitable to base your metapac peripheral definition files on.
+- A YAML per peripheral, with transforms applied and namespaces stripped. These files are suitable to base your metapac peripheral definition files on.
+- Everything in the `raw/original` folder, which are the same files but without the namespaces stripped. These files are the direct output of the transforms, and thus useful when developing the transforms.
 - `_addresses.json`: A list of all peripherals and their addresses, taken from the SVD. Handy for adding it to the metadata.
 - `_interrupts.json`: A list of all interrupts and their numbers, taken from the SVD. Handy for adding it to the metadata.
 
-The other folders contain the manually curated YAMLs of the peripherals.
-The exact names are not prescribed. NXP doesn't give us names, so it's up to us to create some sort of consistency there.
-The metadata points to those YAMLs.
+Thus the workflow to add or change a peripheral is as follows: (change MCXA577 to your chipset)
+* Run `cargo run -p generator -- extract MCXA577`
+* Open `/data/metadata/peripherals/raw/MCXA577/<peripheral>.yaml`
+* Check if it is correct, if not change the transforms in `/data/transforms` and re-run `extract` until it is.
+* Copy the file over, and check the changes compared to what was already committed when relevant.
+* It is also allowed to change the file by hand at this point, but please use comments to denote what and why you changed (and why you didn't use a transform).
+* Generate the new nxp-pac code by running `cargo run -p generator -- generate MCXA577`
+* Check the code changes and commit both the nxp-pac code and the metadata definitions.

--- a/data/metadata/peripherals/README.md
+++ b/data/metadata/peripherals/README.md
@@ -1,10 +1,9 @@
-The generator will put transformed SVD data into the `raw` folder.
+The generator when using the extract command will put transformed SVD data into the `raw` folder.
 This is not used for anything later on, but serves for debugging purposes.
 This is per device:
 
-- A YAML per peripheral, directly from the SVD
-- A `_debug_ir.yaml` that represents the non-metapac version of the pac. It's the result of running the SVD through the transforms.
-  This is a good source when porting over a pac to the metapac.
+- A YAML per peripheral, with transforms applied and namespaces stripped. In order to develop transforms, refer to everything in the `raw/original` folder, which are the same files but without the namespaces stripped.
+  These files are suitable to base your metapac peripheral definition files on.
 - `_addresses.json`: A list of all peripherals and their addresses, taken from the SVD. Handy for adding it to the metadata.
 - `_interrupts.json`: A list of all interrupts and their numbers, taken from the SVD. Handy for adding it to the metadata.
 

--- a/data/metadata/peripherals/mcxa/TRNG.yaml
+++ b/data/metadata/peripherals/mcxa/TRNG.yaml
@@ -111,7 +111,7 @@ block/Trng:
     description: Statistical Check Run Length 6+ Count Register.
     byte_offset: 56
     access: Read
-    fieldset: SCr6pc
+    fieldset: Scr6pc
   - name: scr6pl
     description: Statistical Check Run Length 6+ Limit Register.
     byte_offset: 56

--- a/data/transforms/mcxa/adc.yaml
+++ b/data/transforms/mcxa/adc.yaml
@@ -3,19 +3,19 @@ transforms:
     from: hsadc::(.*)
     to: adc::$1
     type: All
-  
+
   - !Rename
     from: adc::Hsadc
     to: adc::Adc
     type: Block
 
   - !MergeEnums
-    from: adc::vals::Cmdl(\d+)(.+)
-    to: adc::vals::$2
+    from: adc::Cmdl(\d+)(.+)
+    to: adc::$2
 
   - !MergeFieldsets
-    from: adc::regs::Cmdl(\d+)
-    to: adc::regs::Cmdl
+    from: adc::Cmdl(\d+)
+    to: adc::Cmdl
 
   - !MakeRegisterArray
     blocks: adc::Adc
@@ -23,26 +23,26 @@ transforms:
     to: cmdl
 
   - !MergeEnums
-    from: adc::vals::Cmdh(\d+)(.+)
-    to: adc::vals::$2
+    from: adc::Cmdh(\d+)(.+)
+    to: adc::$2
 
   - !MergeFieldsets
-    from: adc::regs::Cmdh(\d+)
-    to: adc::regs::Cmdh
-  
+    from: adc::Cmdh(\d+)
+    to: adc::Cmdh
+
   - !MakeRegisterArray
     blocks: adc::Adc
     from: cmdh(\d+)
     to: cmdh
 
   - !DeleteEnums
-    from: adc::vals::Swt(\d+)
+    from: adc::Swt(\d+)
 
   # ADC channel select is not correct at all, better use bare u8.
   - !DeleteEnums
-    from: adc::vals::Adch
+    from: adc::Adch
 
   - !MakeFieldArray
-    fieldsets: adc::regs::Swtrig
+    fieldsets: adc::Swtrig
     from: swt(\d+)
     to: swt

--- a/data/transforms/mcxa/can.yaml
+++ b/data/transforms/mcxa/can.yaml
@@ -1,23 +1,23 @@
 transforms:
   - !MergeFieldsets
-    from: can::regs::(Cs|Id)(\d+)
-    to: can::regs::$1
+    from: can::(Cs|Id)(\d+)
+    to: can::$1
 
   - !MergeFieldsets
-    from: can::regs::Mb(\d+)b(Cs|Id)
-    to: can::regs::Mbb$2
+    from: can::Mb(\d+)b(Cs|Id)
+    to: can::Mbb$2
 
   - !DeleteFieldsets
-    from: can::regs::Mb(\d+)bWord(\d+)
-  
+    from: can::Mb(\d+)bWord(\d+)
+
   - !DeleteFieldsets
-    from: can::regs::Word(\d+)
+    from: can::Word(\d+)
 
   - !MakeRegisterArray
     blocks: can::Can
     from: word(0|1)(\d+)
     to: word$1
-  
+
   - !MakeRegisterArray
     blocks: can::Can
     from: id(\d+)
@@ -27,22 +27,22 @@ transforms:
     blocks: can::Can
     from: cs(\d+)
     to: cs
-  
+
   - !MakeRegisterArray
     blocks: can::Can
     from: mb(\d+)_8b_cs
     to: mb_8b_cs
-  
+
   - !MakeRegisterArray
     blocks: can::Can
     from: mb(\d+)_16b_cs
     to: mb_16b_cs
-  
+
   - !MakeRegisterArray
     blocks: can::Can
     from: mb(\d+)_32b_cs
     to: mb_32b_cs
-  
+
   - !MakeRegisterArray
     blocks: can::Can
     from: mb(\d+)_64b_cs
@@ -52,22 +52,22 @@ transforms:
     blocks: can::Can
     from: mb(\d+)_8b_id
     to: mb_8b_id
-  
+
   - !MakeRegisterArray
     blocks: can::Can
     from: mb(\d+)_16b_id
     to: mb_16b_id
-  
+
   - !MakeRegisterArray
     blocks: can::Can
     from: mb(\d+)_32b_id
     to: mb_32b_id
-  
+
   - !MakeRegisterArray
     blocks: can::Can
     from: mb(\d+)_64b_id
     to: mb_64b_id
-  
+
   # For now delete all extra word registers.
   # Can be re-added when needed for HAL implementation.
   - !DeleteRegisters

--- a/data/transforms/mcxa/cdog.yaml
+++ b/data/transforms/mcxa/cdog.yaml
@@ -1,4 +1,4 @@
 transforms:
   - !MergeEnums
-    from: cdog::vals::(Timeout|Miscompare|Sequence|State|Address)Ctrl
-    to: cdog::vals::Ctrl
+    from: cdog::(Timeout|Miscompare|Sequence|State|Address)Ctrl
+    to: cdog::Ctrl

--- a/data/transforms/mcxa/ctimer.yaml
+++ b/data/transforms/mcxa/ctimer.yaml
@@ -1,50 +1,50 @@
 transforms:
   - !RenameEnumVariants
-    enum: ctimer::vals::([A-Za-z]+)(\d+)(.+)
+    enum: ctimer::([A-Za-z]+)(\d+)(.+)
     from: ([A-Z]+)[0-9O]([A-Z]+)_([0-9])
     to: $1$2$3
 
   - !RenameEnumVariants
-    enum: ctimer::vals::Mr[0-9]s
+    enum: ctimer::Mr[0-9]s
     from: ([A-Z_]+)([0-9])
     to: MRS$2
 
   - !MergeEnums
-    from: ctimer::vals::Cap(\d+)(.+)
-    to: ctimer::vals::Cap$2
+    from: ctimer::Cap(\d+)(.+)
+    to: ctimer::Cap$2
     skip_unmergeable: false
 
   - !MergeEnums
-    from: ctimer::vals::Em(\d+)
-    to: ctimer::vals::Em
+    from: ctimer::Em(\d+)
+    to: ctimer::Em
     skip_unmergeable: false
 
   - !MergeEnums
-    from: ctimer::vals::Emc(\d+)
-    to: ctimer::vals::Emc
+    from: ctimer::Emc(\d+)
+    to: ctimer::Emc
     skip_unmergeable: false
 
   - !MergeEnums
-    from: ctimer::vals::Mr(\d+)i
-    to: ctimer::vals::Mri
+    from: ctimer::Mr(\d+)i
+    to: ctimer::Mri
     skip_unmergeable: false
 
   - !MergeEnums
-    from: ctimer::vals::Mr(\d+)r
-    to: ctimer::vals::Mrr
+    from: ctimer::Mr(\d+)r
+    to: ctimer::Mrr
     skip_unmergeable: false
 
   - !MergeEnums
-    from: ctimer::vals::Mr(\d+)rl
-    to: ctimer::vals::Mrrl
+    from: ctimer::Mr(\d+)rl
+    to: ctimer::Mrrl
     skip_unmergeable: false
 
   - !MergeEnums
-    from: ctimer::vals::Mr(\d+)s
-    to: ctimer::vals::Mrs
+    from: ctimer::Mr(\d+)s
+    to: ctimer::Mrs
     skip_unmergeable: false
 
   - !MergeEnums
-    from: ctimer::vals::Pwmen(\d+)
-    to: ctimer::vals::Pwmen
+    from: ctimer::Pwmen(\d+)
+    to: ctimer::Pwmen
     skip_unmergeable: false

--- a/data/transforms/mcxa/dma.yaml
+++ b/data/transforms/mcxa/dma.yaml
@@ -2,26 +2,26 @@ transforms:
   - !RenamePeripherals
     from: EDMA0_TCD0
     to: EDMA_0_TCD0
-    
+
   - !Rename
     from: edma0_tcd0::(.*)
     to: edma_0_tcd0::$1
     type: All
 
   - !Rename
-    from: edma_0_tcd0::vals::Ssize
-    to: edma_0_tcd0::vals::Size
+    from: edma_0_tcd0::Ssize
+    to: edma_0_tcd0::Size
 
   - !ModifyFieldsEnum
-    fieldset: edma_0_tcd0::regs::TcdAttr
+    fieldset: edma_0_tcd0::TcdAttr
     field: dsize
-    enum: edma_0_tcd0::vals::Size
+    enum: edma_0_tcd0::Size
 
   - !DeleteEnums
-    from: edma_0_tcd0::vals::Int
+    from: edma_0_tcd0::Int
 
   - !DeleteEnums
-    from: edma_0_tcd0::vals::(S|D)mod
+    from: edma_0_tcd0::(S|D)mod
 
   - !RenameInterrupts
     from: DMA0_CH([0-9]+)

--- a/data/transforms/mcxa/flexpwm.yaml
+++ b/data/transforms/mcxa/flexpwm.yaml
@@ -1,38 +1,38 @@
 transforms:
   # Fix names of sm*sel(23|45) enum variants such that they overlap
   - !RenameEnumVariants
-    enum: flexpwm::vals::Sm\d+sel\d+
+    enum: flexpwm::Sm\d+sel\d+
     from: (.*)SM\d+(PWM|OUT)\d+
     to: $1$2
 
   - !RenameEnumVariants
-    enum: flexpwm::vals::Sm\d+sel\d+
+    enum: flexpwm::Sm\d+sel\d+
     from: PWM\d+_EXTA
     to: PWM_EXTA
 
   - !MergeEnums
-    from: flexpwm::vals::Sm\d(.+)
-    to: flexpwm::vals::Sm$1
+    from: flexpwm::Sm\d(.+)
+    to: flexpwm::Sm$1
 
   - !MergeEnums
-    from: flexpwm::vals::([^\d]+)\d+([^\d]*)$
-    to: flexpwm::vals::$1$2
+    from: flexpwm::([^\d]+)\d+([^\d]*)$
+    to: flexpwm::$1$2
     skip_unmergeable: true
     check: Layout
 
   - !MergeFieldsets
-    from: flexpwm::regs::Sm\d(.+)
-    to: flexpwm::regs::Sm$1
-  
+    from: flexpwm::Sm\d(.+)
+    to: flexpwm::Sm$1
+
   - !RenameFields
-    fieldset: flexpwm::regs::Smval\d
+    fieldset: flexpwm::Smval\d
     from: ([^\d]+)\d+
     to: $1
 
   - !MergeFieldsets
-    from: flexpwm::regs::Smval\d
-    to: flexpwm::regs::Smval
-  
+    from: flexpwm::Smval\d
+    to: flexpwm::Smval
+
   - !MakeRegisterArray
     blocks: flexpwm::Flexpwm
     from: (sm\d+val)\d+

--- a/data/transforms/mcxa/gpio.yaml
+++ b/data/transforms/mcxa/gpio.yaml
@@ -11,44 +11,44 @@ transforms:
     type: All
 
   - !DeleteEnums
-    from: gpio::vals::(Ptto|Pdi|Pdo)(\d+)
+    from: gpio::(Ptto|Pdi|Pdo)(\d+)
 
   - !MergeEnums
-    from: gpio::vals::(Pdd|Pid|Ptso|Ptco)(\d+)
-    to: gpio::vals::$1
-  
+    from: gpio::(Pdd|Pid|Ptso|Ptco)(\d+)
+    to: gpio::$1
+
   - !MakeFieldArray
-    fieldsets: gpio::regs::Pddr
+    fieldsets: gpio::Pddr
     from: pdd(\d+)
     to: pdd
 
   - !MakeFieldArray
-    fieldsets: gpio::regs::Pidr
+    fieldsets: gpio::Pidr
     from: pid(\d+)
     to: pid
-  
+
   - !MakeFieldArray
-    fieldsets: gpio::regs::Psor
+    fieldsets: gpio::Psor
     from: ptso(\d+)
     to: ptso
 
   - !MakeFieldArray
-    fieldsets: gpio::regs::Pcor
+    fieldsets: gpio::Pcor
     from: ptco(\d+)
     to: ptco
-  
+
   - !MakeFieldArray
-    fieldsets: gpio::regs::Ptor
+    fieldsets: gpio::Ptor
     from: ptto(\d+)
     to: ptto
-  
+
   - !MakeFieldArray
-    fieldsets: gpio::regs::Pdir
+    fieldsets: gpio::Pdir
     from: pdi(\d+)
     to: pdi
 
   - !MakeFieldArray
-    fieldsets: gpio::regs::Pdor
+    fieldsets: gpio::Pdor
     from: pdo(\d+)
     to: pdo
 
@@ -58,5 +58,5 @@ transforms:
     to: isfr
 
   - !MergeFieldsets
-    from: gpio::regs::Isfr\d
-    to: gpio::regs::Isfr
+    from: gpio::Isfr\d
+    to: gpio::Isfr

--- a/data/transforms/mcxa/i3c.yaml
+++ b/data/transforms/mcxa/i3c.yaml
@@ -1,9 +1,9 @@
 transforms:
   - !DeleteEnums
-    from: i3c0::vals::Mintclr(.+)
+    from: i3c0::Mintclr(.+)
 
   - !DeleteEnums
-    from: i3c0::vals::(.+)Flush(f|t)b
+    from: i3c0::(.+)Flush(f|t)b
 
   - !DeleteEnums
-    from: i3c0::vals::Mstatus(Txnotfull|Rxpend)
+    from: i3c0::Mstatus(Txnotfull|Rxpend)

--- a/data/transforms/mcxa/inputmux.yaml
+++ b/data/transforms/mcxa/inputmux.yaml
@@ -1,27 +1,27 @@
 transforms:
   - !MergeEnums
-    from: inputmux0::vals::(.+)(\d+)(TrigTrigin|InputInp|TrigInp|Inp)$
-    to: inputmux0::vals::$1$3
+    from: inputmux0::(.+)(\d+)(TrigTrigin|InputInp|TrigInp|Inp)$
+    to: inputmux0::$1$3
 
   - !MergeEnums
-    from: inputmux0::vals::TrigIn(\d+)Val
-    to: inputmux0::vals::TrigInVal
-  
-  - !MergeEnums
-    from: inputmux0::vals::FlexPwm(.+)Trigin
-    to: inputmux0::vals::FlexPwmTrigin
-  
-  - !MergeEnums
-    from: inputmux0::vals::Qdc(\d+)(Home|Icap|Index)Inp
-    to: inputmux0::vals::Qdc${2}Inp
+    from: inputmux0::TrigIn(\d+)Val
+    to: inputmux0::TrigInVal
 
-  - !MergeFieldsets
-    from: inputmux0::regs::([^\d]+|Lpi2c)(\d+)(Trig|Input|)$
-    to: inputmux0::regs::$1$3
+  - !MergeEnums
+    from: inputmux0::FlexPwm(.+)Trigin
+    to: inputmux0::FlexPwmTrigin
+
+  - !MergeEnums
+    from: inputmux0::Qdc(\d+)(Home|Icap|Index)Inp
+    to: inputmux0::Qdc${2}Inp
 
   - !MergeFieldsets
-    from: inputmux0::regs::FlexPwm(.+)
-    to: inputmux0::regs::FlexPwm
+    from: inputmux0::([^\d]+|Lpi2c)(\d+)(Trig|Input|)$
+    to: inputmux0::$1$3
+
+  - !MergeFieldsets
+    from: inputmux0::FlexPwm(.+)
+    to: inputmux0::FlexPwm
 
   - !MakeRegisterArray
     blocks: inputmux0::Inputmux0

--- a/data/transforms/mcxa/lpi2c.yaml
+++ b/data/transforms/mcxa/lpi2c.yaml
@@ -1,19 +1,47 @@
 transforms:
   - !DeleteEnumVariants
-    enum: lpi2c::vals::Cmd
+    enum: lpi2c::Cmd
     from: .*
-  
+
   - !AddEnumVariants
-    enum: lpi2c::vals::Cmd
+    enum: lpi2c::Cmd
     variants:
-    - { name: TRANSMIT, value: 0, description: "Transmit value in DATA[7:0]" }
-    - { name: RECEIVE, value: 1, description: "Receive (DATA[7:0] + 1) bytes." }
-    - { name: STOP, value: 2, description: "Generate Stop condition on I2C bus." }
-    - { name: RECEIVE_AND_DISCARD, value: 3, description: "Receive and discard (DATA[7:0] + 1) bytes." }
-    - { name: START, value: 4, description: "Generate (repeated) Start on the I2C bus and transmit the address in DATA[7:0]" }
-    - { name: START_EXPECT_NACK, value: 5, description: "Generate (repeated) Start on the I2C bus and transmit the address in DATA[7:0] expecting a NACK response" }
-    - { name: START_HS, value: 6, description: "Generate (repeated) Start on the I2C bus and transmit the address in DATA[7:0] using HS mode" }
-    - { name: START_HS_EXPECT_NACK, value: 7, description: "Generate (repeated) Start on the I2C bus and transmit the address in DATA[7:0] using HS mode expecting a NACK response" }
+      - { name: TRANSMIT, value: 0, description: "Transmit value in DATA[7:0]" }
+      - {
+          name: RECEIVE,
+          value: 1,
+          description: "Receive (DATA[7:0] + 1) bytes.",
+        }
+      - {
+          name: STOP,
+          value: 2,
+          description: "Generate Stop condition on I2C bus.",
+        }
+      - {
+          name: RECEIVE_AND_DISCARD,
+          value: 3,
+          description: "Receive and discard (DATA[7:0] + 1) bytes.",
+        }
+      - {
+          name: START,
+          value: 4,
+          description: "Generate (repeated) Start on the I2C bus and transmit the address in DATA[7:0]",
+        }
+      - {
+          name: START_EXPECT_NACK,
+          value: 5,
+          description: "Generate (repeated) Start on the I2C bus and transmit the address in DATA[7:0] expecting a NACK response",
+        }
+      - {
+          name: START_HS,
+          value: 6,
+          description: "Generate (repeated) Start on the I2C bus and transmit the address in DATA[7:0] using HS mode",
+        }
+      - {
+          name: START_HS_EXPECT_NACK,
+          value: 7,
+          description: "Generate (repeated) Start on the I2C bus and transmit the address in DATA[7:0] using HS mode expecting a NACK response",
+        }
 
   - !DeleteEnums
-    from: lpi2c::vals::(Rsf|SsrSdf|Bef|SsrFef)
+    from: lpi2c::(Rsf|SsrSdf|Bef|SsrFef)

--- a/data/transforms/mcxa/lpuart.yaml
+++ b/data/transforms/mcxa/lpuart.yaml
@@ -1,3 +1,3 @@
 transforms:
   - !DeleteEnums
-    from: lpuart::vals::(Osr)
+    from: lpuart::(Osr)

--- a/data/transforms/mcxa/mbc.yaml
+++ b/data/transforms/mcxa/mbc.yaml
@@ -1,26 +1,25 @@
 transforms:
   - !Rename
-    from: mbc0::vals::Mbc0Dom0(.+)
-    to: mbc0::vals::$1
+    from: mbc0::Mbc0Dom0(.+)
+    to: mbc0::$1
 
   - !MergeEnums
-    from: mbc0::vals::Mem(\d+)BlkCfgW(\d+)(Nse|Mbacsel)(\d+)
-    to: mbc0::vals::MemBlkCfgW$3
+    from: mbc0::Mem(\d+)BlkCfgW(\d+)(Nse|Mbacsel)(\d+)
+    to: mbc0::MemBlkCfgW$3
 
   - !Rename
-    from: mbc0::vals::MemBlkCfgW(.+)
-    to: mbc0::vals::$1
+    from: mbc0::MemBlkCfgW(.+)
+    to: mbc0::$1
 
   - !Rename
-    from: mbc0::regs::Mbc0(.+)
-    to: mbc0::regs::$1
+    from: mbc0::Mbc0(.+)
+    to: mbc0::$1
 
   - !MergeFieldsets
-    from: mbc0::regs::Dom0Mem(\d+)BlkCfgW(\d+)
-    to: mbc0::regs::MemnBlkCfgW
+    from: mbc0::Dom0Mem(\d+)BlkCfgW(\d+)
+    to: mbc0::MemnBlkCfgW
 
   - !MakeRegisterArray
     blocks: mbc0::Mbc0
     from: mbc0_dom0_mem0_blk_cfg_w(\d+)
     to: mbc0_dom0_mem0_blk_cfg_wn
-  

--- a/data/transforms/mcxa/mcxa5/ahbsc.yaml
+++ b/data/transforms/mcxa/mcxa5/ahbsc.yaml
@@ -1,49 +1,54 @@
 transforms:
   # Temporarily move everything that is not a Rule someplace else
   - !Rename
-    from: ahbsc::vals::(Lock.+|Master.+|MiscCtrl.+|SecVio.+)
-    to: ahbsc::vals_misc::$1
+    from: ahbsc::(Lock.+|Master.+|MiscCtrl.+|SecVio.+)
+    to: ahbsc_other::$1
 
   # Merge all identical rules
   - !MergeEnums
-    from: ahbsc::vals::.+
-    to: ahbsc::vals::Rule
+    from: ahbsc::.+
+    to: ahbsc::Rule
 
   # Move everything back
   - !Rename
-    from: ahbsc::vals_misc::(.+)
-    to: ahbsc::vals::$1
+    from: ahbsc_other::(.+)
+    to: ahbsc::$1
 
   # Fix the rest
   - !MergeEnums
-    from: ahbsc::vals::MasterSec.+
-    to: ahbsc::vals::MasterSec
+    from: ahbsc::MasterSec.+
+    to: ahbsc::MasterSec
   - !MergeEnums
-    from: ahbsc::vals::MiscCtrl(Dp)?Reg(.+)
-    to: ahbsc::vals::MiscCtrlReg$2
+    from: ahbsc::MiscCtrl(Dp)?Reg(.+)
+    to: ahbsc::MiscCtrlReg$2
   - !MergeEnums
-    from: ahbsc::vals::MiscCtrlReg(Enable.+)
-    to: ahbsc::vals::MiscCtrlEnable
+    from: ahbsc::MiscCtrlReg(Enable.+)
+    to: ahbsc::MiscCtrlEnable
 
   - !MakeFieldArray
-    fieldsets: ahbsc::regs::(.+MemRule|AhbSecureCtrlMemRule0)
+    fieldsets: ahbsc::(.+MemRule|AhbSecureCtrlMemRule0)
     from: rule(\d+)
     to: rule
 
   - !MergeFieldsets
-    from: ahbsc::regs::Ram[abx]MemRule
-    to: ahbsc::regs::RamMemRule
+    from: ahbsc::Ram[abx]MemRule
+    to: ahbsc::RamMemRule
 
   - !MakeFieldArray
-    fieldsets: ahbsc::regs::SecGpReg\d+
+    fieldsets: ahbsc::SecGpReg\d+
     from: dma[01]_ipd_req_\d+
     to: dma_ipd_req
 
   - !MergeFieldsets
-    from: ahbsc::regs::SecGpReg\d+
-    to: ahbsc::regs::SecGpReg
+    from: ahbsc::SecGpReg\d+
+    to: ahbsc::SecGpReg
 
   - !MakeRegisterArray
     blocks: ahbsc::Ahbsc
     from: sec_gp_reg\d+
     to: sec_gp_reg
+
+  - !MakeFieldArray
+    fieldsets: ahbsc::SecVioInfoValid
+    from: vio_info_valid\d+
+    to: vio_info_valid

--- a/data/transforms/mcxa/mcxa5/dma.yaml
+++ b/data/transforms/mcxa/mcxa5/dma.yaml
@@ -2,23 +2,23 @@ transforms:
   - !RenamePeripherals
     from: EDMA1_TCD0
     to: EDMA_1_TCD0
-    
+
   - !Rename
     from: edma1_tcd0::(.*)
     to: edma_1_tcd0::$1
     type: All
 
   - !Rename
-    from: edma_1_tcd0::vals::Ssize
-    to: edma_1_tcd0::vals::Size
+    from: edma_1_tcd0::Ssize
+    to: edma_1_tcd0::Size
 
   - !ModifyFieldsEnum
-    fieldset: edma_1_tcd0::regs::TcdAttr
+    fieldset: edma_1_tcd0::TcdAttr
     field: dsize
-    enum: edma_1_tcd0::vals::Size
+    enum: edma_1_tcd0::Size
 
   - !DeleteEnums
-    from: edma_1_tcd0::vals::Int
+    from: edma_1_tcd0::Int
 
   - !DeleteEnums
-    from: edma_1_tcd0::vals::(S|D)mod
+    from: edma_1_tcd0::(S|D)mod

--- a/data/transforms/mcxa/mcxa5/i3c.yaml
+++ b/data/transforms/mcxa/mcxa5/i3c.yaml
@@ -2,277 +2,277 @@ transforms:
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mconfig
-    fieldset: i3c::regs::Mconfig
+    fieldset: i3c::Mconfig
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mconfig_ext
-    fieldset: i3c::regs::MconfigExt
+    fieldset: i3c::MconfigExt
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: sconfig
-    fieldset: i3c::regs::Sconfig
+    fieldset: i3c::Sconfig
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: sstatus
-    fieldset: i3c::regs::Sstatus
+    fieldset: i3c::Sstatus
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: sctrl
-    fieldset: i3c::regs::Sctrl
+    fieldset: i3c::Sctrl
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: sintset
-    fieldset: i3c::regs::Sintset
+    fieldset: i3c::Sintset
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: sintclr
-    fieldset: i3c::regs::Sintclr
+    fieldset: i3c::Sintclr
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: sintmasked
-    fieldset: i3c::regs::Sintmasked
+    fieldset: i3c::Sintmasked
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: serrwarn
-    fieldset: i3c::regs::Serrwarn
+    fieldset: i3c::Serrwarn
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: sdmactrl
-    fieldset: i3c::regs::Sdmactrl
+    fieldset: i3c::Sdmactrl
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: sdatactrl
-    fieldset: i3c::regs::Sdatactrl
+    fieldset: i3c::Sdatactrl
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: swdatab
-    fieldset: i3c::regs::Swdatab
+    fieldset: i3c::Swdatab
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: swdatabe
-    fieldset: i3c::regs::Swdatabe
+    fieldset: i3c::Swdatabe
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: swdatah
-    fieldset: i3c::regs::Swdatah
+    fieldset: i3c::Swdatah
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: swdatahe
-    fieldset: i3c::regs::Swdatahe
+    fieldset: i3c::Swdatahe
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: srdatab
-    fieldset: i3c::regs::Srdatab
+    fieldset: i3c::Srdatab
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: srdatah
-    fieldset: i3c::regs::Srdatah
+    fieldset: i3c::Srdatah
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: swdatab1
-    fieldset: i3c::regs::Swdatab1
+    fieldset: i3c::Swdatab1
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: scapabilities2
-    fieldset: i3c::regs::Scapabilities2
+    fieldset: i3c::Scapabilities2
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: scapabilities
-    fieldset: i3c::regs::Scapabilities
+    fieldset: i3c::Scapabilities
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: smaxlimits
-    fieldset: i3c::regs::Smaxlimits
+    fieldset: i3c::Smaxlimits
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: sidpartno
-    fieldset: i3c::regs::Sidpartno
+    fieldset: i3c::Sidpartno
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: sidext
-    fieldset: i3c::regs::Sidext
+    fieldset: i3c::Sidext
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: svendorid
-    fieldset: i3c::regs::Svendorid
+    fieldset: i3c::Svendorid
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: stcclock
-    fieldset: i3c::regs::Stcclock
+    fieldset: i3c::Stcclock
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: smsgmapaddr
-    fieldset: i3c::regs::Smsgmapaddr
+    fieldset: i3c::Smsgmapaddr
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mctrl
-    fieldset: i3c::regs::Mctrl
+    fieldset: i3c::Mctrl
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mstatus
-    fieldset: i3c::regs::Mstatus
+    fieldset: i3c::Mstatus
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mibirules
-    fieldset: i3c::regs::Mibirules
+    fieldset: i3c::Mibirules
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mintset
-    fieldset: i3c::regs::Mintset
+    fieldset: i3c::Mintset
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mintclr
-    fieldset: i3c::regs::Mintclr
+    fieldset: i3c::Mintclr
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mintmasked
-    fieldset: i3c::regs::Mintmasked
+    fieldset: i3c::Mintmasked
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: merrwarn
-    fieldset: i3c::regs::Merrwarn
+    fieldset: i3c::Merrwarn
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mdmactrl
-    fieldset: i3c::regs::Mdmactrl
+    fieldset: i3c::Mdmactrl
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mwdatab
-    fieldset: i3c::regs::Mwdatab
+    fieldset: i3c::Mwdatab
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mwdatabe
-    fieldset: i3c::regs::Mwdatabe
+    fieldset: i3c::Mwdatabe
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mwdatah
-    fieldset: i3c::regs::Mwdatah
+    fieldset: i3c::Mwdatah
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mwdatahe
-    fieldset: i3c::regs::Mwdatahe
+    fieldset: i3c::Mwdatahe
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mrdatab
-    fieldset: i3c::regs::Mrdatab
+    fieldset: i3c::Mrdatab
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mrdatah
-    fieldset: i3c::regs::Mrdatah
+    fieldset: i3c::Mrdatah
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mwdatab1
-    fieldset: i3c::regs::Mwdatab1
+    fieldset: i3c::Mwdatab1
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mdatactrl
-    fieldset: i3c::regs::Mdatactrl
+    fieldset: i3c::Mdatactrl
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mwmsg_sdr_control
-    fieldset: i3c::regs::MwmsgSdrControl
+    fieldset: i3c::MwmsgSdrControl
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mwmsg_sdr_data
-    fieldset: i3c::regs::MwmsgSdrData
+    fieldset: i3c::MwmsgSdrData
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mrmsg_sdr
-    fieldset: i3c::regs::MrmsgSdr
+    fieldset: i3c::MrmsgSdr
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mrmsg_ddr
-    fieldset: i3c::regs::MrmsgDdr
+    fieldset: i3c::MrmsgDdr
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mwmsg_ddr_control
-    fieldset: i3c::regs::MwmsgDdrControl
+    fieldset: i3c::MwmsgDdrControl
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mwmsg_ddr_control2
-    fieldset: i3c::regs::MwmsgDdrControl2
+    fieldset: i3c::MwmsgDdrControl2
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mwmsg_ddr_data
-    fieldset: i3c::regs::MwmsgDdrData
+    fieldset: i3c::MwmsgDdrData
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: mdynaddr
-    fieldset: i3c::regs::Mdynaddr
+    fieldset: i3c::Mdynaddr
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: smapctrl0
-    fieldset: i3c::regs::Smapctrl0
+    fieldset: i3c::Smapctrl0
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: smapctrl1
-    fieldset: i3c::regs::Smapctrl1
+    fieldset: i3c::Smapctrl1
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: ibiext1
-    fieldset: i3c::regs::Ibiext1
+    fieldset: i3c::Ibiext1
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: ibiext2
-    fieldset: i3c::regs::Ibiext2
+    fieldset: i3c::Ibiext2
 
   - !ModifyRegisters
     blocks: i3c1::I3c1
     registers: sid
-    fieldset: i3c::regs::Sid
+    fieldset: i3c::Sid
 
   - !MergeBlocks
     from: i3c1::I3c1
@@ -284,10 +284,10 @@ transforms:
     type: All
 
   - !DeleteEnums
-    from: i3c::vals::Mintclr(.+)
+    from: i3c::Mintclr(.+)
 
   - !DeleteEnums
-    from: i3c::vals::(.+)Flush(f|t)b
+    from: i3c::(.+)Flush(f|t)b
 
   - !DeleteEnums
-    from: i3c::vals::Mstatus(Txnotfull|Rxpend)
+    from: i3c::Mstatus(Txnotfull|Rxpend)

--- a/data/transforms/mcxa/mcxa5/port.yaml
+++ b/data/transforms/mcxa/mcxa5/port.yaml
@@ -1,20 +1,5 @@
 transforms:
-  # Add missing PCR28 ~ PCR31
-  - !AddRegisters
-    block: port0::Port0
-    registers:
-      - name: pcr28
-        byte_offset: 0xf0
-        fieldset: port::Pcr
-
-      - name: pcr29
-        byte_offset: 0xf4
-        fieldset: port::Pcr
-
-      - name: pcr30
-        byte_offset: 0xf8
-        fieldset: port::Pcr
-
-      - name: pcr31
-        byte_offset: 0xfc
-        fieldset: port::Pcr
+  - !Rename
+    from: port::(.*)
+    to: port3::$1
+    type: All

--- a/data/transforms/mcxa/mcxa5/port.yaml
+++ b/data/transforms/mcxa/mcxa5/port.yaml
@@ -3,18 +3,18 @@ transforms:
   - !AddRegisters
     block: port0::Port0
     registers:
-    - name: pcr28
-      byte_offset: 0xf0
-      fieldset: port::regs::Pcr
+      - name: pcr28
+        byte_offset: 0xf0
+        fieldset: port::Pcr
 
-    - name: pcr29
-      byte_offset: 0xf4
-      fieldset: port::regs::Pcr
+      - name: pcr29
+        byte_offset: 0xf4
+        fieldset: port::Pcr
 
-    - name: pcr30
-      byte_offset: 0xf8
-      fieldset: port::regs::Pcr
+      - name: pcr30
+        byte_offset: 0xf8
+        fieldset: port::Pcr
 
-    - name: pcr31
-      byte_offset: 0xfc
-      fieldset: port::regs::Pcr
+      - name: pcr31
+        byte_offset: 0xfc
+        fieldset: port::Pcr

--- a/data/transforms/mcxa/mcxa5/rtc.yaml
+++ b/data/transforms/mcxa/mcxa5/rtc.yaml
@@ -1,6 +1,6 @@
 transforms:
   - !DeleteEnums
-    from: rtc0::vals::(InvalBit|ClkSel|Clkout|ClkoDis|Dow|MonCnt|AlmMatch|We)
+    from: rtc0::(InvalBit|ClkSel|Clkout|ClkoDis|Dow|MonCnt|AlmMatch|We)
 
   - !AddRegisters
     block: rtc0::Rtc0

--- a/data/transforms/mcxa/mrcc.yaml
+++ b/data/transforms/mcxa/mrcc.yaml
@@ -1,22 +1,22 @@
 transforms:
   - !MergeEnums
-    from: mrcc0::vals::Mrcc(.+)(\d+)(.+)
-    to: mrcc0::vals::Mrcc$3
+    from: mrcc0::Mrcc(.+)(\d+)(.+)
+    to: mrcc0::Mrcc$3
     skip_unmergeable: true
-  
+
   # Merge unmergeable per number, but keep the group intact.
   - !MergeEnums
-    from: mrcc0::vals::Mrcc(.+)(\d+)(.+)
-    to: mrcc0::vals::Mrcc$1$3
+    from: mrcc0::Mrcc(.+)(\d+)(.+)
+    to: mrcc0::Mrcc$1$3
 
   - !MergeEnums
-    from: mrcc0::vals::Mrcc(.*)(\d*)(ClkdivReset|ClkdivHalt|ClkdivUnstab)
-    to: mrcc0::vals::Mrcc$3
+    from: mrcc0::Mrcc(.*)(\d*)(ClkdivReset|ClkdivHalt|ClkdivUnstab)
+    to: mrcc0::Mrcc$3
 
   - !Rename
-    from: mrcc0::vals::Mrcc(.+)
-    to: mrcc0::vals::$1
+    from: mrcc0::Mrcc(.+)
+    to: mrcc0::$1
 
   - !MergeFieldsets
-    from: mrcc0::regs::Mrcc(.+)(\d+)(.+)
-    to: mrcc0::regs::$1$3
+    from: mrcc0::Mrcc(.+)(\d+)(.+)
+    to: mrcc0::$1$3

--- a/data/transforms/mcxa/ostimer.yaml
+++ b/data/transforms/mcxa/ostimer.yaml
@@ -1,3 +1,3 @@
 transforms:
   - !DeleteEnums
-    from: ostimer0::vals::OstimerIntena
+    from: ostimer0::OstimerIntena

--- a/data/transforms/mcxa/port.yaml
+++ b/data/transforms/mcxa/port.yaml
@@ -6,16 +6,16 @@ transforms:
     to: port::Pcr
 
   - !ModifyRegisters
-    blocks: port(\d+)::Port(\d+)
-    registers: pcr(\d+)
+    blocks: port\d+::Port(\d+)
+    registers: pcr\d+
     fieldset: port::Pcr
 
   - !DeleteFieldsets
-    from: port(\d+)::Pcr(\d+)
+    from: port\d+::Pcr\d+
 
   # Roughly merge all port blocks together.
   - !MergeBlocks
-    from: port(\d+)::Port(\d+)
+    from: port\d*::Port\d*
     to: port0::Port0
     main: port0::Port0
     check: Layout

--- a/data/transforms/mcxa/port.yaml
+++ b/data/transforms/mcxa/port.yaml
@@ -2,16 +2,16 @@ transforms:
   # Pick a prototype Pcr register and apply it to all ports for all Pcr registers.
   # Some ports do not have some Pcr registers, but we will ignore that in the PAC and fix that in the HAL.
   - !Rename
-    from: port0::regs::Pcr2
-    to: port::regs::Pcr
+    from: port0::Pcr2
+    to: port::Pcr
 
   - !ModifyRegisters
     blocks: port(\d+)::Port(\d+)
     registers: pcr(\d+)
-    fieldset: port::regs::Pcr
+    fieldset: port::Pcr
 
   - !DeleteFieldsets
-    from: port(\d+)::regs::Pcr(\d+)
+    from: port(\d+)::Pcr(\d+)
 
   # Roughly merge all port blocks together.
   - !MergeBlocks
@@ -30,63 +30,60 @@ transforms:
     to: port::Port
     type: Block
 
-  - !Delete
-    from: port(\d+)::(.*)
-
-    # Merge all Mux into the most capable variant of it with bitsize = 4.
-    # Pcr 0, 1 and 7 have a smaller Mux set for ports 0 and 4.
-    # In the HAL we will enforce this constraint, but for the PAC this only makes the types more complex.
+  # Merge all Mux into the most capable variant of it with bitsize = 4.
+  # Pcr 0, 1 and 7 have a smaller Mux set for ports 0 and 4.
+  # In the HAL we will enforce this constraint, but for the PAC this only makes the types more complex.
   - !DeleteEnums
-    from: port::vals::Pcr(\d+)Mux
+    from: port::Pcr(\d+)Mux
     bit_size: 3
   - !MergeEnums
-    from: port::vals::Pcr(\d+)Mux
-    to: port::vals::Mux
+    from: port::Pcr(\d+)Mux
+    to: port::Mux
 
   - !DeleteEnumVariants
-    enum: port::vals::Mux
+    enum: port::Mux
     from: .*
-  
+
   - !AddEnumVariants
-    enum: port::vals::Mux
+    enum: port::Mux
     variants:
-    - { name: MUX0, value: 0 }
-    - { name: MUX1, value: 1 }
-    - { name: MUX2, value: 2 }
-    - { name: MUX3, value: 3 }
-    - { name: MUX4, value: 4 }
-    - { name: MUX5, value: 5 }
-    - { name: MUX6, value: 6 }
-    - { name: MUX7, value: 7 }
-    - { name: MUX8, value: 8 }
-    - { name: MUX9, value: 9 }
-    - { name: MUX10, value: 10 }
-    - { name: MUX11, value: 11 }
-    - { name: MUX12, value: 12 }
-    - { name: MUX13, value: 13 }
+      - { name: MUX0, value: 0 }
+      - { name: MUX1, value: 1 }
+      - { name: MUX2, value: 2 }
+      - { name: MUX3, value: 3 }
+      - { name: MUX4, value: 4 }
+      - { name: MUX5, value: 5 }
+      - { name: MUX6, value: 6 }
+      - { name: MUX7, value: 7 }
+      - { name: MUX8, value: 8 }
+      - { name: MUX9, value: 9 }
+      - { name: MUX10, value: 10 }
+      - { name: MUX11, value: 11 }
+      - { name: MUX12, value: 12 }
+      - { name: MUX13, value: 13 }
 
   - !MergeEnums
-    from: port::vals::Gpwe(\d+)
-    to: port::vals::Gpwe
+    from: port::Gpwe\d+
+    to: port::Gpwe
 
   # Delete uncommon fields that we will not expose in the HAL regardless.
   # In the future, you may consider re-adding them.
   - !DeleteFields
-    fieldset: port::regs::Pcr(\d+)
+    fieldset: port::Pcr(\d+)
     from: (dse1|pfe|pv)
 
   - !DeleteEnums
-    from: port::vals::Pcr(\d+)(Dse1|Pfe)
+    from: port::Pcr(\d+)(Dse1|Pfe)
   - !DeleteEnums
-    from: port::vals::Pv
+    from: port::Pv
 
   - !MergeEnums
-    from: port::vals::Pcr(\d+)(.+)
-    to: port::vals::$2
+    from: port::Pcr(\d+)(.+)
+    to: port::$2
 
   - !MergeFieldsets
-    from: port::regs::Pcr(\d+)
-    to: port::regs::Pcr
+    from: port::Pcr(\d+)
+    to: port::Pcr
 
   - !MakeRegisterArray
     blocks: port::Port
@@ -94,6 +91,6 @@ transforms:
     to: pcr
 
   - !MakeFieldArray
-    fieldsets: port::regs::Gpc(l|h)r
+    fieldsets: port::Gpc(l|h)r
     from: gpwe(\d+)
     to: gpwe

--- a/data/transforms/mcxa/rtc.yaml
+++ b/data/transforms/mcxa/rtc.yaml
@@ -1,3 +1,3 @@
 transforms:
   - !DeleteEnums
-    from: rtc0::vals::(Tce|Tiie|Toie|Taie|Tsie|Taf|Tif|Tof)
+    from: rtc0::(Tce|Tiie|Toie|Taie|Tsie|Taf|Tif|Tof)

--- a/data/transforms/mcxa/scg.yaml
+++ b/data/transforms/mcxa/scg.yaml
@@ -1,5 +1,4 @@
 transforms:
   - !MergeEnums
-    from: scg0::vals::(Rccr|Csr)Scs
-    to: scg0::vals::Scs
-
+    from: scg0::(Rccr|Csr)Scs
+    to: scg0::Scs

--- a/data/transforms/mcxa/spc.yaml
+++ b/data/transforms/mcxa/spc.yaml
@@ -1,13 +1,13 @@
 transforms:
   - !DeleteEnums
-      from: spc0::vals::(Busy|Req|Ack)
-  
+    from: spc0::(Busy|Req|Ack)
+
   - !DeleteEnumVariants
-    enum: spc0::vals::Vsm
+    enum: spc0::Vsm
     from: .*
-  
+
   - !AddEnumVariants
-    enum: spc0::vals::Vsm
+    enum: spc0::Vsm
     variants:
-    - { name: SRAM1V0, value: 1, description: "SRAM configured for 1.0V" }
-    - { name: SRAM1V2, value: 3, description: "SRAM configured for 1.2V" }
+      - { name: SRAM1V0, value: 1, description: "SRAM configured for 1.0V" }
+      - { name: SRAM1V2, value: 3, description: "SRAM configured for 1.2V" }

--- a/data/transforms/mcxa/trng.yaml
+++ b/data/transforms/mcxa/trng.yaml
@@ -4,9 +4,9 @@ transforms:
     from: ent0
 
   - !Rename
-    from: trng0::regs::Ent0
-    to: trng0::regs::Ent
+    from: trng0::Ent0
+    to: trng0::Ent
     type: Fieldset
 
   - !DeleteEnums
-    from: trng0::vals::(IntMaskHwErr|IntMaskIntgFlt|IntStatusFrqCtFail|IntStatusHwErr|IntStatusIntgFlt|LocalEdc|LocalEdcClr|NoPrgm|RedFsm|RedFsmClr|RedSigs|RedSigsClr|IntMaskFrqCtFail|IntMaskEntVal|IntCtrlIntgFlt|IntCtrlHwErr|IntCtrlFrqCtFail|IntCtrlEntVal|BusEdcClr|BusEdc)
+    from: trng0::(IntMaskHwErr|IntMaskIntgFlt|IntStatusFrqCtFail|IntStatusHwErr|IntStatusIntgFlt|LocalEdc|LocalEdcClr|NoPrgm|RedFsm|RedFsmClr|RedSigs|RedSigsClr|IntMaskFrqCtFail|IntMaskEntVal|IntCtrlIntgFlt|IntCtrlHwErr|IntCtrlFrqCtFail|IntCtrlEntVal|BusEdcClr|BusEdc)

--- a/data/transforms/mcxa/wwdt.yaml
+++ b/data/transforms/mcxa/wwdt.yaml
@@ -1,3 +1,3 @@
 transforms:
   - !DeleteEnums
-    from: wwdt([0-9]+)?::vals::Wdtof
+    from: wwdt([0-9]+)?::Wdtof

--- a/data/transforms/mcxa256.yaml
+++ b/data/transforms/mcxa256.yaml
@@ -12,7 +12,7 @@ includes:
   - mcxa/dma.yaml
   - mcxa/flexpwm.yaml
   - mcxa/gpio.yaml
-  # - mcxa/i3c.yaml
+  - mcxa/i3c.yaml
   - mcxa/inputmux.yaml
   - mcxa/lpi2c.yaml
   - mcxa/lpuart.yaml

--- a/data/transforms/mcxa256.yaml
+++ b/data/transforms/mcxa256.yaml
@@ -1,4 +1,6 @@
 includes:
+  - sanitize.yaml
+
   - cm33.yaml
   - useless.yaml
 
@@ -10,7 +12,7 @@ includes:
   - mcxa/dma.yaml
   - mcxa/flexpwm.yaml
   - mcxa/gpio.yaml
-  - mcxa/i3c.yaml
+  # - mcxa/i3c.yaml
   - mcxa/inputmux.yaml
   - mcxa/lpi2c.yaml
   - mcxa/lpuart.yaml

--- a/data/transforms/mcxa577.yaml
+++ b/data/transforms/mcxa577.yaml
@@ -1,4 +1,6 @@
 includes:
+  - sanitize.yaml
+
   - cm33.yaml
   - useless.yaml
 
@@ -31,6 +33,6 @@ includes:
   - mcxa/wwdt.yaml
 
   - remove-suffix.yaml
-
 transforms:
   - !Sort
+  - !Sanitize

--- a/data/transforms/mcxa577.yaml
+++ b/data/transforms/mcxa577.yaml
@@ -35,4 +35,4 @@ includes:
   - remove-suffix.yaml
 transforms:
   - !Sort
-  - !Sanitize
+

--- a/data/transforms/remove-namespace.yaml
+++ b/data/transforms/remove-namespace.yaml
@@ -1,5 +1,0 @@
-transforms:
-  - !Rename
-    from: (.*)::(.+)
-    to: $2
-    type: All

--- a/data/transforms/remove-namespace.yaml
+++ b/data/transforms/remove-namespace.yaml
@@ -1,0 +1,5 @@
+transforms:
+  - !Rename
+    from: (.*)::(.+)
+    to: $2
+    type: All

--- a/data/transforms/sanitize.yaml
+++ b/data/transforms/sanitize.yaml
@@ -1,0 +1,2 @@
+transforms:
+  - !Sanitize

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -7,6 +7,8 @@ license = "BSD-3-Clause"
 description = "Generator for nxp-pac"
 
 [dependencies]
+clap = { version = "4.6.0", features = ["derive"] }
+
 anyhow = "1.0.98"
 rayon = "1.10.0"
 temp-dir = "0.1.16"

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -23,6 +23,7 @@ read-dir-all = "1.0.0"
 indexmap = { version = "2.13.0", features = ["serde"] }
 inflections = "1.1"
 regex = "1.12"
+serde_yaml = "=0.9.34-deprecated"
 
-chiptool = { git = "https://github.com/embassy-rs/chiptool.git", rev = "fe4d3b069d778b9e1872759b78be6e569745464d" }
+chiptool = { git = "https://github.com/embassy-rs/chiptool.git", rev = "e32df6ff54b4520692452e6f4432039336be40a6" }
 

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -22,5 +22,7 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 read-dir-all = "1.0.0"
 indexmap = { version = "2.13.0", features = ["serde"] }
 inflections = "1.1"
+regex = "1.12"
 
-chiptool = { git = "https://github.com/embassy-rs/chiptool.git", rev = "2fd28c5825998008a1a2ab8bab18555c2e314334" }
+chiptool = { git = "https://github.com/embassy-rs/chiptool.git", rev = "fe4d3b069d778b9e1872759b78be6e569745464d" }
+

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -26,4 +26,4 @@ inflections = "1.1"
 itertools = "0.14"
 regex = "1.12"
 
-chiptool = { git = "https://github.com/embassy-rs/chiptool.git", rev = "e32df6ff54b4520692452e6f4432039336be40a6" }
+chiptool = { git = "https://github.com/embassy-rs/chiptool.git", rev = "be1bff3e9e1b27b090e69bd9ac753c66fdcce678" }

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -17,13 +17,13 @@ proc-macro2 = "1.0.95"
 quote = "1.0.40"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+serde_yaml = "=0.9.34-deprecated"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 read-dir-all = "1.0.0"
 indexmap = { version = "2.13.0", features = ["serde"] }
 inflections = "1.1"
+itertools = "0.14"
 regex = "1.12"
-serde_yaml = "=0.9.34-deprecated"
 
 chiptool = { git = "https://github.com/embassy-rs/chiptool.git", rev = "e32df6ff54b4520692452e6f4432039336be40a6" }
-

--- a/generator/README.md
+++ b/generator/README.md
@@ -15,5 +15,31 @@ You must switch to the root of the repository, which is the parent directory of
 the generator crate directory.
 
 ```
-cargo run -p generator
+cargo run -p generator -- -h
+```
+
+```
+Usage: generator <COMMAND>
+
+Commands:
+  generate  Generate the nxp-pac Rust code for a single chip or all the chips
+  extract   Extract all metadata information from the SVD and apply any transforms
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+```
+
+## Updating
+
+The chips supported by this project are defined in [`lib.rs`](/generator/src/lib.rs).
+The SVDs can be selected from the submodule in `data/mcux-soc-svd`.
+These SVDs are transformed using definitions in [`data/transforms`](/data/transforms).
+Refer to the [chiptool](https://github.com/embassy-rs/chiptool/) project to find out how these transforms work.
+
+For metapac chips the peripheral definitions are manually curated in [`data/metadata/peripherals`](/data/metadata/peripherals). Refer to the [README](/data/metadata/peripherals/README.md) in that folder on how to update these files.
+
+For all chips you can (re-)generate the nxp-pac code by running (replace MCXA577 with your chip).
+```
+cargo run -p generator -- MCXA577
 ```

--- a/generator/src/commands/extract.rs
+++ b/generator/src/commands/extract.rs
@@ -63,12 +63,7 @@ fn extract_chip(
                 .join(core)
         });
 
-        crate::metadata::extract_peripherals(
-            &svd,
-            core,
-            transforms_dir.as_ref().map(|path| path.as_path()),
-            &output_dir,
-        )?;
+        crate::metadata::extract_peripherals(&svd, core, transforms_dir.as_deref(), &output_dir)?;
     }
 
     Ok(())

--- a/generator/src/commands/extract.rs
+++ b/generator/src/commands/extract.rs
@@ -1,6 +1,9 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
+use tracing::*;
+
+use crate::ChipDescription;
 
 /// Extract all metadata information from the SVD and apply any transforms.
 #[derive(Parser)]
@@ -9,13 +12,46 @@ pub struct Extract {
     #[clap(required = true)]
     pub chip: String,
     /// Output directory of the metadata.
-    #[clap(short, long, default_value = "./data/metadata/raw")]
-    pub output: PathBuf,
+    #[clap(short, long)]
+    pub output: Option<PathBuf>,
 }
 
 /// Command to extract all metadata information from a single SVD.
 ///
 /// Applies any transforms automagically.
 pub fn extract(extract: Extract) -> Result<()> {
-    todo!()
+    let chip = crate::CHIPS
+        .iter()
+        .find(|chip_description| chip_description.chip == extract.chip)
+        .context("selected chip does not exist in generate list")?;
+
+    extract_chip(chip, extract.output)
+}
+
+fn extract_chip(chip_description: &ChipDescription, output: Option<PathBuf>) -> Result<()> {
+    let current_dir = env::current_dir()?;
+
+    let chip_src_dir = current_dir
+        .join("data")
+        .join("mcux-soc-svd")
+        .join(chip_description.chip);
+
+    for core in chip_description.cores {
+        let svd = chip_src_dir.join(core).with_extension("xml");
+        debug!("svd path: {:?}", svd);
+        let transforms_dir = current_dir.join("data").join("transforms");
+        debug!("transforms path: {:?}", transforms_dir);
+        let output_dir = output.clone().unwrap_or_else(|| {
+            current_dir
+                .join("data")
+                .join("metadata")
+                .join("peripherals")
+                .join("raw")
+                .join(core)
+        });
+
+        crate::metadata::extract_peripherals(&svd, core, &transforms_dir, &output_dir)?;
+    }
+
+    Ok(())
 }

--- a/generator/src/commands/extract.rs
+++ b/generator/src/commands/extract.rs
@@ -11,6 +11,8 @@ pub struct Extract {
     /// One of the encoded chip names.
     #[clap(required = true)]
     pub chip: String,
+    #[clap(long)]
+    pub skip_transforms: bool,
     /// Output directory of the metadata.
     #[clap(short, long)]
     pub output: Option<PathBuf>,
@@ -25,10 +27,14 @@ pub fn extract(extract: Extract) -> Result<()> {
         .find(|chip_description| chip_description.chip == extract.chip)
         .context("selected chip does not exist in generate list")?;
 
-    extract_chip(chip, extract.output)
+    extract_chip(chip, extract.output, extract.skip_transforms)
 }
 
-fn extract_chip(chip_description: &ChipDescription, output: Option<PathBuf>) -> Result<()> {
+fn extract_chip(
+    chip_description: &ChipDescription,
+    output: Option<PathBuf>,
+    skip_transforms: bool,
+) -> Result<()> {
     let current_dir = env::current_dir()?;
 
     let chip_src_dir = current_dir
@@ -39,8 +45,15 @@ fn extract_chip(chip_description: &ChipDescription, output: Option<PathBuf>) -> 
     for core in chip_description.cores {
         let svd = chip_src_dir.join(core).with_extension("xml");
         debug!("svd path: {:?}", svd);
-        let transforms_dir = current_dir.join("data").join("transforms");
-        debug!("transforms path: {:?}", transforms_dir);
+
+        let transforms_dir = if skip_transforms {
+            None
+        } else {
+            let transforms_dir = current_dir.join("data").join("transforms");
+            debug!("transforms path: {:?}", transforms_dir);
+            Some(transforms_dir)
+        };
+
         let output_dir = output.clone().unwrap_or_else(|| {
             current_dir
                 .join("data")
@@ -50,7 +63,12 @@ fn extract_chip(chip_description: &ChipDescription, output: Option<PathBuf>) -> 
                 .join(core)
         });
 
-        crate::metadata::extract_peripherals(&svd, core, &transforms_dir, &output_dir)?;
+        crate::metadata::extract_peripherals(
+            &svd,
+            core,
+            transforms_dir.as_ref().map(|path| path.as_path()),
+            &output_dir,
+        )?;
     }
 
     Ok(())

--- a/generator/src/commands/extract.rs
+++ b/generator/src/commands/extract.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Extract all metadata information from the SVD and apply any transforms.
+#[derive(Parser)]
+pub struct Extract {
+    /// One of the encoded chip names.
+    #[clap(required = true)]
+    pub chip: String,
+    /// Output directory of the metadata.
+    #[clap(short, long, default_value = "./data/metadata/raw")]
+    pub output: PathBuf,
+}
+
+/// Command to extract all metadata information from a single SVD.
+///
+/// Applies any transforms automagically.
+pub fn extract(extract: Extract) -> Result<()> {
+    todo!()
+}

--- a/generator/src/commands/extract.rs
+++ b/generator/src/commands/extract.rs
@@ -1,14 +1,14 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Parser;
 use std::{env, path::PathBuf};
 use tracing::*;
 
-use crate::ChipDescription;
+use crate::{ChipDescription, commands::select_chip};
 
 /// Extract all metadata information from the SVD and apply any transforms.
 #[derive(Parser)]
 pub struct Extract {
-    /// One of the encoded chip names.
+    /// Chip name to extract the SVD data for.
     #[clap(required = true)]
     pub chip: String,
     /// Do not run the configured transforms.
@@ -23,12 +23,11 @@ pub struct Extract {
 ///
 /// Applies any transforms automagically.
 pub fn extract(extract: Extract) -> Result<()> {
-    let chip = crate::CHIPS
-        .iter()
-        .find(|chip_description| chip_description.chip == extract.chip)
-        .context("selected chip does not exist in generate list")?;
-
-    extract_chip(chip, extract.output, extract.skip_transforms)
+    extract_chip(
+        select_chip(&extract.chip)?,
+        extract.output,
+        extract.skip_transforms,
+    )
 }
 
 fn extract_chip(

--- a/generator/src/commands/extract.rs
+++ b/generator/src/commands/extract.rs
@@ -58,7 +58,7 @@ fn extract_chip(
             &svd,
             core,
             transforms_dir.as_deref(),
-            &output.join(core).canonicalize()?,
+            &output.join(core),
         )?;
     }
 

--- a/generator/src/commands/extract.rs
+++ b/generator/src/commands/extract.rs
@@ -11,11 +11,12 @@ pub struct Extract {
     /// One of the encoded chip names.
     #[clap(required = true)]
     pub chip: String,
+    /// Do not run the configured transforms.
     #[clap(long)]
     pub skip_transforms: bool,
     /// Output directory of the metadata.
-    #[clap(short, long)]
-    pub output: Option<PathBuf>,
+    #[clap(short, long, default_value = "./data/metadata/peripherals/raw")]
+    pub output: PathBuf,
 }
 
 /// Command to extract all metadata information from a single SVD.
@@ -32,7 +33,7 @@ pub fn extract(extract: Extract) -> Result<()> {
 
 fn extract_chip(
     chip_description: &ChipDescription,
-    output: Option<PathBuf>,
+    output: PathBuf,
     skip_transforms: bool,
 ) -> Result<()> {
     let current_dir = env::current_dir()?;
@@ -54,16 +55,12 @@ fn extract_chip(
             Some(transforms_dir)
         };
 
-        let output_dir = output.clone().unwrap_or_else(|| {
-            current_dir
-                .join("data")
-                .join("metadata")
-                .join("peripherals")
-                .join("raw")
-                .join(core)
-        });
-
-        crate::metadata::extract_peripherals(&svd, core, transforms_dir.as_deref(), &output_dir)?;
+        crate::metadata::extract_peripherals(
+            &svd,
+            core,
+            transforms_dir.as_deref(),
+            &output.join(core).canonicalize()?,
+        )?;
     }
 
     Ok(())

--- a/generator/src/commands/generate.rs
+++ b/generator/src/commands/generate.rs
@@ -68,8 +68,6 @@ fn generate_chip(current_dir: &Path, feature: &ChipDescription) -> anyhow::Resul
     let pac_dir = current_dir.join("nxp-pac");
 
     for core in feature.cores {
-        let svd = chip_src_dir.join(core).with_extension("xml");
-        debug!("svd path: {:?}", svd);
         let chips_dir = pac_dir.join("src").join("chips");
 
         if feature.metapac {
@@ -77,9 +75,8 @@ fn generate_chip(current_dir: &Path, feature: &ChipDescription) -> anyhow::Resul
                 bail!("Metadata should not be empty when using metapac");
             }
 
-            let metadata = crate::metadata::generate_core(
+            let metadata = crate::metadata::generate(
                 &chips_dir,
-                &svd,
                 &metadata_dir.join(feature.metadata).with_extension("json"),
                 core,
             )
@@ -90,6 +87,8 @@ fn generate_chip(current_dir: &Path, feature: &ChipDescription) -> anyhow::Resul
                     .context(format!("Assembling metapac for {core}"))?
             }
         } else {
+            let svd = chip_src_dir.join(core).with_extension("xml");
+            debug!("svd path: {:?}", svd);
             let transforms_dir = current_dir.join("data").join("transforms");
             debug!("transforms path: {:?}", transforms_dir);
 

--- a/generator/src/commands/generate.rs
+++ b/generator/src/commands/generate.rs
@@ -82,10 +82,8 @@ fn generate_chip(current_dir: &Path, feature: &ChipDescription) -> anyhow::Resul
             )
             .context("Generating metadata")?;
 
-            if feature.metapac {
-                crate::metapac::generate_core(current_dir, core, metadata)
-                    .context(format!("Assembling metapac for {core}"))?
-            }
+            crate::metapac::generate_core(current_dir, core, metadata)
+                .context(format!("Assembling metapac for {core}"))?
         } else {
             let svd = chip_src_dir.join(core).with_extension("xml");
             debug!("svd path: {:?}", svd);

--- a/generator/src/commands/generate.rs
+++ b/generator/src/commands/generate.rs
@@ -33,7 +33,7 @@ pub fn generate(args: Generate) -> anyhow::Result<()> {
     let current = env::current_dir()?;
 
     // Export the metapac peripherals
-    crate::metapac::export_meta_peripherals(&current)?;
+    crate::metapac::generate_meta_peripherals(&current)?;
 
     // Generating code for SVDs can take a moment (RT11xx can generate a million lines of code)
     // so it is best to run multiple cores in parallel.
@@ -86,7 +86,7 @@ fn generate_chip(current_dir: &Path, feature: &ChipDescription) -> anyhow::Resul
             .context("Generating metadata")?;
 
             if feature.metapac {
-                crate::metapac::assemble_metapac(current_dir, core, metadata)
+                crate::metapac::generate_core(current_dir, core, metadata)
                     .context(format!("Assembling metapac for {core}"))?
             }
         } else {
@@ -94,9 +94,6 @@ fn generate_chip(current_dir: &Path, feature: &ChipDescription) -> anyhow::Resul
             debug!("transforms path: {:?}", transforms_dir);
 
             info!("Generating {}/{}", feature.chip, core);
-            crate::pac::generate_peripherals(&svd, &metadata_dir, core, &transforms_dir)
-                .context("Generating peripherals")?;
-
             crate::pac::generate_core(&svd, &chips_dir, &transforms_dir, core)
                 .context("Generating PAC")?;
         }

--- a/generator/src/commands/generate.rs
+++ b/generator/src/commands/generate.rs
@@ -55,8 +55,6 @@ pub fn generate(args: Generate) -> anyhow::Result<()> {
         bail!("Failed to generate chips {:?}", error);
     }
 
-    // TODO: we used to call cargo fmt here, but that seems redundant with rustfmt on every file.
-
     Ok(())
 }
 

--- a/generator/src/commands/generate.rs
+++ b/generator/src/commands/generate.rs
@@ -1,0 +1,108 @@
+use std::{env, path::Path};
+
+use anyhow::{Context, bail};
+use clap::Parser;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use tracing::*;
+
+use crate::{CHIPS, ChipDescription};
+
+/// Generate the nxp-pac Rust code for a single chip or all the chips.
+///
+/// Will apply any transforms defined for the chips that are pre-metapac.
+#[derive(Parser)]
+pub struct Generate {
+    /// Select a single chip.
+    #[clap(long)]
+    pub chip: Option<String>,
+}
+
+/// Command to generate the nxp-pac Rust code for one or all of the chips.
+pub fn generate(args: Generate) -> anyhow::Result<()> {
+    let chips = if let Some(chip_name) = args.chip {
+        let chip = CHIPS
+            .iter()
+            .find(|feature| feature.chip == chip_name)
+            .context("selected chip does not exist in generate list")?;
+
+        vec![chip]
+    } else {
+        CHIPS.iter().collect()
+    };
+
+    let current = env::current_dir()?;
+
+    // Export the metapac peripherals
+    crate::metapac::export_meta_peripherals(&current)?;
+
+    // Generating code for SVDs can take a moment (RT11xx can generate a million lines of code)
+    // so it is best to run multiple cores in parallel.
+    let outputs: Vec<anyhow::Result<()>> = chips
+        .par_iter()
+        .map(|feature| generate_chip(&current, feature))
+        .collect();
+
+    let mut error = false;
+
+    for output in outputs {
+        if let Err(e) = output {
+            error |= true;
+            error!("Error for output {e:?}");
+        }
+    }
+
+    if error {
+        bail!("Failed to generate chips {:?}", error);
+    }
+
+    // TODO: we used to call cargo fmt here, but that seems redundant with rustfmt on every file.
+
+    Ok(())
+}
+
+/// Generate (unformatted) code for a single chip.
+fn generate_chip(current_dir: &Path, feature: &ChipDescription) -> anyhow::Result<()> {
+    let chip_src_dir = current_dir
+        .join("data")
+        .join("mcux-soc-svd")
+        .join(feature.chip);
+    let metadata_dir = current_dir.join("data").join("metadata");
+    let pac_dir = current_dir.join("nxp-pac");
+
+    for core in feature.cores {
+        let svd = chip_src_dir.join(core).with_extension("xml");
+        debug!("svd path: {:?}", svd);
+        let chips_dir = pac_dir.join("src").join("chips");
+
+        if feature.metapac {
+            if feature.metadata.is_empty() {
+                bail!("Metadata should not be empty when using metapac");
+            }
+
+            let metadata = crate::metadata::generate_core(
+                &chips_dir,
+                &svd,
+                &metadata_dir.join(feature.metadata).with_extension("json"),
+                core,
+            )
+            .context("Generating metadata")?;
+
+            if feature.metapac {
+                crate::metapac::assemble_metapac(current_dir, core, metadata)
+                    .context(format!("Assembling metapac for {core}"))?
+            }
+        } else {
+            let transforms_dir = current_dir.join("data").join("transforms");
+            debug!("transforms path: {:?}", transforms_dir);
+
+            info!("Generating {}/{}", feature.chip, core);
+            crate::pac::generate_peripherals(&svd, &metadata_dir, core, &transforms_dir)
+                .context("Generating peripherals")?;
+
+            crate::pac::generate_core(&svd, &chips_dir, &transforms_dir, core)
+                .context("Generating PAC")?;
+        }
+    }
+
+    Ok(())
+}

--- a/generator/src/commands/generate.rs
+++ b/generator/src/commands/generate.rs
@@ -12,8 +12,7 @@ use crate::{CHIPS, ChipDescription};
 /// Will apply any transforms defined for the chips that are pre-metapac.
 #[derive(Parser)]
 pub struct Generate {
-    /// Select a single chip.
-    #[clap(long)]
+    /// Select a single chip, or all chips if not provided.
     pub chip: Option<String>,
 }
 

--- a/generator/src/commands/generate.rs
+++ b/generator/src/commands/generate.rs
@@ -19,12 +19,7 @@ pub struct Generate {
 /// Command to generate the nxp-pac Rust code for one or all of the chips.
 pub fn generate(args: Generate) -> anyhow::Result<()> {
     let chips = if let Some(chip_name) = args.chip {
-        let chip = CHIPS
-            .iter()
-            .find(|feature| feature.chip == chip_name)
-            .context("selected chip does not exist in generate list")?;
-
-        vec![chip]
+        vec![crate::commands::select_chip(&chip_name)?]
     } else {
         CHIPS.iter().collect()
     };

--- a/generator/src/commands/generate.rs
+++ b/generator/src/commands/generate.rs
@@ -65,13 +65,13 @@ fn generate_chip(current_dir: &Path, feature: &ChipDescription) -> anyhow::Resul
         let chips_dir = pac_dir.join("src").join("chips");
 
         if feature.metapac {
-            if feature.metadata.is_empty() {
+            let Some(metadata_file) = feature.metadata else {
                 bail!("Metadata should not be empty when using metapac");
-            }
+            };
 
             let metadata = crate::metadata::generate(
                 &chips_dir,
-                &metadata_dir.join(feature.metadata).with_extension("json"),
+                &metadata_dir.join(metadata_file).with_extension("json"),
                 core,
             )
             .context("Generating metadata")?;

--- a/generator/src/commands/mod.rs
+++ b/generator/src/commands/mod.rs
@@ -1,0 +1,2 @@
+pub mod extract;
+pub mod generate;

--- a/generator/src/commands/mod.rs
+++ b/generator/src/commands/mod.rs
@@ -1,2 +1,22 @@
+use anyhow::{Result, anyhow};
+use itertools::Itertools;
+
+use crate::ChipDescription;
+
 pub mod extract;
 pub mod generate;
+
+fn select_chip(chip_name: &str) -> Result<&'static ChipDescription> {
+    crate::CHIPS
+        .iter()
+        .find(|chip_description| chip_description.chip == chip_name)
+        .ok_or_else(|| {
+            let list = crate::CHIPS
+                .iter()
+                .map(|chip| format!("- {}", chip.chip))
+                .join("\n");
+
+            anyhow!("Supported chips:\n{}", list)
+                .context(format!("Selected chip '{}' not supported", chip_name))
+        })
+}

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1,0 +1,34 @@
+pub mod commands;
+pub mod metadata;
+pub mod metapac;
+pub mod pac;
+pub mod util;
+
+pub struct ChipDescription {
+    /// The name of the chip to generate.
+    chip: &'static str,
+
+    /// Metadata file for this chip.
+    metadata: &'static str,
+
+    /// Cores to generate. If the chip has a single core, then this is the same as the
+    /// [`name`](Feature::name) of the chip.
+    cores: &'static [&'static str],
+
+    /// When true, the source of the chip won't be the SVD anymore, but the manually curated peripherals
+    metapac: bool,
+}
+
+/// Parts (and cores) to generate.
+#[rustfmt::skip]
+pub const CHIPS: &[ChipDescription] = &[
+    ChipDescription { chip: "MIMXRT1011", metadata: "MIMXRT1011", cores: &["MIMXRT1011"], metapac: false },
+    ChipDescription { chip: "MIMXRT1062", metadata: "MIMXRT106x", cores: &["MIMXRT1062"], metapac: false },
+    ChipDescription { chip: "MIMXRT1064", metadata: "MIMXRT106x", cores: &["MIMXRT1064"], metapac: false },
+    ChipDescription { chip: "MIMXRT685S", metadata: "", cores: &["MIMXRT685S_cm33"], metapac: false },
+    ChipDescription { chip: "LPC55S16", metadata: "LPC55S16", cores: &["LPC55S16"], metapac: false },
+    ChipDescription { chip: "LPC55S69", metadata: "LPC55S6x", cores: &["LPC55S69_cm33_core0", "LPC55S69_cm33_core1"], metapac: false },
+    ChipDescription { chip: "MCXN947", metadata: "", cores: &["MCXN947_cm33_core0", "MCXN947_cm33_core1"], metapac: false },
+    ChipDescription { chip: "MCXA256", metadata: "MCXA2xx", cores: &["MCXA256"], metapac: true },
+    ChipDescription { chip: "MCXA577", metadata: "MCXA5xx", cores: &["MCXA577"], metapac: true },
+];

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -9,7 +9,7 @@ pub struct ChipDescription {
     chip: &'static str,
 
     /// Metadata file for this chip.
-    metadata: &'static str,
+    metadata: Option<&'static str>,
 
     /// Cores to generate. If the chip has a single core, then this is the same as the
     /// [`name`](Feature::name) of the chip.
@@ -22,13 +22,13 @@ pub struct ChipDescription {
 /// Parts (and cores) to generate.
 #[rustfmt::skip]
 pub const CHIPS: &[ChipDescription] = &[
-    ChipDescription { chip: "MIMXRT1011", metadata: "MIMXRT1011", cores: &["MIMXRT1011"], metapac: false },
-    ChipDescription { chip: "MIMXRT1062", metadata: "MIMXRT106x", cores: &["MIMXRT1062"], metapac: false },
-    ChipDescription { chip: "MIMXRT1064", metadata: "MIMXRT106x", cores: &["MIMXRT1064"], metapac: false },
-    ChipDescription { chip: "MIMXRT685S", metadata: "", cores: &["MIMXRT685S_cm33"], metapac: false },
-    ChipDescription { chip: "LPC55S16", metadata: "LPC55S16", cores: &["LPC55S16"], metapac: false },
-    ChipDescription { chip: "LPC55S69", metadata: "LPC55S6x", cores: &["LPC55S69_cm33_core0", "LPC55S69_cm33_core1"], metapac: false },
-    ChipDescription { chip: "MCXN947", metadata: "", cores: &["MCXN947_cm33_core0", "MCXN947_cm33_core1"], metapac: false },
-    ChipDescription { chip: "MCXA256", metadata: "MCXA2xx", cores: &["MCXA256"], metapac: true },
-    ChipDescription { chip: "MCXA577", metadata: "MCXA5xx", cores: &["MCXA577"], metapac: true },
+    ChipDescription { chip: "MIMXRT1011", metadata: Some("MIMXRT1011"), cores: &["MIMXRT1011"], metapac: false },
+    ChipDescription { chip: "MIMXRT1062", metadata: Some("MIMXRT106x"), cores: &["MIMXRT1062"], metapac: false },
+    ChipDescription { chip: "MIMXRT1064", metadata: Some("MIMXRT106x"), cores: &["MIMXRT1064"], metapac: false },
+    ChipDescription { chip: "MIMXRT685S", metadata: None, cores: &["MIMXRT685S_cm33"], metapac: false },
+    ChipDescription { chip: "LPC55S16", metadata: Some("LPC55S16"), cores: &["LPC55S16"], metapac: false },
+    ChipDescription { chip: "LPC55S69", metadata: Some("LPC55S6x"), cores: &["LPC55S69_cm33_core0", "LPC55S69_cm33_core1"], metapac: false },
+    ChipDescription { chip: "MCXN947", metadata: None, cores: &["MCXN947_cm33_core0", "MCXN947_cm33_core1"], metapac: false },
+    ChipDescription { chip: "MCXA256", metadata: Some("MCXA2xx"), cores: &["MCXA256"], metapac: true },
+    ChipDescription { chip: "MCXA577", metadata: Some("MCXA5xx"), cores: &["MCXA577"], metapac: true },
 ];

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -12,49 +12,25 @@
 //! cargo run -p generator -- MIMXRT1011
 //! ```
 
-mod metadata;
-mod metapac;
-mod pac;
-
-use std::{
-    env,
-    path::Path,
-    process::{Command, Stdio},
+use clap::Parser;
+use generator::commands::{
+    extract::{Extract, extract},
+    generate::{Generate, generate},
 };
-
-use anyhow::{Context, bail};
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use tracing::{debug, error, info, level_filters::LevelFilter};
+use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
-struct Feature {
-    /// The name of the chip to generate.
-    chip: &'static str,
-
-    /// Metadata file for this chip.
-    metadata: &'static str,
-
-    /// Cores to generate. If the chip has a single core, then this is the same as the
-    /// [`name`](Feature::name) of the chip.
-    cores: &'static [&'static str],
-
-    /// When true, the source of the chip won't be the SVD anymore, but the manually curated peripherals
-    metapac: bool,
+#[derive(Parser)]
+struct Opts {
+    #[clap(subcommand)]
+    subcommand: Subcommand,
 }
 
-/// Parts (and cores) to generate.
-#[rustfmt::skip]
-const GENERATE: &[Feature] = &[
-    Feature { chip: "MIMXRT1011", metadata: "MIMXRT1011", cores: &["MIMXRT1011"], metapac: false },
-    Feature { chip: "MIMXRT1062", metadata: "MIMXRT106x", cores: &["MIMXRT1062"], metapac: false },
-    Feature { chip: "MIMXRT1064", metadata: "MIMXRT106x", cores: &["MIMXRT1064"], metapac: false },
-    Feature { chip: "MIMXRT685S", metadata: "", cores: &["MIMXRT685S_cm33"], metapac: false },
-    Feature { chip: "LPC55S16", metadata: "LPC55S16", cores: &["LPC55S16"], metapac: false },
-    Feature { chip: "LPC55S69", metadata: "LPC55S6x", cores: &["LPC55S69_cm33_core0", "LPC55S69_cm33_core1"], metapac: false },
-    Feature { chip: "MCXN947", metadata: "", cores: &["MCXN947_cm33_core0", "MCXN947_cm33_core1"], metapac: false },
-    Feature { chip: "MCXA256", metadata: "MCXA2xx", cores: &["MCXA256"], metapac: true },
-    Feature { chip: "MCXA577", metadata: "MCXA5xx", cores: &["MCXA577"], metapac: true },
-];
+#[derive(Parser)]
+enum Subcommand {
+    Generate(Generate),
+    Extract(Extract),
+}
 
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
@@ -66,117 +42,10 @@ fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let current = env::current_dir()?;
+    let opts: Opts = Opts::parse();
 
-    let mut args = env::args();
-
-    let generate_chips: Vec<&Feature> = if args.len() > 1 {
-        let chip = args.nth(1).context("unreachable")?;
-
-        let feature = GENERATE
-            .iter()
-            .find(|feature| feature.chip == chip)
-            .context("selected chip does not exist in generate list")?;
-
-        vec![feature]
-    } else {
-        GENERATE.iter().collect()
-    };
-
-    // Export the metapac peripherals
-    metapac::export_meta_peripherals(&current)?;
-
-    // Generating code for SVDs can take a moment (RT11xx can generate a million lines of code)
-    // so it is best to run multiple cores in parallel.
-    let outputs: Vec<anyhow::Result<()>> = generate_chips
-        .par_iter()
-        .map(|&feature| generate_chip(&current, feature))
-        .collect();
-
-    let mut error = false;
-
-    for output in outputs {
-        if let Err(e) = output {
-            error |= true;
-            error!("Error for output {e:?}");
-        }
+    match opts.subcommand {
+        Subcommand::Generate(args) => generate(args),
+        Subcommand::Extract(args) => extract(args),
     }
-
-    if error {
-        bail!("Failed to generate chips {:?}", error);
-    }
-
-    info!("Formatting code");
-    Command::new("cargo")
-        .arg("fmt")
-        .current_dir(current)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
-        .context("Formatting pac code with `cargo fmt`")?;
-
-    Ok(())
-}
-
-fn generate_chip(current_dir: &Path, feature: &Feature) -> anyhow::Result<()> {
-    let chip_src_dir = current_dir
-        .join("data")
-        .join("mcux-soc-svd")
-        .join(feature.chip);
-    let metadata_dir = current_dir.join("data").join("metadata");
-    let pac_dir = current_dir.join("nxp-pac");
-
-    for core in feature.cores {
-        let svd = chip_src_dir.join(core).with_extension("xml");
-        debug!("svd path: {:?}", svd);
-        let chips_dir = pac_dir.join("src").join("chips");
-
-        if feature.metapac {
-            if feature.metadata.is_empty() {
-                bail!("Metadata should not be empty when using metapac");
-            }
-
-            let metadata = metadata::generate_core(
-                &chips_dir,
-                &svd,
-                &metadata_dir.join(feature.metadata).with_extension("json"),
-                core,
-            )
-            .context("Generating metadata")?;
-
-            if feature.metapac {
-                metapac::assemble_metapac(current_dir, core, metadata)
-                    .context(format!("Assembling metapac for {core}"))?
-            }
-        } else {
-            let transforms_dir = current_dir.join("data").join("transforms");
-            debug!("transforms path: {:?}", transforms_dir);
-
-            info!("Generating {}/{}", feature.chip, core);
-            pac::generate_peripherals(&svd, &metadata_dir, core, &transforms_dir)
-                .context("Generating peripherals")?;
-
-            pac::generate_core(&svd, &chips_dir, &transforms_dir, core)
-                .context("Generating PAC")?;
-        }
-    }
-
-    Ok(())
-}
-
-fn rustfmt(path: &Path) -> anyhow::Result<()> {
-    let output = Command::new("rustfmt")
-        .arg(path.canonicalize()?)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .output()?;
-
-    if !output.status.success() {
-        bail!(
-            "Error during rustfmt: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    Ok(())
 }

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -129,20 +129,13 @@ fn generate_chip(current_dir: &Path, feature: &Feature) -> anyhow::Result<()> {
     for core in feature.cores {
         let svd = chip_src_dir.join(core).with_extension("xml");
         debug!("svd path: {:?}", svd);
-        let transforms_dir = current_dir.join("data").join("transforms");
-        debug!("transforms path: {:?}", transforms_dir);
         let chips_dir = pac_dir.join("src").join("chips");
 
-        pac::generate_peripherals(&svd, &metadata_dir, core, &transforms_dir)
-            .context("Generating peripherals")?;
+        if feature.metapac {
+            if feature.metadata.is_empty() {
+                bail!("Metadata should not be empty when using metapac");
+            }
 
-        if !feature.metapac {
-            info!("Generating {}/{}", feature.chip, core);
-            pac::generate_core(&svd, &chips_dir, &transforms_dir, core)
-                .context("Generating PAC")?;
-        }
-
-        if !feature.metadata.is_empty() {
             let metadata = metadata::generate_core(
                 &chips_dir,
                 &svd,
@@ -155,6 +148,16 @@ fn generate_chip(current_dir: &Path, feature: &Feature) -> anyhow::Result<()> {
                 metapac::assemble_metapac(current_dir, core, metadata)
                     .context(format!("Assembling metapac for {core}"))?
             }
+        } else {
+            let transforms_dir = current_dir.join("data").join("transforms");
+            debug!("transforms path: {:?}", transforms_dir);
+
+            info!("Generating {}/{}", feature.chip, core);
+            pac::generate_peripherals(&svd, &metadata_dir, core, &transforms_dir)
+                .context("Generating peripherals")?;
+
+            pac::generate_core(&svd, &chips_dir, &transforms_dir, core)
+                .context("Generating PAC")?;
         }
     }
 

--- a/generator/src/metadata.rs
+++ b/generator/src/metadata.rs
@@ -371,8 +371,7 @@ pub fn extract_peripherals(
         let filename: String = entry.file_name().to_string_lossy().into_owned();
         let name = path_regex
             .captures(&filename)
-            .map(|c| c.get(1))
-            .flatten()
+            .and_then(|c| c.get(1))
             .ok_or_else(|| anyhow!("Failed strip namespace from filename {:?}", &entry))?;
 
         chiptool::commands::transform::transform(Transform {

--- a/generator/src/metadata.rs
+++ b/generator/src/metadata.rs
@@ -1,12 +1,7 @@
-use std::{
-    fmt::Write,
-    fs,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::{fmt::Write, fs, path::Path};
 
 use anyhow::{Context, anyhow, bail};
-use chiptool::commands::{ExtractShared, extract_all::ExtractAll, transform::Transform};
+use chiptool::commands::{ExtractShared, extract_all::ExtractAll};
 use indexmap::IndexMap;
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
@@ -374,12 +369,21 @@ pub fn extract_peripherals(
             .and_then(|c| c.get(1))
             .ok_or_else(|| anyhow!("Failed strip namespace from filename {:?}", &entry))?;
 
-        chiptool::commands::transform::transform(Transform {
-            input: entry.path(),
-            output: output_dir.join(format!("{}.yaml", name.as_str().to_uppercase())),
-            transform: PathBuf::from_str("data/transforms/remove-namespace.yaml")?,
-        })
-        .with_context(|| format!("Error generating peripheral yamls for {core}"))?;
+        let from: chiptool::transform::common::RegexSet = serde_yaml::from_str("(.*)::(.+)")?;
+
+        let mut ir: chiptool::ir::IR = serde_yaml::from_reader(fs::File::open(entry.path())?)?;
+        chiptool::transform::rename::Rename {
+            from,
+            to: "$2".to_string(),
+            r#type: chiptool::transform::rename::RenameType::All,
+        }
+        .run(&mut ir)?;
+
+        let data = serde_yaml::to_string(&ir)?;
+        fs::write(
+            output_dir.join(format!("{}.yaml", name.as_str().to_uppercase())),
+            data.as_bytes(),
+        )?;
     }
 
     let svd_contents = fs::read_to_string(svd).context("Read SVD")?;

--- a/generator/src/metadata.rs
+++ b/generator/src/metadata.rs
@@ -6,7 +6,7 @@ use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 use serde::Deserialize;
 
-use crate::rustfmt;
+use crate::util::rustfmt;
 
 #[allow(unused)]
 #[derive(Debug, Clone, Deserialize)]

--- a/generator/src/metadata.rs
+++ b/generator/src/metadata.rs
@@ -1,7 +1,12 @@
-use std::{fmt::Write, fs, path::Path};
+use std::{
+    fmt::Write,
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
-use anyhow::{Context, bail};
-use chiptool::commands::extract_all::ExtractAll;
+use anyhow::{Context, anyhow, bail};
+use chiptool::commands::{ExtractShared, extract_all::ExtractAll, transform::Transform};
 use indexmap::IndexMap;
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
@@ -268,7 +273,7 @@ fn generate_metadata(name: &str, metadata: &Metadata) -> TokenStream {
     }
 }
 
-/// Read the metadata, generate the Rust source files for it and return the metadata.
+/// Read the metadata, generate the Rust source files for the metadata file used in build.rs and return the metadata.
 pub fn generate(chips_dir: &Path, metadata: &Path, core: &str) -> anyhow::Result<Metadata> {
     let metadata = fs::read_to_string(metadata).context("Read metadata")?;
     let metadata = serde_json::from_str::<Metadata>(&metadata).context("Deserialize metadata")?;
@@ -301,41 +306,82 @@ pub struct BlockPath {
 pub fn extract_peripherals(
     svd: &Path,
     core: &str,
-    transforms_dir: &Path,
+    transforms_dir: Option<&Path>,
     output_dir: &Path,
 ) -> Result<(), anyhow::Error> {
     use std::fmt::Write;
 
-    let transform = transforms_dir
-        .join(core.to_lowercase())
-        .with_extension("yaml");
+    let transform_path =
+        transforms_dir.map(|path| path.join(core.to_lowercase()).with_extension("yaml"));
 
-    if !fs::exists(&transform).context("checking transform existance")? {
-        bail!(
-            "transform {} for core \"{}\" does not exist?",
-            transform.display(),
-            core.to_lowercase()
-        );
-    }
+    let transform = if let Some(transform_path) = transform_path {
+        if !fs::exists(&transform_path).context("checking transform existance")? {
+            bail!(
+                "transform {} for core \"{}\" does not exist?",
+                transform_path.display(),
+                core.to_lowercase()
+            );
+        }
+        vec![transform_path.canonicalize()?]
+    } else {
+        vec![]
+    };
 
     if !fs::exists(output_dir).context("checking output directory existance")? {
         fs::create_dir(output_dir)
             .with_context(|| format!("creating output directory {}", output_dir.display()))?;
     }
-    for file in fs::read_dir(output_dir).context("reading raw peripherals dir")? {
-        let file = file?;
-        if file.file_name().to_string_lossy() != ".gitignore" {
-            fs::remove_file(file.path())
-                .with_context(|| format!("removing {}", file.path().display()))?;
+
+    for entry in fs::read_dir(output_dir).context("reading raw peripherals dir")? {
+        let entry = entry?;
+        if entry.file_name().to_string_lossy() != ".gitignore" {
+            if entry.file_type()?.is_dir() {
+                fs::remove_dir_all(entry.path())
+                    .with_context(|| format!("removing {}", entry.path().display()))?;
+            } else {
+                fs::remove_file(entry.path())
+                    .with_context(|| format!("removing {}", entry.path().display()))?;
+            }
         }
     }
 
+    let original_dir = &output_dir.join("original");
+
+    if !fs::exists(original_dir).context("checking output original subdirectory existance")? {
+        fs::create_dir(original_dir).with_context(|| {
+            format!("creating original subdirectory {}", original_dir.display())
+        })?;
+    }
+
     chiptool::commands::extract_all::extract_all(ExtractAll {
-        svd: svd.canonicalize()?,
-        output: output_dir.canonicalize()?,
-        transform: Some(vec![transform.canonicalize()?]),
+        output: original_dir.canonicalize()?,
+        extract_shared: ExtractShared {
+            svd: svd.canonicalize()?,
+            transform,
+            namespaces: chiptool::svd2ir::NamespaceMode::Block,
+        },
+        mode: chiptool::commands::extract_all::ExtractionMode::Block,
     })
     .with_context(|| format!("Error generating peripheral yamls for {core}"))?;
+
+    let path_regex = regex::Regex::new("^(.+)::.+$")?;
+    for entry in fs::read_dir(original_dir).context("reading original subdir")? {
+        let entry = entry?;
+
+        let filename: String = entry.file_name().to_string_lossy().into_owned();
+        let name = path_regex
+            .captures(&filename)
+            .map(|c| c.get(1))
+            .flatten()
+            .ok_or_else(|| anyhow!("Failed strip namespace from filename {:?}", &entry))?;
+
+        chiptool::commands::transform::transform(Transform {
+            input: entry.path(),
+            output: output_dir.join(format!("{}.yaml", name.as_str().to_uppercase())),
+            transform: PathBuf::from_str("data/transforms/remove-namespace.yaml")?,
+        })
+        .with_context(|| format!("Error generating peripheral yamls for {core}"))?;
+    }
 
     let svd_contents = fs::read_to_string(svd).context("Read SVD")?;
     let svd = svd_parser::parse(&svd_contents).context("Parse SVD")?;

--- a/generator/src/metadata.rs
+++ b/generator/src/metadata.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Write, fs, path::Path};
 
-use anyhow::Context;
+use anyhow::{Context, bail};
+use chiptool::commands::extract_all::ExtractAll;
 use indexmap::IndexMap;
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
@@ -267,33 +268,10 @@ fn generate_metadata(name: &str, metadata: &Metadata) -> TokenStream {
     }
 }
 
-pub fn generate_core(
-    chips_dir: &Path,
-    svd: &Path,
-    metadata: &Path,
-    core: &str,
-) -> anyhow::Result<Metadata> {
+/// Read the metadata, generate the Rust source files for it and return the metadata.
+pub fn generate(chips_dir: &Path, metadata: &Path, core: &str) -> anyhow::Result<Metadata> {
     let metadata = fs::read_to_string(metadata).context("Read metadata")?;
-    let mut metadata =
-        serde_json::from_str::<Metadata>(&metadata).context("Deserialize metadata")?;
-
-    if metadata.interrupts.is_empty() {
-        // If the metadata doesn't define the interrupts, we'll get it from the SVD
-
-        let svd_contents = fs::read_to_string(svd).context("Read SVD")?;
-        let svd = svd_parser::parse(&svd_contents).context("Parse SVD")?;
-
-        for peripheral in svd.peripherals.iter() {
-            for interrupt in peripheral.interrupt.iter() {
-                // Rust uses fully capitalized interrupt names for singletons.
-                metadata
-                    .interrupts
-                    .insert(interrupt.name.clone().to_uppercase(), interrupt.value);
-            }
-        }
-
-        metadata.interrupts.sort_unstable_by_key(|_, val| *val);
-    }
+    let metadata = serde_json::from_str::<Metadata>(&metadata).context("Deserialize metadata")?;
 
     let mut metadata_out = String::new();
     write!(metadata_out, "{}", generate_metadata(core, &metadata))?;
@@ -317,4 +295,112 @@ pub struct BlockPath {
     pub path: String,
     pub rust_mod_name: String,
     pub rust_type_name: String,
+}
+
+/// Extract peripheral metadata definitions from a SVD and puts them in a .gitignored raw folder.
+pub fn extract_peripherals(
+    svd: &Path,
+    core: &str,
+    transforms_dir: &Path,
+    output_dir: &Path,
+) -> Result<(), anyhow::Error> {
+    use std::fmt::Write;
+
+    let transform = transforms_dir
+        .join(core.to_lowercase())
+        .with_extension("yaml");
+
+    if !fs::exists(&transform).context("checking transform existance")? {
+        bail!(
+            "transform {} for core \"{}\" does not exist?",
+            transform.display(),
+            core.to_lowercase()
+        );
+    }
+
+    if !fs::exists(output_dir).context("checking output directory existance")? {
+        fs::create_dir(output_dir)
+            .with_context(|| format!("creating output directory {}", output_dir.display()))?;
+    }
+    for file in fs::read_dir(output_dir).context("reading raw peripherals dir")? {
+        let file = file?;
+        if file.file_name().to_string_lossy() != ".gitignore" {
+            fs::remove_file(file.path())
+                .with_context(|| format!("removing {}", file.path().display()))?;
+        }
+    }
+
+    chiptool::commands::extract_all::extract_all(ExtractAll {
+        svd: svd.canonicalize()?,
+        output: output_dir.canonicalize()?,
+        transform: Some(vec![transform.canonicalize()?]),
+    })
+    .with_context(|| format!("Error generating peripheral yamls for {core}"))?;
+
+    let svd_contents = fs::read_to_string(svd).context("Read SVD")?;
+    let svd = svd_parser::parse(&svd_contents).context("Parse SVD")?;
+
+    let nvic_priority_bits = svd
+        .cpu
+        .map(|cpu| cpu.nvic_priority_bits)
+        .unwrap_or_default();
+
+    let mut interrupts = Vec::new();
+
+    for peripheral in svd.peripherals.iter() {
+        for interrupt in peripheral.interrupt.iter() {
+            // Rust uses fully capitalized interrupt names for singletons.
+            interrupts.push((interrupt.name.clone().to_uppercase(), interrupt.value));
+        }
+    }
+
+    interrupts.sort_unstable_by_key(|(_, val)| *val);
+    interrupts.dedup();
+
+    let mut interrupts_json = String::new();
+    writeln!(
+        &mut interrupts_json,
+        "{{\n  \"nvic_prio_bits\": {nvic_priority_bits},\n  \"interrupts\": {{"
+    )?;
+    for (i, (name, num)) in interrupts.iter().enumerate() {
+        writeln!(
+            &mut interrupts_json,
+            "    \"{name}\": {num}{}",
+            if i != interrupts.len() - 1 { "," } else { "" }
+        )?;
+    }
+    writeln!(&mut interrupts_json, "  }}\n}}")?;
+
+    fs::write(
+        output_dir.join("_interrupts.json"),
+        interrupts_json.as_bytes(),
+    )
+    .context("writing _interrupts.json")?;
+
+    let peripheral_addresses = svd
+        .peripherals
+        .iter()
+        .map(|p| (&p.name, p.base_address))
+        .collect::<Vec<_>>();
+    let mut addresses_json = String::new();
+    writeln!(&mut addresses_json, "{{")?;
+    for (i, (name, address)) in peripheral_addresses.iter().enumerate() {
+        writeln!(
+            &mut addresses_json,
+            "  \"{name}\": \"{address:#010X}\"{}",
+            if i != peripheral_addresses.len() - 1 {
+                ","
+            } else {
+                ""
+            }
+        )?;
+    }
+    writeln!(&mut addresses_json, "}}")?;
+    fs::write(
+        output_dir.join("_addresses.json"),
+        addresses_json.as_bytes(),
+    )
+    .context("writing _addresses.json")?;
+
+    Ok(())
 }

--- a/generator/src/metapac.rs
+++ b/generator/src/metapac.rs
@@ -230,7 +230,9 @@ fn export_mod_rs(chip_dir: &Path, metadata: &Metadata) -> anyhow::Result<()> {
 
     writeln!(&mut contents, "pub mod common;")?;
 
-    fs::write(chip_dir.join("mod.rs"), contents.as_bytes()).context("writing contents to file")?;
+    let path = chip_dir.join("mod.rs");
+    fs::write(&path, contents.as_bytes()).context("writing contents to file")?;
+    crate::util::rustfmt(&path)?;
 
     Ok(())
 }
@@ -331,8 +333,9 @@ fn export_vectors_rs(chip_dir: &Path, metadata: &Metadata) -> anyhow::Result<()>
     writeln!(&mut contents, "{}", extern_functions_tokens)?;
     writeln!(&mut contents, "{}", interrupt_vector_table)?;
 
-    fs::write(chip_dir.join("_vectors.rs"), contents.as_bytes())
-        .context("writing contents to file")?;
+    let path = chip_dir.join("_vectors.rs");
+    fs::write(&path, contents.as_bytes()).context("writing contents to file")?;
+    crate::util::rustfmt(&path)?;
 
     Ok(())
 }

--- a/generator/src/metapac.rs
+++ b/generator/src/metapac.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, fs, path::Path, str::FromStr};
 
 use anyhow::Context;
-use chiptool::commands::{GenShared, ModulePath, gen_block::GenBlock, gen_common::GenCommon};
+use chiptool::commands::{GenerateShared, ModulePath, gen_block::GenBlock, gen_common::GenCommon};
 use indexmap::IndexSet;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::quote;
@@ -54,7 +54,7 @@ pub fn generate_meta_peripherals(current: &Path) -> anyhow::Result<()> {
                     .canonicalize()
                     .context("Canonicalizing entry path")?,
                 output: output_path.clone(),
-                gen_shared: GenShared {
+                gen_shared: GenerateShared {
                     common_module: Some(ModulePath::from_str("crate::pac::common")?),
                     defmt_feature: "defmt".to_string(),
                     no_defmt: false,

--- a/generator/src/metapac.rs
+++ b/generator/src/metapac.rs
@@ -1,12 +1,6 @@
-use std::{
-    collections::HashSet,
-    fs,
-    path::Path,
-    process::{Command, Stdio},
-    str::FromStr,
-};
+use std::{collections::HashSet, fs, path::Path, str::FromStr};
 
-use anyhow::{Context, bail};
+use anyhow::Context;
 use chiptool::commands::{GenShared, ModulePath, gen_block::GenBlock, gen_common::GenCommon};
 use indexmap::IndexSet;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
@@ -16,7 +10,7 @@ use rayon::iter::{ParallelBridge, ParallelIterator};
 use crate::metadata::{BlockPath, Metadata};
 
 /// Take all yamls and export them to the pac after being transformed to Rust code using chiptool
-pub fn export_meta_peripherals(current: &Path) -> anyhow::Result<()> {
+pub fn generate_meta_peripherals(current: &Path) -> anyhow::Result<()> {
     let pac_peri_dir = current.join("nxp-pac/src/meta_peripherals");
     let yaml_peri_dir = current.join("data/metadata/peripherals");
 
@@ -70,35 +64,22 @@ pub fn export_meta_peripherals(current: &Path) -> anyhow::Result<()> {
             })
             .with_context(|| format!("Error generating block {}", relative_entry_path.display()))?;
 
-            let output = Command::new("rustfmt")
-                .arg("--edition")
-                .arg("2024")
-                .arg(output_path)
-                .stdout(Stdio::inherit())
-                .stderr(Stdio::inherit())
-                .output()?;
-
-            if !output.status.success() {
-                bail!(
-                    "Error formatting block {}:\nSTDERR:\n{}",
-                    relative_entry_path.display(),
-                    String::from_utf8_lossy(&output.stderr)
-                );
-            }
-
-            Ok(())
+            crate::util::rustfmt(&output_path).with_context(|| {
+                format!("Error formatting block {}", relative_entry_path.display())
+            })
         })?;
 
     Ok(())
 }
 
-pub fn assemble_metapac(current: &Path, core: &str, mut metadata: Metadata) -> anyhow::Result<()> {
-    let chip_dir = current.join("nxp-pac/src/chips").join(core.to_lowercase());
-    if !chip_dir.exists() {
-        fs::create_dir_all(&chip_dir).context("creating chip dir")?;
+/// Generates all core-specific code for a metapac PAC, including any peripherals that have been mapped.
+pub fn generate_core(current: &Path, core: &str, mut metadata: Metadata) -> anyhow::Result<()> {
+    let core_dir = current.join("nxp-pac/src/chips").join(core.to_lowercase());
+    if !core_dir.exists() {
+        fs::create_dir_all(&core_dir).context("creating chip dir")?;
     }
 
-    // Remove all peripherals that are defined, but don't have a driver
+    // Remove all peripherals that are defined, but don't have a metaperipheral mapped.
     let yaml_peri_dir = current.join("data/metadata/peripherals");
     metadata.peripherals.retain(|p| {
         let peripheral_block = match p.parse_block_path() {
@@ -135,10 +116,10 @@ pub fn assemble_metapac(current: &Path, core: &str, mut metadata: Metadata) -> a
         }
     });
 
-    export_device_x(&chip_dir, &metadata).context("exporting device.x")?;
-    export_mod_rs(&chip_dir, &metadata).context("exporting mod.rs")?;
-    export_vectors_rs(&chip_dir, &metadata).context("exporting _vectors.rs")?;
-    export_common_rs(&chip_dir).context("exporting common.rs")?;
+    export_device_x(&core_dir, &metadata).context("exporting device.x")?;
+    export_mod_rs(&core_dir, &metadata).context("exporting mod.rs")?;
+    export_vectors_rs(&core_dir, &metadata).context("exporting _vectors.rs")?;
+    export_common_rs(&core_dir).context("exporting common.rs")?;
 
     Ok(())
 }

--- a/generator/src/pac.rs
+++ b/generator/src/pac.rs
@@ -8,8 +8,6 @@ use anyhow::{Context, bail};
 use chiptool::commands::{GenShared, extract_all::ExtractAll, generate::Generate};
 use temp_dir::TempDir;
 
-use crate::util::rustfmt;
-
 pub fn generate_core(
     svd: &Path,
     chip_dir: &Path,
@@ -54,7 +52,6 @@ pub fn generate_core(
     .context(format!("Error generating {core}"))?;
 
     let lib_temp = temp.path().join("lib.rs");
-    rustfmt(&lib_temp).context("Formatting lib.rs")?;
 
     let device_x = temp.path().join("device.x");
     let output_dir = chip_dir.join(core.to_lowercase());
@@ -71,7 +68,9 @@ pub fn generate_core(
         .status()
         .context("Running the `form` command. Make sure to have it installed: https://crates.io/crates/form")?;
 
-    fs::rename(output_dir.join("lib.rs"), output_dir.join("mod.rs"))?;
+    let mod_path = output_dir.join("mod.rs");
+    fs::rename(output_dir.join("lib.rs"), &mod_path)?;
+    crate::util::rustfmt(&mod_path)?;
 
     Ok(())
 }

--- a/generator/src/pac.rs
+++ b/generator/src/pac.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{Context, bail};
-use chiptool::commands::{GenShared, extract_all::ExtractAll, generate::Generate};
+use chiptool::commands::{GenShared, generate::Generate};
 use temp_dir::TempDir;
 
 /// Generates nxp-pac Rust code for non-metapac PACs.
@@ -72,113 +72,6 @@ pub fn generate_core(
     let mod_path = output_dir.join("mod.rs");
     fs::rename(output_dir.join("lib.rs"), &mod_path)?;
     crate::util::rustfmt(&mod_path)?;
-
-    Ok(())
-}
-
-/// Generates metapac data
-pub fn extract_peripherals(
-    svd: &Path,
-    metadata_dir: &Path,
-    core: &str,
-    transforms_dir: &Path,
-) -> Result<(), anyhow::Error> {
-    use std::fmt::Write;
-
-    let transform = transforms_dir
-        .join(core.to_lowercase())
-        .with_extension("yaml");
-
-    if !fs::exists(&transform).context("checking transform existance")? {
-        bail!(
-            "transform for core \"{}\" does not exist?",
-            core.to_lowercase()
-        );
-    }
-
-    let raw_peripherals_dir = metadata_dir.join("peripherals/raw").join(core);
-    if !fs::exists(&raw_peripherals_dir).context("checking raw_peripherals_dir existance")? {
-        fs::create_dir(&raw_peripherals_dir).context("creating raw_peripherals_dir")?;
-    }
-    for file in fs::read_dir(&raw_peripherals_dir).context("reading raw peripherals dir")? {
-        let file = file?;
-        if file.file_name().to_string_lossy() != ".gitignore" {
-            fs::remove_file(file.path())
-                .with_context(|| format!("removing {}", file.path().display()))?;
-        }
-    }
-
-    chiptool::commands::extract_all::extract_all(ExtractAll {
-        svd: svd.canonicalize()?,
-        output: raw_peripherals_dir.canonicalize()?,
-        transform: Some(vec![transform.canonicalize()?]),
-    })
-    .with_context(|| format!("Error generating peripheral yamls for {core}"))?;
-
-    let svd_contents = fs::read_to_string(svd).context("Read SVD")?;
-    let svd = svd_parser::parse(&svd_contents).context("Parse SVD")?;
-
-    let nvic_priority_bits = svd
-        .cpu
-        .map(|cpu| cpu.nvic_priority_bits)
-        .unwrap_or_default();
-
-    let mut interrupts = Vec::new();
-
-    for peripheral in svd.peripherals.iter() {
-        for interrupt in peripheral.interrupt.iter() {
-            // Rust uses fully capitalized interrupt names for singletons.
-            interrupts.push((interrupt.name.clone().to_uppercase(), interrupt.value));
-        }
-    }
-
-    interrupts.sort_unstable_by_key(|(_, val)| *val);
-    interrupts.dedup();
-
-    let mut interrupts_json = String::new();
-    writeln!(
-        &mut interrupts_json,
-        "{{\n  \"nvic_prio_bits\": {nvic_priority_bits},\n  \"interrupts\": {{"
-    )?;
-    for (i, (name, num)) in interrupts.iter().enumerate() {
-        writeln!(
-            &mut interrupts_json,
-            "    \"{name}\": {num}{}",
-            if i != interrupts.len() - 1 { "," } else { "" }
-        )?;
-    }
-    writeln!(&mut interrupts_json, "  }}\n}}")?;
-
-    fs::write(
-        raw_peripherals_dir.join("_interrupts.json"),
-        interrupts_json.as_bytes(),
-    )
-    .context("writing _interrupts.json")?;
-
-    let peripheral_addresses = svd
-        .peripherals
-        .iter()
-        .map(|p| (&p.name, p.base_address))
-        .collect::<Vec<_>>();
-    let mut addresses_json = String::new();
-    writeln!(&mut addresses_json, "{{")?;
-    for (i, (name, address)) in peripheral_addresses.iter().enumerate() {
-        writeln!(
-            &mut addresses_json,
-            "  \"{name}\": \"{address:#010X}\"{}",
-            if i != peripheral_addresses.len() - 1 {
-                ","
-            } else {
-                ""
-            }
-        )?;
-    }
-    writeln!(&mut addresses_json, "}}")?;
-    fs::write(
-        raw_peripherals_dir.join("_addresses.json"),
-        addresses_json.as_bytes(),
-    )
-    .context("writing _addresses.json")?;
 
     Ok(())
 }

--- a/generator/src/pac.rs
+++ b/generator/src/pac.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, bail};
 use chiptool::commands::{GenShared, extract_all::ExtractAll, generate::Generate};
 use temp_dir::TempDir;
 
+/// Generates nxp-pac Rust code for non-metapac PACs.
 pub fn generate_core(
     svd: &Path,
     chip_dir: &Path,
@@ -75,7 +76,8 @@ pub fn generate_core(
     Ok(())
 }
 
-pub fn generate_peripherals(
+/// Generates metapac data
+pub fn extract_peripherals(
     svd: &Path,
     metadata_dir: &Path,
     core: &str,

--- a/generator/src/pac.rs
+++ b/generator/src/pac.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, bail};
 use chiptool::commands::{GenShared, extract_all::ExtractAll, generate::Generate};
 use temp_dir::TempDir;
 
-use crate::rustfmt;
+use crate::util::rustfmt;
 
 pub fn generate_core(
     svd: &Path,

--- a/generator/src/pac.rs
+++ b/generator/src/pac.rs
@@ -107,27 +107,6 @@ pub fn generate_peripherals(
         }
     }
 
-    let debug_ir_path = raw_peripherals_dir.join("_debug_ir").with_extension("yaml");
-
-    let temp = TempDir::new()
-        .context("Creating temp dir")?
-        .panic_on_cleanup_error();
-
-    chiptool::commands::generate::generate(Generate {
-        svd: svd.canonicalize()?,
-        transform: vec![transform.canonicalize()?],
-        gen_shared: GenShared {
-            common_module: None,
-            defmt_feature: "defmt".to_string(),
-            no_defmt: false,
-            yes_defmt: false,
-            skip_no_std: false,
-        },
-        debug_ir_output: Some(debug_ir_path),
-        output: Some(temp.path().to_path_buf()),
-    })
-    .with_context(|| format!("Error generating debug yaml for {core}"))?;
-
     chiptool::commands::extract_all::extract_all(ExtractAll {
         svd: svd.canonicalize()?,
         output: raw_peripherals_dir.canonicalize()?,

--- a/generator/src/pac.rs
+++ b/generator/src/pac.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{Context, bail};
-use chiptool::commands::{GenShared, generate::Generate};
+use chiptool::commands::{GenerateShared, generate::Generate};
 use temp_dir::TempDir;
 
 /// Generates nxp-pac Rust code for non-metapac PACs.
@@ -40,7 +40,9 @@ pub fn generate_core(
     chiptool::commands::generate::generate(Generate {
         svd: svd.canonicalize()?,
         transform: vec![transform.canonicalize()?],
-        gen_shared: GenShared {
+        // Note: would rather use 'Block' but this is what the current (non-metapac) PACs use.
+        namespaces: chiptool::svd2ir::NamespaceMode::BlockWithRegsVals,
+        gen_shared: GenerateShared {
             common_module: None,
             defmt_feature: "defmt".to_string(),
             no_defmt: false,

--- a/generator/src/util.rs
+++ b/generator/src/util.rs
@@ -8,6 +8,7 @@ use anyhow::bail;
 /// Perform rustfmt on a single file.
 pub fn rustfmt(path: &Path) -> anyhow::Result<()> {
     let output = Command::new("rustfmt")
+        .args(["--edition", "2024"])
         .arg(path.canonicalize()?)
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())

--- a/generator/src/util.rs
+++ b/generator/src/util.rs
@@ -1,0 +1,24 @@
+use std::{
+    path::Path,
+    process::{Command, Stdio},
+};
+
+use anyhow::bail;
+
+/// Perform rustfmt on a single file.
+pub fn rustfmt(path: &Path) -> anyhow::Result<()> {
+    let output = Command::new("rustfmt")
+        .arg(path.canonicalize()?)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .output()?;
+
+    if !output.status.success() {
+        bail!(
+            "Error during rustfmt: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    Ok(())
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-09-26"
+channel = "1.94.1"
 components = [ "rust-src", "rustfmt", "clippy" ]
 targets = [
     "thumbv7em-none-eabihf",


### PR DESCRIPTION
Currently the generator main does everything at the same time, making it hard to separate concerns and organize code.

This PR pulls each separate step / responsibility into its own separate command, cleaning up as I go.

Note that the transforms for MCXA are not necessarily up to date, especially because the SVD was updated in the meantime. We also expressly do not update the metadata yet.

### Side effects
* Because `cargo fmt` is no longer necessary the PAC generation for a single chip has been reduced to ~0.5s for the metapac PAC's.
* Moved away from Rust nightly for the generator.

### TODO's
- [x] update READMEs
- [x] check out I3C transforms
- [x] clean up remove-namespaces transform