### PR TITLE
Add pin features to metadata

### DIFF
--- a/data/metadata/MCXA2xx.json
+++ b/data/metadata/MCXA2xx.json
@@ -86,15 +86,18 @@
     },
     {
       "name": "P1_29",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "dangerous-reset-as-gpio"
     },
     {
       "name": "P1_30",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "sosc-as-gpio"
     },
     {
       "name": "P1_31",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "sosc-as-gpio"
     },
     {
       "name": "P4_0",
@@ -366,19 +369,23 @@
     },
     {
       "name": "P0_0",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "swd-as-gpio"
     },
     {
       "name": "P0_1",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "swd-as-gpio"
     },
     {
       "name": "P0_2",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "swd-swo-as-gpio"
     },
     {
       "name": "P0_3",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "jtag-extras-as-gpio"
     },
     {
       "name": "P0_4",
@@ -390,7 +397,8 @@
     },
     {
       "name": "P0_6",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "jtag-extras-as-gpio"
     },
     {
       "name": "P0_7",

--- a/data/metadata/MCXA5xx.json
+++ b/data/metadata/MCXA5xx.json
@@ -84,15 +84,18 @@
     },
     {
       "name": "P1_29",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "dangerous-reset-as-gpio"
     },
     {
       "name": "P1_30",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "sosc-as-gpio"
     },
     {
       "name": "P1_31",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "sosc-as-gpio"
     },
     {
       "name": "P4_0",
@@ -276,11 +279,13 @@
     },
     {
       "name": "P5_0",
-      "supply": "VDD_BAT"
+      "supply": "VDD_BAT",
+      "feature": "rosc-32k-as-gpio"
     },
     {
       "name": "P5_1",
-      "supply": "VDD_BAT"
+      "supply": "VDD_BAT",
+      "feature": "rosc-32k-as-gpio"
     },
     {
       "name": "P5_2",
@@ -444,19 +449,23 @@
     },
     {
       "name": "P0_0",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "swd-as-gpio"
     },
     {
       "name": "P0_1",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "swd-as-gpio"
     },
     {
       "name": "P0_2",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "swd-swo-as-gpio"
     },
     {
       "name": "P0_3",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "jtag-extras-as-gpio"
     },
     {
       "name": "P0_4",
@@ -468,7 +477,8 @@
     },
     {
       "name": "P0_6",
-      "supply": "VDD"
+      "supply": "VDD",
+      "feature": "jtag-extras-as-gpio"
     },
     {
       "name": "P0_7",

--- a/data/metadata/schema.json
+++ b/data/metadata/schema.json
@@ -55,6 +55,10 @@
         "iomuxc": {
           "description": "IOMUXC metadata for the pin. Not allowed if the chip isn't an RT1xxx family device",
           "$ref": "#/$defs/iomuxc"
+        },
+        "feature": {
+          "description": "Rust Feature required to \"unlock\" the pin.",
+          "type": "string"
         }
       },
       "required": [

--- a/generator/src/metadata.rs
+++ b/generator/src/metadata.rs
@@ -31,6 +31,12 @@ pub struct Pin {
 
     /// IOMUXC information for this pin. Only applicable on RT1xxx chips.
     pub iomuxc: Option<PinIomuxc>,
+
+    /// Rust Feature required to "unlock" the pin.
+    ///
+    /// An example of this is when a pin is used for SWD communication by default,
+    /// and it would be dangerous to unlock unless explicitly designed around it.
+    pub feature: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/generator/src/metadata.rs
+++ b/generator/src/metadata.rs
@@ -156,11 +156,17 @@ fn generate_metadata(name: &str, metadata: &Metadata) -> TokenStream {
                 }
             })
             .unwrap_or_else(|| quote! { None });
