### PR TITLE
Fix CI doc regression

### DIFF
--- a/.github/ci/doc.sh
+++ b/.github/ci/doc.sh
@@ -11,15 +11,12 @@ export CARGO_HOME=/ci/cache/cargo
 export CARGO_TARGET_DIR=/ci/cache/target
 export BUILDER_THREADS=4
 export BUILDER_COMPRESS=true
+export RUST_TOOLCHAIN=nightly-2025-09-26
 
 # SUBMODULES!!!
 git submodule update --init --recursive --checkout
 
-# force rustup to download the toolchain before starting building.
-# Otherwise, the docs builder is running multiple instances of cargo rustdoc concurrently.
-# They all see the toolchain is not installed and try to install it in parallel
-# which makes rustup very sad
-rustc --version > /dev/null
+rustup toolchain install ${RUST_TOOLCHAIN}
 
 cd nxp-pac
 docserver build -i . -o webroot/crates/nxp-pac/git.zup


### PR DESCRIPTION
Project toolchain was set to stable in [this commit](https://github.com/embassy-rs/nxp-pac/commit/95fde73e68bb365900f26261e21b1f9d26ffbbac), but [docserver requires nightly](https://github.com/embassy-rs/docserver/blob/bf49e85666d4754212cd0d10381bf57e41b68f42/src/commands/build.rs#L277-L278). This PR sets nightly just for building the docs.