+        let feature = pin
+            .feature
+            .as_ref()
+            .map(|feature| quote! { Some(#feature) })
+            .unwrap_or_else(|| quote! { None });
 
         quote! {
             Pin {
                 name: #name,
                 iomuxc: #iomuxc,
+                feature: #feature
             }
         }
     });

--- a/nxp-pac/src/chips/mcxa256/metadata.rs
+++ b/nxp-pac/src/chips/mcxa256/metadata.rs
@@ -9,458 +9,572 @@ pub const PINS: &[Pin] = &[
     Pin {
         name: "P1_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_29",
         iomuxc: None,
+        feature: Some("dangerous-reset-as-gpio"),
     },
     Pin {
         name: "P1_30",
         iomuxc: None,
+        feature: Some("sosc-as-gpio"),
     },
     Pin {
         name: "P1_31",
         iomuxc: None,
+        feature: Some("sosc-as-gpio"),
     },
     Pin {
         name: "P4_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_20",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_21",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_22",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_23",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_24",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_25",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_26",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_31",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_30",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_29",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_28",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_27",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_26",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_25",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_24",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_23",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_22",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_21",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_20",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_0",
         iomuxc: None,
+        feature: Some("swd-as-gpio"),
     },
     Pin {
         name: "P0_1",
         iomuxc: None,
+        feature: Some("swd-as-gpio"),
     },
     Pin {
         name: "P0_2",
         iomuxc: None,
+        feature: Some("swd-swo-as-gpio"),
     },
     Pin {
         name: "P0_3",
         iomuxc: None,
+        feature: Some("jtag-extras-as-gpio"),
     },
     Pin {
         name: "P0_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_6",
         iomuxc: None,
+        feature: Some("jtag-extras-as-gpio"),
     },
     Pin {
         name: "P0_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_20",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_21",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_22",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_23",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_24",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_25",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_26",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_27",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_7",
         iomuxc: None,
+        feature: None,
     },
 ];
 pub const PERIPHERALS: &[Peripheral] = &[

--- a/nxp-pac/src/chips/mcxa577/metadata.rs
+++ b/nxp-pac/src/chips/mcxa577/metadata.rs
@@ -9,554 +9,692 @@ pub const PINS: &[Pin] = &[
     Pin {
         name: "P1_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_29",
         iomuxc: None,
+        feature: Some("dangerous-reset-as-gpio"),
     },
     Pin {
         name: "P1_30",
         iomuxc: None,
+        feature: Some("sosc-as-gpio"),
     },
     Pin {
         name: "P1_31",
         iomuxc: None,
+        feature: Some("sosc-as-gpio"),
     },
     Pin {
         name: "P4_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P4_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_28",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_29",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_30",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_20",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_21",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_31",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_22",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_23",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_24",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_25",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P2_26",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P5_0",
         iomuxc: None,
+        feature: Some("rosc-32k-as-gpio"),
     },
     Pin {
         name: "P5_1",
         iomuxc: None,
+        feature: Some("rosc-32k-as-gpio"),
     },
     Pin {
         name: "P5_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P5_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P5_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P5_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P5_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P5_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P5_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P5_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_31",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_30",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_29",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_28",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_27",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_26",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_25",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_24",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_23",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_22",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_21",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_20",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P3_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_0",
         iomuxc: None,
+        feature: Some("swd-as-gpio"),
     },
     Pin {
         name: "P0_1",
         iomuxc: None,
+        feature: Some("swd-as-gpio"),
     },
     Pin {
         name: "P0_2",
         iomuxc: None,
+        feature: Some("swd-swo-as-gpio"),
     },
     Pin {
         name: "P0_3",
         iomuxc: None,
+        feature: Some("jtag-extras-as-gpio"),
     },
     Pin {
         name: "P0_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_6",
         iomuxc: None,
+        feature: Some("jtag-extras-as-gpio"),
     },
     Pin {
         name: "P0_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_20",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_21",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_22",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_23",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_24",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_25",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_26",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P0_27",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "P1_7",
         iomuxc: None,
+        feature: None,
     },
 ];
 pub const PERIPHERALS: &[Peripheral] = &[
@@ -6516,7 +6654,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 iomuxc_daisy: None,
             },
             Signal {
-                name: "29",
+                name: "27",
                 pins: &[SignalPin {
                     pin: "P3_29",
                     alt: 0u8,

--- a/nxp-pac/src/metadata.rs
+++ b/nxp-pac/src/metadata.rs
@@ -30,6 +30,7 @@ pub struct Metadata {
 pub struct Pin {
     pub name: &'static str,
     pub iomuxc: Option<PinIomuxc>,
+    pub feature: Option<&'static str>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Some pins require to be protected from the end-user, unless they opt-in to exposing the pin.

Examples of this include SWD-pins, which should really never be configured unless the user has an alternative, never plans to use SWD again, or has a robust way to recover SWD access.

In the HAL this is now exposed as follows: https://github.com/embassy-rs/embassy/blob/6b015329e6784d084c1b589ba31af7a7dee13a7e/embassy-mcxa/src/chips/mcxa5xx.rs#L141-L157

We want to generate these feature flags from the metadata.