### PR TITLE
Revert AHBSC to mcux-soc-svd @ 13bbf70 based version

### DIFF
--- a/data/metadata/peripherals/mcxa/AHBSC.yaml
+++ b/data/metadata/peripherals/mcxa/AHBSC.yaml
@@ -1,191 +1,182 @@
+# File not directly generated from transforms!
+# This file was manually copied from mcux-soc-svd @ 13bbf70 with some transforms applied.
+# Current release 25.06.00 commit da354fa is very incorrect.
+
 block/Ahbsc:
   description: AHBSC.
   items:
-  - name: ahb_slave_port_p0_slave_rule
-    description: AHB Slave Port 0 Rule.
-    array:
-      len: 4
-      stride: 4
-    byte_offset: 0
-    fieldset: AhbSlavePortP0SlaveRule
   - name: flash00_mem_rule
     description: Flash Memory Rule.
     array:
       len: 4
       stride: 4
     byte_offset: 16
-    fieldset: Flash00MemRule
-  - name: flash01_mem_rule0
+    fieldset: Rule8
+  - name: flash01_mem_rule
     description: Flash Memory Rule.
-    byte_offset: 32
-    fieldset: Flash01MemRule0
-  - name: flash02_mem_rule0
-    description: Flash Memory Rule.
-    byte_offset: 48
-    fieldset: Flash02MemRule0
-  - name: ahb_slave_port_p1_slave_rule
-    description: AHB Slave Port 1 Rule.
     array:
       len: 4
       stride: 4
+    byte_offset: 32
+    fieldset: Rule8
+  - name: flash02_mem_rule
+    description: Flash IFR0 Rule register.
+    byte_offset: 48
+    fieldset: Rule4
+  - name: flash03_mem_rule
+    description: Flash Memory Rule.
     byte_offset: 64
-    fieldset: AhbSlavePortP1SlaveRule
+    fieldset: Rule4
   - name: rom_mem_rule
     description: ROM Memory Rule.
     array:
       len: 4
       stride: 4
-    byte_offset: 80
-    fieldset: RomMemRule
-  - name: ahb_slave_port_p2_slave_rule
-    description: AHB Slave Port 2 Rule.
-    array:
-      len: 4
-      stride: 4
     byte_offset: 96
-    fieldset: AhbSlavePortP2SlaveRule
-  - name: ramx_mem_rule0
+    fieldset: Rule8
+  - name: ramx_mem_rule
     description: RAMX Memory Rule.
-    byte_offset: 112
-    fieldset: RamxMemRule0
-  - name: ahb_slave_port_p3_slave_rule
-    description: AHB Slave Port 3 Rule.
     array:
       len: 4
       stride: 4
     byte_offset: 128
-    fieldset: AhbSlavePortP3SlaveRule
+    fieldset: Rule8
   - name: rama_mem_rule
-    description: RAMA Memory Rule.
+    description: RAMA Memory Rule 0.
     array:
-      len: 4
-      stride: 4
-    byte_offset: 144
-    fieldset: RamMemRule
-  - name: ahb_slave_port_p4_slave_rule
-    description: AHB Slave Port 4 Rule.
-    array:
-      len: 4
+      len: 8
       stride: 4
     byte_offset: 160
-    fieldset: AhbSlavePortP4SlaveRule
+    fieldset: Rule8
   - name: ramb_mem_rule
-    description: RAMB Memory Rule.
+    description: RAMB Memory Rule 0.
     array:
-      len: 4
+      len: 8
       stride: 4
-    byte_offset: 176
-    fieldset: RamMemRule
-  - name: ahb_peripheral_slave_port_p5_slave_rule0
-    description: AHB Peripheral Slave Port 5 Slave Rule 0.
-    byte_offset: 192
-    fieldset: AhbPeripheralSlavePortP5SlaveRule0
-  - name: ahb_peripheral_slave_port_p5_slave_rule1
-    description: AHB Peripheral Slave Port 5 Slave Rule 1.
-    byte_offset: 196
-    fieldset: AhbPeripheralSlavePortP5SlaveRule1
-  - name: apb_peripheral_group0_mem_rule0
-    description: APB Bridge Group 0 Memory Rule 0.
     byte_offset: 208
-    fieldset: ApbPeripheralGroup0MemRule0
+    fieldset: Rule8
+  - name: ahb_slave_port_p5_slave_rule0
+    description: AHB Slave Port 5 Rule Register.
+    byte_offset: 240
+    fieldset: AhbSlavePortP5slaveRule0
+  - name: apb_peripheral_group0_mem_rule0
+    description: APB Bridge Group 0 Memory Rule Register 0.
+    byte_offset: 256
+    fieldset: ApbPeripheralGroup0memRule0
   - name: apb_peripheral_group0_mem_rule1
-    description: APB Bridge Group 0 Memory Rule 1.
-    byte_offset: 212
-    fieldset: ApbPeripheralGroup0MemRule1
-  - name: apb_peripheral_group0_mem_rule2
-    description: APB Bridge Group 0 Rule 2.
-    byte_offset: 216
-    access: Read
-  - name: apb_peripheral_group0_mem_rule3
-    description: APB Bridge Group 0 Memory Rule 3.
-    byte_offset: 220
-    access: Read
+    description: APB Bridge Group 0 Memory Rule Register 1.
+    byte_offset: 260
+    fieldset: ApbPeripheralGroup0memRule1
   - name: aips_bridge_group0_mem_rule0
     description: AIPS Bridge Group 0 Memory Rule 0.
-    byte_offset: 224
-    fieldset: AipsBridgeGroup0MemRule0
+    byte_offset: 272
+    fieldset: AipsBridgeGroup0memRule0
   - name: aips_bridge_group0_mem_rule1
     description: AIPS Bridge Group 0 Memory Rule 1.
-    byte_offset: 228
-    fieldset: AipsBridgeGroup0MemRule1
-  - name: aips_bridge_group0_mem_rule2
-    description: AIPS Bridge Group 0 Memory Rule 2.
-    byte_offset: 232
-    fieldset: AipsBridgeGroup0MemRule2
-  - name: aips_bridge_group0_mem_rule3
-    description: AIPS Bridge Group 0 Memory Rule 3.
-    byte_offset: 236
-    fieldset: AipsBridgeGroup0MemRule3
-  - name: aips_bridge_group2_mem_rule0
-    description: AIPS Bridge Group 2 Memory Rule 0.
-    byte_offset: 240
-    fieldset: AipsBridgeGroup2MemRule0
-  - name: aips_bridge_group2_mem_rule1
-    description: AIPS Bridge Group 2 Memory Rule 1.
-    byte_offset: 244
-    fieldset: AipsBridgeGroup2MemRule1
-  - name: aips_bridge_group2_mem_rule2
-    description: AIPS Bridge Group 2 Memory Rule 2.
-    byte_offset: 248
-    fieldset: AipsBridgeGroup2MemRule2
-  - name: aips_bridge_group2_mem_rule3
-    description: AIPS Bridge Group 2 Memory Rule 3.
-    byte_offset: 252
-    fieldset: AipsBridgeGroup2MemRule3
-  - name: aips_bridge_group3_mem_rule0
-    description: AIPS Bridge Group 3 Rule 0.
-    byte_offset: 256
-    fieldset: AipsBridgeGroup3MemRule0
-  - name: aips_bridge_group3_mem_rule1
-    description: AIPS Bridge Group 3 Memory Rule 1.
-    byte_offset: 260
-    access: Read
-  - name: aips_bridge_group3_mem_rule2
-    description: AIPS Bridge Group 3 Rule 2.
-    byte_offset: 264
-    fieldset: AipsBridgeGroup3MemRule2
-  - name: aips_bridge_group3_mem_rule3
-    description: AIPS Bridge Group 3 Rule 3.
-    byte_offset: 268
-    fieldset: AipsBridgeGroup3MemRule3
-  - name: ahb_secure_ctrl_peripheral_rule0
-    description: AHB Secure Control Peripheral Rule 0.
-    byte_offset: 272
-    fieldset: AhbSecureCtrlPeripheralRule0
-  - name: ahb_slave_port_p6_slave_rule
-    description: AHB Slave Port 6 Rule.
-    array:
-      len: 4
-      stride: 4
+    byte_offset: 276
+    fieldset: AipsBridgeGroup0memRule1
+  - name: aips_bridge_group1_mem_rule0
+    description: AIPS Bridge Group 1 Memory Rule 0.
     byte_offset: 288
-    fieldset: AhbSlavePortP6SlaveRule
-  - name: aon_domain_peripheral_mem_rule0
-    description: AON Domain Peripheral Rule 0.
+    fieldset: AipsBridgeGroup1memRule0
+  - name: aips_bridge_group1_mem_rule1
+    description: AIPS Bridge Group 1 Memory Rule 1.
+    byte_offset: 292
+    fieldset: AipsBridgeGroup1memRule1
+  - name: ahb_secure_ctrl_mem_rule0
+    description: AHB Secure Control Peripheral Rule.
     byte_offset: 304
-    fieldset: AonDomainPeripheralMemRule0
-  - name: aon_domain_peripheral_mem_rule1
-    description: AON Domain Peripheral Rule 1.
-    byte_offset: 308
-    fieldset: AonDomainPeripheralMemRule1
-  - name: aon_domain_peripheral_mem_rule2
-    description: AON Domain Peripheral Rule 2.
-    byte_offset: 312
-    fieldset: AonDomainPeripheralMemRule2
-  - name: aon_domain_peripheral_mem_rule3
-    description: AON Domain Peripheral Rule 3.
-    byte_offset: 316
-    fieldset: AonDomainPeripheralMemRule3
-  - name: ahb_slave_port_p7_slave_rule
-    description: AHB Slave Port 6 Rule.
+    fieldset: Rule4
+  - name: ahb_peripheral0_mem_rule1
+    description: AHB Peripheral 0 Memory Rule 1.
+    byte_offset: 320
+    fieldset: AhbPeripheral0memRule1
+  - name: ahb_peripheral0_mem_rule2
+    description: AHB Peripheral 0 Memory Rule 2.
+    byte_offset: 336
+    fieldset: AhbPeripheral0memRule2
+  - name: ahb_peripheral0_mem_rule3
+    description: AHB Peripheral 0 Memory Rule 3.
+    byte_offset: 352
+    fieldset: AhbPeripheral0memRule3
+  - name: ahb_peripheral0_mem_rule4
+    description: AHB Peripheral 0 Memory Rule 4.
+    byte_offset: 368
+    fieldset: AhbPeripheral0memRule4
+  - name: ahb_peripheral0_mem_rule5
+    description: AHB Peripheral 0 Memory Rule 5.
+    byte_offset: 384
+    fieldset: AhbPeripheral0memRule5
+  - name: aips_bridge_group2_mem_rule0
+    description: AIPS Bridge Group 2 Rule 0.
+    byte_offset: 416
+    fieldset: AipsBridgeGroup2memRule0
+  - name: aips_bridge_group2_mem_rule1
+    description: AIPS Bridge Group 2 Rule 1.
+    byte_offset: 420
+    fieldset: AipsBridgeGroup2memRule1
+  - name: aips_bridge_group2_mem_rule2
+    description: AIPS Bridge Group 2 Rule 2.
+    byte_offset: 424
+    fieldset: AipsBridgeGroup2memRule2
+  - name: aips_bridge_group2_mem_rule3
+    description: AIPS Bridge Group 2 Rule 3.
+    byte_offset: 428
+    fieldset: AipsBridgeGroup2memRule3
+  - name: aips_bridge_group2_mem_rule4
+    description: AIPS Bridge Group 2 Rule 4.
+    byte_offset: 432
+    fieldset: AipsBridgeGroup2memRule4
+  - name: aips_bridge_group2_mem_rule5
+    description: AIPS Bridge Group 2 Rule 5.
+    byte_offset: 436
+    fieldset: AipsBridgeGroup2memRule5
+  - name: aips_bridge_group2_mem_rule6
+    description: AIPS Bridge Group 2 Rule 6.
+    byte_offset: 440
+    fieldset: AipsBridgeGroup2memRule6
+  - name: aips_bridge_group2_mem_rule7
+    description: AIPS Bridge Group 2 Rule 7.
+    byte_offset: 444
+    fieldset: AipsBridgeGroup2memRule7
+  - name: aips_bridge_group2_mem_rule8
+    description: AIPS Bridge Group 2 Rule 8.
+    byte_offset: 448
+    fieldset: AipsBridgeGroup2memRule8
+  - name: aips_bridge_group2_mem_rule9
+    description: AIPS Bridge Group 2 Rule 9.
+    byte_offset: 452
+    fieldset: AipsBridgeGroup2memRule9
+  - name: aips_bridge_group2_mem_rule10
+    description: AIPS Bridge Group 2 Rule 10.
+    byte_offset: 456
+    fieldset: AipsBridgeGroup2memRule10
+  - name: aips_bridge_group2_mem_rule11
+    description: AIPS Bridge Group 2 Rule 11.
+    byte_offset: 460
+    fieldset: AipsBridgeGroup2memRule11
+  - name: aips_bridge_group2_mem_rule12
+    description: AIPS Bridge Group 2 Rule 12.
+    byte_offset: 464
+    fieldset: AipsBridgeGroup2memRule12
+  - name: aips_bridge_group2_mem_rule13
+    description: AIPS Bridge Group 2 Rule 13.
+    byte_offset: 468
+    fieldset: AipsBridgeGroup2memRule13
+  - name: flexspi0_region0_mem_rule
+    description: FLEXSPI0 Region 0 Memory Rule.
     array:
       len: 4
       stride: 4
-    byte_offset: 320
-    fieldset: AhbSlavePortP7SlaveRule
-  - name: aon_domain_sram_mem_rule0
-    description: AON Domain SRAM Memory Rule.
-    byte_offset: 336
-    fieldset: AonDomainSramMemRule0
+    byte_offset: 496
+    fieldset: Rule8
+  - name: flexspi0_region1_6_mem_rule
+    description: 'Array of registers: FLEXSPI0_REGION_MEM_RULE.'
+    array:
+      len: 6
+      stride: 16
+    byte_offset: 512
+    block: Flexspi0region16memRule
   - name: sec_vio_addr
     description: Security Violation Address.
     array:
@@ -224,7 +215,7 @@ block/Ahbsc:
   - name: cpu0_lock_reg
     description: Miscellaneous CPU0 Control Signals.
     byte_offset: 4076
-    fieldset: Cpu0LockReg
+    fieldset: Cpu0lockReg
   - name: misc_ctrl_dp_reg
     description: Secure Control Duplicate.
     byte_offset: 4088
@@ -233,259 +224,434 @@ block/Ahbsc:
     description: Secure Control.
     byte_offset: 4092
     fieldset: MiscCtrlReg
-fieldset/AhbPeripheralSlavePortP5SlaveRule0:
-  description: AHB Peripheral Slave Port 5 Slave Rule 0.
+block/Flexspi0region16memRule:
+  description: 'Array of registers: FLEXSPI0_REGION_MEM_RULE.'
+  items:
+  - name: flexspi0_region_mem_rule
+    description: FLEXSPI0 Region index Memory Rule.
+    byte_offset: 0
+    fieldset: Rule4
+fieldset/AhbPeripheral0memRule1:
+  description: AHB Peripheral 0 Memory Rule 1.
   fields:
-  - name: aips4_slaves
-    description: AIPS4 slaves.
-    bit_offset: 16
+  - name: gpio0
+    description: GPIO0.
+    bit_offset: 0
     bit_size: 2
     enum: Rule
-  - name: cdog0
-    description: CDOG0.
-    bit_offset: 20
+  - name: gpio0_alias
+    description: GPIO0 ALIAS.
+    bit_offset: 4
     bit_size: 2
     enum: Rule
-  - name: debug_mailbox
-    description: DEBUG_MAILBOX.
-    bit_offset: 24
-    bit_size: 2
-    enum: Rule
+fieldset/AhbPeripheral0memRule2:
+  description: AHB Peripheral 0 Memory Rule 2.
+  fields:
   - name: gpio1
     description: GPIO1.
-    bit_offset: 28
+    bit_offset: 0
     bit_size: 2
     enum: Rule
-fieldset/AhbPeripheralSlavePortP5SlaveRule1:
-  description: AHB Peripheral Slave Port 5 Slave Rule 1.
+  - name: gpio1_alias
+    description: GPIO1 ALIAS.
+    bit_offset: 4
+    bit_size: 2
+    enum: Rule
+fieldset/AhbPeripheral0memRule3:
+  description: AHB Peripheral 0 Memory Rule 3.
   fields:
   - name: gpio2
     description: GPIO2.
     bit_offset: 0
     bit_size: 2
     enum: Rule
+  - name: gpio2_alias
+    description: GPIO2 ALIAS.
+    bit_offset: 4
+    bit_size: 2
+    enum: Rule
+fieldset/AhbPeripheral0memRule4:
+  description: AHB Peripheral 0 Memory Rule 4.
+  fields:
   - name: gpio3
     description: GPIO3.
+    bit_offset: 0
+    bit_size: 2
+    enum: Rule
+  - name: gpio3_alias
+    description: GPIO3 ALIAS.
     bit_offset: 4
+    bit_size: 2
+    enum: Rule
+fieldset/AhbPeripheral0memRule5:
+  description: AHB Peripheral 0 Memory Rule 5.
+  fields:
+  - name: gpio4
+    description: GPIO4.
+    bit_offset: 0
+    bit_size: 2
+    enum: Rule
+  - name: gpio4_alias
+    description: GPIO4 ALIAS.
+    bit_offset: 4
+    bit_size: 2
+    enum: Rule
+fieldset/AhbSlavePortP5slaveRule0:
+  description: AHB Slave Port 5 Rule Register.
+  fields:
+  - name: cdog0
+    description: CDOG0.
+    bit_offset: 12
     bit_size: 2
     enum: Rule
   - name: cdog1
     description: CDOG1.
-    bit_offset: 8
-    bit_size: 2
-    enum: Rule
-fieldset/AhbSecureCtrlPeripheralRule0:
-  description: AHB Secure Control Peripheral Rule 0.
-  fields:
-  - name: rule
-    description: Rule 0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 4
-      stride: 4
-    enum: Rule
-fieldset/AhbSlavePortP0SlaveRule:
-  description: AHB Slave Port 0 Rule.
-  fields:
-  - name: rule
-    description: Rule 0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 8
-      stride: 4
-    enum: Rule
-fieldset/AhbSlavePortP1SlaveRule:
-  description: AHB Slave Port 1 Rule.
-  fields:
-  - name: rule
-    description: Rule 0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 8
-      stride: 4
-    enum: Rule
-fieldset/AhbSlavePortP2SlaveRule:
-  description: AHB Slave Port 2 Rule.
-  fields:
-  - name: rule
-    description: Rule 0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 8
-      stride: 4
-    enum: Rule
-fieldset/AhbSlavePortP3SlaveRule:
-  description: AHB Slave Port 3 Rule.
-  fields:
-  - name: rule
-    description: Rule 0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 8
-      stride: 4
-    enum: Rule
-fieldset/AhbSlavePortP4SlaveRule:
-  description: AHB Slave Port 4 Rule.
-  fields:
-  - name: rule
-    description: Rule 0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 8
-      stride: 4
-    enum: Rule
-fieldset/AhbSlavePortP6SlaveRule:
-  description: AHB Slave Port 6 Rule.
-  fields:
-  - name: rule
-    description: Rule 0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 8
-      stride: 4
-    enum: Rule
-fieldset/AhbSlavePortP7SlaveRule:
-  description: AHB Slave Port 6 Rule.
-  fields:
-  - name: rule
-    description: Rule 0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 8
-      stride: 4
-    enum: Rule
-fieldset/AipsBridgeGroup0MemRule0:
-  description: AIPS Bridge Group 0 Memory Rule 0.
-  fields:
-  - name: e_dma_0_mp
-    description: eDMA_0_MP.
-    bit_offset: 0
-    bit_size: 2
-    enum: Rule
-  - name: e_dma_0_tcd0
-    description: eDMA_0_TCD0.
-    bit_offset: 4
-    bit_size: 2
-    enum: Rule
-  - name: e_dma_0_tcd1
-    description: eDMA_0_TCD1.
-    bit_offset: 8
-    bit_size: 2
-    enum: Rule
-  - name: e_dma_0_tcd2
-    description: eDMA_0_TCD2.
-    bit_offset: 12
-    bit_size: 2
-    enum: Rule
-  - name: e_dma_0_tcd3
-    description: FLEXSPI0 Registers.
     bit_offset: 16
     bit_size: 2
     enum: Rule
-  - name: e_dma_0_tcd4
-    description: eDMA_0_TCD4 (Reserved).
+  - name: debug_mailbox
+    description: DEBUG_MAILBOX.
     bit_offset: 20
     bit_size: 2
     enum: Rule
-  - name: e_dma_0_tcd5
-    description: eDMA_0_TCD5 (Reserved).
+  - name: mau0
+    description: Rule 6.
     bit_offset: 24
     bit_size: 2
     enum: Rule
-  - name: e_dma_0_tcd6
-    description: eDMA_0_TCD6 (Reserved).
-    bit_offset: 28
-    bit_size: 2
-    enum: Rule
-fieldset/AipsBridgeGroup0MemRule1:
-  description: AIPS Bridge Group 0 Memory Rule 1.
+fieldset/AipsBridgeGroup0memRule0:
+  description: AIPS Bridge Group 0 Memory Rule 0.
   fields:
-  - name: e_dma_0_tcd7
-    description: eDMA_0_TCD7 (Reserved).
+  - name: ewm0
+    description: EWM0.
     bit_offset: 0
     bit_size: 2
     enum: Rule
-  - name: aoi0
-    description: AOI0.
+  - name: romcp
+    description: ROMCP.
     bit_offset: 4
     bit_size: 2
     enum: Rule
-  - name: crc0
-    description: CRC0.
+  - name: pkc0
+    description: PKC0.
     bit_offset: 8
     bit_size: 2
     enum: Rule
-  - name: cmc0
-    description: CMC0.
+  - name: dma_1_mp
+    description: DMA_1_MP.
     bit_offset: 12
     bit_size: 2
     enum: Rule
-  - name: erm0
-    description: ERM0.
+  - name: dma_1_ch0
+    description: DMA_1_CH0.
+    bit_offset: 16
+    bit_size: 2
+    enum: Rule
+  - name: dma_1_ch1
+    description: DMA_1_CH1.
     bit_offset: 20
     bit_size: 2
     enum: Rule
-  - name: mbc0
-    description: MBC0.
+  - name: dma_1_ch2
+    description: DMA_1_CH2.
     bit_offset: 24
     bit_size: 2
     enum: Rule
-  - name: scg0
-    description: SCG0.
+  - name: dma_1_ch3
+    description: DMA_1_CH3.
     bit_offset: 28
     bit_size: 2
     enum: Rule
-fieldset/AipsBridgeGroup0MemRule2:
-  description: AIPS Bridge Group 0 Memory Rule 2.
+fieldset/AipsBridgeGroup0memRule1:
+  description: AIPS Bridge Group 0 Memory Rule 1.
+  fields:
+  - name: enet0_0
+    description: ENET0_0.
+    bit_offset: 16
+    bit_size: 2
+    enum: Rule
+  - name: enet0_1
+    description: ENET0_1.
+    bit_offset: 20
+    bit_size: 2
+    enum: Rule
+  - name: e_spi
+    description: eSPI.
+    bit_offset: 28
+    bit_size: 2
+    enum: Rule
+fieldset/AipsBridgeGroup1memRule0:
+  description: AIPS Bridge Group 1 Memory Rule 0.
+  fields:
+  - name: flexspi0
+    description: FLEXSPI0.
+    bit_offset: 0
+    bit_size: 2
+    enum: Rule
+  - name: lpspi2
+    description: LPSPI2.
+    bit_offset: 4
+    bit_size: 2
+    enum: Rule
+  - name: lpspi3
+    description: LPSPI3.
+    bit_offset: 8
+    bit_size: 2
+    enum: Rule
+  - name: lpspi4
+    description: LPSPI4.
+    bit_offset: 12
+    bit_size: 2
+    enum: Rule
+  - name: lpspi5
+    description: LPSPI5.
+    bit_offset: 16
+    bit_size: 2
+    enum: Rule
+fieldset/AipsBridgeGroup1memRule1:
+  description: AIPS Bridge Group 1 Memory Rule 1.
+  fields:
+  - name: spi_fileter0
+    description: SPI_FILETER0.
+    bit_offset: 16
+    bit_size: 2
+    enum: Rule
+  - name: t1s0
+    description: 10BASE_T1S0.
+    bit_offset: 20
+    bit_size: 2
+    enum: Rule
+  - name: usb1
+    description: USB1.
+    bit_offset: 24
+    bit_size: 2
+    enum: Rule
+  - name: usb1_phy
+    description: USB1_PHY.
+    bit_offset: 28
+    bit_size: 2
+    enum: Rule
+fieldset/AipsBridgeGroup2memRule0:
+  description: AIPS Bridge Group 2 Rule 0.
+  fields:
+  - name: dma_0_mp
+    description: DMA_0_MP.
+    bit_offset: 0
+    bit_size: 2
+    enum: Rule
+  - name: dma_0_ch0
+    description: DMA_0_CH0.
+    bit_offset: 4
+    bit_size: 2
+    enum: Rule
+  - name: dma_0_ch1
+    description: DMA_0_CH1.
+    bit_offset: 8
+    bit_size: 2
+    enum: Rule
+  - name: dma_0_ch2
+    description: DMA_0_CH2.
+    bit_offset: 12
+    bit_size: 2
+    enum: Rule
+  - name: dma_0_ch3
+    description: DMA_0_CH3.
+    bit_offset: 16
+    bit_size: 2
+    enum: Rule
+  - name: dma_0_ch4
+    description: DMA_0_CH4.
+    bit_offset: 20
+    bit_size: 2
+    enum: Rule
+  - name: dma_0_ch5
+    description: DMA_0_CH5.
+    bit_offset: 24
+    bit_size: 2
+    enum: Rule
+  - name: dma_0_ch6
+    description: DMA_0_CH6.
+    bit_offset: 28
+    bit_size: 2
+    enum: Rule
+fieldset/AipsBridgeGroup2memRule1:
+  description: AIPS Bridge Group 2 Rule 1.
+  fields:
+  - name: dma_0_ch7
+    description: DMA_0_CH7.
+    bit_offset: 0
+    bit_size: 2
+    enum: Rule
+  - name: dma_0_ch8
+    description: DMA_0_CH8.
+    bit_offset: 4
+    bit_size: 2
+    enum: Rule
+  - name: dma_0_ch9
+    description: DMA_0_CH9.
+    bit_offset: 8
+    bit_size: 2
+    enum: Rule
+  - name: dma_0_ch10
+    description: DMA_0_CH10.
+    bit_offset: 12
+    bit_size: 2
+    enum: Rule
+  - name: dma_0_ch11
+    description: DMA_0_CH11.
+    bit_offset: 16
+    bit_size: 2
+    enum: Rule
+fieldset/AipsBridgeGroup2memRule10:
+  description: AIPS Bridge Group 2 Rule 10.
+  fields:
+  - name: can1_region0
+    description: CAN1 Region 0.
+    bit_offset: 0
+    bit_size: 2
+    enum: Rule
+  - name: can1_region1
+    description: CAN1 Region 1.
+    bit_offset: 4
+    bit_size: 2
+    enum: Rule
+  - name: can1_region2
+    description: CAN1 Region 2.
+    bit_offset: 8
+    bit_size: 2
+    enum: Rule
+  - name: can1_region3
+    description: CAN1 Region 3.
+    bit_offset: 12
+    bit_size: 2
+    enum: Rule
+  - name: lpi2c2
+    description: LPI2C2.
+    bit_offset: 16
+    bit_size: 2
+    enum: Rule
+  - name: lpi2c3
+    description: LPI2C3.
+    bit_offset: 20
+    bit_size: 2
+    enum: Rule
+  - name: lpi2c4
+    description: LPI2C4.
+    bit_offset: 24
+    bit_size: 2
+    enum: Rule
+fieldset/AipsBridgeGroup2memRule11:
+  description: AIPS Bridge Group 2 Rule 11.
+  fields:
+  - name: lpuart5
+    description: LPUART5.
+    bit_offset: 8
+    bit_size: 2
+    enum: Rule
+  - name: i3c3
+    description: I3C3.
+    bit_offset: 24
+    bit_size: 2
+    enum: Rule
+  - name: gpio5
+    description: GPIO5.
+    bit_offset: 28
+    bit_size: 2
+    enum: Rule
+fieldset/AipsBridgeGroup2memRule12:
+  description: AIPS Bridge Group 2 Rule 12.
+  fields:
+  - name: gpio5_alias
+    description: GPIO5_ALIAS.
+    bit_offset: 0
+    bit_size: 2
+    enum: Rule
+  - name: port5
+    description: PORT5.
+    bit_offset: 12
+    bit_size: 2
+    enum: Rule
+  - name: dgdet0
+    description: DGDET0.
+    bit_offset: 20
+    bit_size: 2
+    enum: Rule
+  - name: itrc0
+    description: ITRC0.
+    bit_offset: 28
+    bit_size: 2
+    enum: Rule
+fieldset/AipsBridgeGroup2memRule13:
+  description: AIPS Bridge Group 2 Rule 13.
+  fields:
+  - name: glikey0
+    description: GLIKEY0.
+    bit_offset: 0
+    bit_size: 2
+    enum: Rule
+  - name: tdet0
+    description: TDET0.
+    bit_offset: 4
+    bit_size: 2
+    enum: Rule
+  - name: seccon
+    description: SECCON.
+    bit_offset: 8
+    bit_size: 2
+    enum: Rule
+  - name: sgi0
+    description: SGI0.
+    bit_offset: 12
+    bit_size: 2
+    enum: Rule
+  - name: trng0
+    description: TRNG0.
+    bit_offset: 16
+    bit_size: 2
+    enum: Rule
+  - name: udf0
+    description: UDF0.
+    bit_offset: 20
+    bit_size: 2
+    enum: Rule
+  - name: rtc0
+    description: RTC0.
+    bit_offset: 24
+    bit_size: 2
+    enum: Rule
+fieldset/AipsBridgeGroup2memRule2:
+  description: AIPS Bridge Group 2 Rule 2.
   fields:
   - name: syscon
     description: SYSCON.
     bit_offset: 4
     bit_size: 2
     enum: Rule
-  - name: wuu0
-    description: WUU0.
+  - name: wuu
+    description: WUU.
     bit_offset: 8
     bit_size: 2
     enum: Rule
-  - name: fmc0
-    description: FMC0.
+  - name: vbat
+    description: VBAT.
+    bit_offset: 12
+    bit_size: 2
+    enum: Rule
+  - name: fmc
+    description: FMC.
     bit_offset: 16
     bit_size: 2
     enum: Rule
-  - name: fmu0
-    description: FMU0.
+  - name: fmu
+    description: FMU.
     bit_offset: 20
     bit_size: 2
     enum: Rule
-  - name: fmu0_tst
-    description: FMU0_TST.
-    bit_offset: 24
-    bit_size: 2
-    enum: Rule
-  - name: bcanxl
-    description: BCANXL (Reserved).
-    bit_offset: 28
-    bit_size: 2
-    enum: Rule
-fieldset/AipsBridgeGroup0MemRule3:
-  description: AIPS Bridge Group 0 Memory Rule 3.
+fieldset/AipsBridgeGroup2memRule3:
+  description: AIPS Bridge Group 2 Rule 3.
   fields:
-  - name: candma
-    description: CANDMA (Reserved).
-    bit_offset: 0
-    bit_size: 2
-    enum: Rule
   - name: flexio
-    description: FLEXIO (Reserved).
+    description: FLEXIO.
     bit_offset: 4
     bit_size: 2
     enum: Rule
@@ -509,8 +675,8 @@ fieldset/AipsBridgeGroup0MemRule3:
     bit_offset: 20
     bit_size: 2
     enum: Rule
-  - name: lpspi2
-    description: LPSPI2 (Reserved).
+  - name: i3c2
+    description: I3C2.
     bit_offset: 24
     bit_size: 2
     enum: Rule
@@ -519,8 +685,8 @@ fieldset/AipsBridgeGroup0MemRule3:
     bit_offset: 28
     bit_size: 2
     enum: Rule
-fieldset/AipsBridgeGroup2MemRule0:
-  description: AIPS Bridge Group 2 Memory Rule 0.
+fieldset/AipsBridgeGroup2memRule4:
+  description: AIPS Bridge Group 2 Rule 4.
   fields:
   - name: lpuart1
     description: LPUART1.
@@ -528,88 +694,48 @@ fieldset/AipsBridgeGroup2MemRule0:
     bit_size: 2
     enum: Rule
   - name: lpuart2
-    description: LPUART2 (Reserved).
+    description: LPUART2.
     bit_offset: 4
     bit_size: 2
     enum: Rule
   - name: lpuart3
-    description: LPUART3 (Reserved).
+    description: LPUART3.
     bit_offset: 8
     bit_size: 2
     enum: Rule
   - name: lpuart4
-    description: LPUART4 (Reserved).
+    description: LPUART4.
     bit_offset: 12
     bit_size: 2
     enum: Rule
-  - name: usb_fs_otg
-    description: USB_FS_OTG (Reserved).
-    bit_offset: 16
-    bit_size: 2
-    enum: Rule
-  - name: usb_fs_dcd
-    description: USB_FS_DCD (Reserved).
-    bit_offset: 20
-    bit_size: 2
-    enum: Rule
-  - name: usb_typec_pd
-    description: USB_TYPEC_PD (Reserved).
-    bit_offset: 24
-    bit_size: 2
-    enum: Rule
-  - name: quad_decoder0
-    description: QUAD_DECODER0 (Reserved).
-    bit_offset: 28
-    bit_size: 2
-    enum: Rule
-fieldset/AipsBridgeGroup2MemRule1:
-  description: AIPS Bridge Group 2 Memory Rule 1.
+fieldset/AipsBridgeGroup2memRule5:
+  description: AIPS Bridge Group 2 Rule 5.
   fields:
-  - name: quad_decoder1
-    description: QUAD_DECODER1 (Reserved).
-    bit_offset: 0
-    bit_size: 2
-    enum: Rule
-  - name: flexpwm0
-    description: FLEXPWM0.
-    bit_offset: 4
-    bit_size: 2
-    enum: Rule
-  - name: flexpwm1
-    description: FLEXPWM1 (Reserved).
-    bit_offset: 8
-    bit_size: 2
-    enum: Rule
-  - name: lptmr0
-    description: LPTMR0 (Reserved).
+  - name: lptmr
+    description: LPTMR.
     bit_offset: 12
     bit_size: 2
     enum: Rule
-  - name: lptmr1
-    description: LPTMR1 (Reserved).
-    bit_offset: 16
-    bit_size: 2
-    enum: Rule
-  - name: ostimer0
-    description: OSTIMER0.
+  - name: ostimer
+    description: OSTIMER.
     bit_offset: 20
     bit_size: 2
     enum: Rule
   - name: wake_timer
-    description: WAKE_TIMER (Reserved).
+    description: WAKE_TIMER.
     bit_offset: 24
     bit_size: 2
     enum: Rule
-  - name: hsadc0
-    description: HSADC0.
+  - name: adc0
+    description: ADC0.
     bit_offset: 28
     bit_size: 2
     enum: Rule
-fieldset/AipsBridgeGroup2MemRule2:
-  description: AIPS Bridge Group 2 Memory Rule 2.
+fieldset/AipsBridgeGroup2memRule6:
+  description: AIPS Bridge Group 2 Rule 6.
   fields:
   - name: adc1
-    description: ADC1 (Reserved).
+    description: ADC1.
     bit_offset: 0
     bit_size: 2
     enum: Rule
@@ -618,302 +744,136 @@ fieldset/AipsBridgeGroup2MemRule2:
     bit_offset: 4
     bit_size: 2
     enum: Rule
-  - name: cmp1
-    description: CMP1 (Reserved).
-    bit_offset: 8
-    bit_size: 2
-    enum: Rule
-  - name: cmp2
-    description: CMP2 (Reserved).
-    bit_offset: 12
-    bit_size: 2
-    enum: Rule
   - name: dac0
-    description: DAC0 (Reserved).
+    description: DAC0.
     bit_offset: 16
     bit_size: 2
     enum: Rule
   - name: dac1
-    description: DAC1 (Reserved).
+    description: DAC1.
     bit_offset: 20
     bit_size: 2
     enum: Rule
-  - name: dac2
-    description: DAC2 (Reserved).
-    bit_offset: 24
-    bit_size: 2
-    enum: Rule
-  - name: opamp0
-    description: OPAMP0 (Reserved).
-    bit_offset: 28
-    bit_size: 2
-    enum: Rule
-fieldset/AipsBridgeGroup2MemRule3:
-  description: AIPS Bridge Group 2 Memory Rule 3.
+fieldset/AipsBridgeGroup2memRule7:
+  description: AIPS Bridge Group 2 Rule 7.
   fields:
-  - name: opamp1
-    description: OPAMP1 (Reserved).
-    bit_offset: 0
-    bit_size: 2
-    enum: Rule
-  - name: opamp2
-    description: OPAMP2 (Reserved).
-    bit_offset: 4
-    bit_size: 2
-    enum: Rule
-  - name: sd_adc0
-    description: SD_ADC0 (Reserved).
-    bit_offset: 8
-    bit_size: 2
-    enum: Rule
-  - name: dgo_gpio1_3
-    description: DGO_GPIO1_3 (Reserved).
+  - name: vref0
+    description: VREF0.
     bit_offset: 12
-    bit_size: 2
-    enum: Rule
-  - name: port1
-    description: PORT1.
-    bit_offset: 16
-    bit_size: 2
-    enum: Rule
-  - name: port2
-    description: PORT2.
-    bit_offset: 20
-    bit_size: 2
-    enum: Rule
-  - name: port3
-    description: PORT3.
-    bit_offset: 24
-    bit_size: 2
-    enum: Rule
-  - name: port4
-    description: PORT4 (Reserved).
-    bit_offset: 28
-    bit_size: 2
-    enum: Rule
-fieldset/AipsBridgeGroup3MemRule0:
-  description: AIPS Bridge Group 3 Rule 0.
-  fields:
-  - name: port5
-    description: PORT5 (Reserved).
-    bit_offset: 0
-    bit_size: 2
-    enum: Rule
-  - name: sai
-    description: SAI (Reserved).
-    bit_offset: 4
-    bit_size: 2
-    enum: Rule
-  - name: segment_lcd
-    description: SEGMENT_LCD (Reserved).
-    bit_offset: 8
-    bit_size: 2
-    enum: Rule
-  - name: tsi
-    description: TSI (Reserved).
-    bit_offset: 12
-    bit_size: 2
-    enum: Rule
-  - name: mu0
-    description: MU0.
-    bit_offset: 16
-    bit_size: 2
-    enum: Rule
-  - name: mu1
-    description: MU1 (Reserved).
-    bit_offset: 20
-    bit_size: 2
-    enum: Rule
-fieldset/AipsBridgeGroup3MemRule2:
-  description: AIPS Bridge Group 3 Rule 2.
-  fields:
-  - name: pkc0
-    description: PKC0.
-    bit_offset: 0
-    bit_size: 2
-    enum: Rule
-  - name: sgi0
-    description: SGI0.
-    bit_offset: 4
-    bit_size: 2
-    enum: Rule
-  - name: trng0
-    description: TRNG0.
-    bit_offset: 8
-    bit_size: 2
-    enum: Rule
-  - name: udf0
-    description: CAN0 RULE0.
-    bit_offset: 12
-    bit_size: 2
-    enum: Rule
-  - name: e_mda_1_mp
-    description: eDMA_1_MP.
-    bit_offset: 28
-    bit_size: 2
-    enum: Rule
-fieldset/AipsBridgeGroup3MemRule3:
-  description: AIPS Bridge Group 3 Rule 3.
-  fields:
-  - name: e_dma_1_tcd0
-    description: eDMA_1_TCD0.
-    bit_offset: 0
-    bit_size: 2
-    enum: Rule
-  - name: e_dma_1_tcd1
-    description: eDMA_1_TCD1.
-    bit_offset: 4
-    bit_size: 2
-    enum: Rule
-  - name: e_dma_1_tcd2
-    description: eDMA_1_TCD2.
-    bit_offset: 8
-    bit_size: 2
-    enum: Rule
-  - name: e_dma_1_tcd3
-    description: eDMA_1_TCD3.
-    bit_offset: 12
-    bit_size: 2
-    enum: Rule
-fieldset/AonDomainPeripheralMemRule0:
-  description: AON Domain Peripheral Rule 0.
-  fields:
-  - name: lpi2c
-    description: LPI2C.
-    bit_offset: 0
-    bit_size: 2
-    enum: Rule
-  - name: rule1
-    description: LPI2C (Reserved).
-    bit_offset: 4
-    bit_size: 2
-    enum: Rule
-  - name: lpuart
-    description: LPUART.
-    bit_offset: 8
-    bit_size: 2
-    enum: Rule
-  - name: rule3
-    description: LPUART (Reserved).
-    bit_offset: 12
-    bit_size: 2
-    enum: Rule
-  - name: mub
-    description: MUB.
-    bit_offset: 16
     bit_size: 2
     enum: Rule
   - name: port0
     description: PORT0.
+    bit_offset: 16
+    bit_size: 2
+    enum: Rule
+  - name: port1
+    description: PORT1.
     bit_offset: 20
     bit_size: 2
     enum: Rule
-  - name: acmp
-    description: ACMP.
+  - name: port2
+    description: PORT2.
     bit_offset: 24
     bit_size: 2
     enum: Rule
-  - name: rule7
-    description: ACMP (Reserved).
+  - name: port3
+    description: PORT3.
     bit_offset: 28
     bit_size: 2
     enum: Rule
-fieldset/AonDomainPeripheralMemRule1:
-  description: AON Domain Peripheral Rule 1.
+fieldset/AipsBridgeGroup2memRule8:
+  description: AIPS Bridge Group 2 Rule 8.
   fields:
-  - name: lptimer
-    description: LPTIMER.
+  - name: port4
+    description: PORT4.
     bit_offset: 0
     bit_size: 2
     enum: Rule
-  - name: qtmr32_0
-    description: QTMR32_0.
+  - name: tsi0
+    description: TSI0.
+    bit_offset: 12
+    bit_size: 2
+    enum: Rule
+  - name: aoi0
+    description: AOI0.
+    bit_offset: 16
+    bit_size: 2
+    enum: Rule
+  - name: crc0
+    description: CRC0.
+    bit_offset: 20
+    bit_size: 2
+    enum: Rule
+  - name: cmc
+    description: CMC.
     bit_offset: 24
     bit_size: 2
     enum: Rule
-  - name: qtmr32_1
-    description: QTMR32_1.
+  - name: eim
+    description: EIM.
     bit_offset: 28
     bit_size: 2
     enum: Rule
-fieldset/AonDomainPeripheralMemRule2:
-  description: AON Domain Peripheral Rule 2.
+fieldset/AipsBridgeGroup2memRule9:
+  description: AIPS Bridge Group 2 Rule 9.
   fields:
-  - name: gp_gpr
-    description: GP_GPR.
+  - name: erm
+    description: ERM.
     bit_offset: 0
     bit_size: 2
     enum: Rule
+  - name: mbc
+    description: MBC.
+    bit_offset: 4
+    bit_size: 2
+    enum: Rule
+  - name: scg
+    description: SCG.
+    bit_offset: 8
+    bit_size: 2
+    enum: Rule
+  - name: spc
+    description: SPC.
+    bit_offset: 12
+    bit_size: 2
+    enum: Rule
+  - name: can0_region0
+    description: CAN0 Region 0.
+    bit_offset: 16
+    bit_size: 2
+    enum: Rule
+  - name: can0_region1
+    description: CAN0 Region 1.
+    bit_offset: 20
+    bit_size: 2
+    enum: Rule
+  - name: can0_region2
+    description: CAN0 Region 2.
+    bit_offset: 24
+    bit_size: 2
+    enum: Rule
+  - name: can0_region3
+    description: CAN0 Region 3.
+    bit_offset: 28
+    bit_size: 2
+    enum: Rule
+fieldset/ApbPeripheralGroup0memRule0:
+  description: APB Bridge Group 0 Memory Rule Register 0.
+  fields:
   - name: inputmux
     description: INPUTMUX.
     bit_offset: 4
     bit_size: 2
     enum: Rule
-  - name: lpadc
-    description: LPADC.
+  - name: i3c0
+    description: I3C0.
     bit_offset: 8
     bit_size: 2
     enum: Rule
-  - name: sglcd
-    description: SGLCD0.
-    bit_offset: 16
-    bit_size: 2
-    enum: Rule
-  - name: kpp
-    description: KPP.
-    bit_offset: 20
-    bit_size: 2
-    enum: Rule
-  - name: advc2
-    description: KPP.
-    bit_offset: 28
-    bit_size: 2
-    enum: Rule
-fieldset/AonDomainPeripheralMemRule3:
-  description: AON Domain Peripheral Rule 3.
-  fields:
-  - name: pmic_ctrl
-    description: PMIC_CTRL.
-    bit_offset: 0
-    bit_size: 2
-    enum: Rule
-  - name: cgu
-    description: CGU.
-    bit_offset: 4
-    bit_size: 2
-    enum: Rule
-  - name: smm
-    description: SMM.
-    bit_offset: 8
-    bit_size: 2
-    enum: Rule
-  - name: lpcmp
-    description: LPCMP.
+  - name: i3c1
+    description: I3C1.
     bit_offset: 12
-    bit_size: 2
-    enum: Rule
-  - name: aon_gpio
-    description: AON_GPIO.
-    bit_offset: 28
-    bit_size: 2
-    enum: Rule
-fieldset/AonDomainSramMemRule0:
-  description: AON Domain SRAM Memory Rule.
-  fields:
-  - name: rule
-    description: Rule 0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 8
-      stride: 4
-    enum: Rule
-fieldset/ApbPeripheralGroup0MemRule0:
-  description: APB Bridge Group 0 Memory Rule 0.
-  fields:
-  - name: inputmux0
-    description: INPUTMUX0.
-    bit_offset: 4
     bit_size: 2
     enum: Rule
   - name: ctimer0
@@ -931,16 +891,26 @@ fieldset/ApbPeripheralGroup0MemRule0:
     bit_offset: 24
     bit_size: 2
     enum: Rule
-fieldset/ApbPeripheralGroup0MemRule1:
-  description: APB Bridge Group 0 Memory Rule 1.
+  - name: ctimer3
+    description: CTIMER3.
+    bit_offset: 28
+    bit_size: 2
+    enum: Rule
+fieldset/ApbPeripheralGroup0memRule1:
+  description: APB Bridge Group 0 Memory Rule Register 1.
   fields:
-  - name: freqme00
-    description: FREQME00.
+  - name: ctimer4
+    description: CTIMER4.
+    bit_offset: 0
+    bit_size: 2
+    enum: Rule
+  - name: freqme
+    description: FREQME.
     bit_offset: 4
     bit_size: 2
     enum: Rule
-  - name: utick0
-    description: UTICK0.
+  - name: utick
+    description: UTCIK0.
     bit_offset: 12
     bit_size: 2
     enum: Rule
@@ -949,7 +919,17 @@ fieldset/ApbPeripheralGroup0MemRule1:
     bit_offset: 16
     bit_size: 2
     enum: Rule
-fieldset/Cpu0LockReg:
+  - name: wwdt1
+    description: WWDT1.
+    bit_offset: 20
+    bit_size: 2
+    enum: Rule
+  - name: smartdma
+    description: SmartDMA.
+    bit_offset: 24
+    bit_size: 2
+    enum: Rule
+fieldset/Cpu0lockReg:
   description: Miscellaneous CPU0 Control Signals.
   fields:
   - name: lock_ns_vtor
@@ -977,73 +957,70 @@ fieldset/Cpu0LockReg:
     bit_offset: 8
     bit_size: 2
     enum: LockSau
-fieldset/Flash00MemRule:
-  description: Flash Memory Rule.
-  fields:
-  - name: rule
-    description: Rule 0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 8
-      stride: 4
-    enum: Rule
-fieldset/Flash01MemRule0:
-  description: Flash Memory Rule.
-  fields:
-  - name: rule
-    description: Rule 0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 4
-      stride: 4
-    enum: Rule
-fieldset/Flash02MemRule0:
-  description: Flash Memory Rule.
-  fields:
-  - name: rule
-    description: Rule 0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 4
-      stride: 4
-    enum: Rule
 fieldset/MasterSecAntiPolReg:
   description: Master Secure Level.
   fields:
+  - name: smartdma
+    description: SMARTDMA Data.
+    bit_offset: 4
+    bit_size: 2
+    enum: MasterSec
   - name: dma0
-    description: DMA0.
-    bit_offset: 2
+    description: eDMA0.
+    bit_offset: 6
+    bit_size: 2
+    enum: MasterSec
+  - name: dma1
+    description: eDMA1.
+    bit_offset: 8
     bit_size: 2
     enum: MasterSec
   - name: pkc
     description: PKC.
-    bit_offset: 4
+    bit_offset: 10
     bit_size: 2
     enum: MasterSec
-  - name: dma1
-    description: DMA1.
-    bit_offset: 6
+  - name: enet0
+    description: ENET0.
+    bit_offset: 24
+    bit_size: 2
+    enum: MasterSec
+  - name: usb1
+    description: USB1.
+    bit_offset: 26
     bit_size: 2
     enum: MasterSec
 fieldset/MasterSecLevel:
   description: Master Secure Level.
   fields:
+  - name: smartdma
+    description: SMARTDMA Data.
+    bit_offset: 4
+    bit_size: 2
+    enum: MasterSec
   - name: dma0
-    description: DMA0.
-    bit_offset: 2
+    description: eDMA0.
+    bit_offset: 6
+    bit_size: 2
+    enum: MasterSec
+  - name: dma1
+    description: eDMA1.
+    bit_offset: 8
     bit_size: 2
     enum: MasterSec
   - name: pkc
     description: PKC.
-    bit_offset: 4
+    bit_offset: 10
     bit_size: 2
     enum: MasterSec
-  - name: dma1
-    description: DMA1.
-    bit_offset: 6
+  - name: enet0
+    description: ENET0.
+    bit_offset: 24
+    bit_size: 2
+    enum: MasterSec
+  - name: usb1
+    description: USB1.
+    bit_offset: 26
     bit_size: 2
     enum: MasterSec
 fieldset/MiscCtrlDpReg:
@@ -1122,30 +1099,19 @@ fieldset/MiscCtrlReg:
     bit_offset: 14
     bit_size: 2
     enum: MiscCtrlRegIdauAllNs
-fieldset/RamMemRule:
-  description: RAMA Memory Rule.
+fieldset/Rule4:
+  description: AHB Secure Control Peripheral Rule.
   fields:
   - name: rule
-    description: Rule 0.
+    description: AHBSC.
     bit_offset: 0
     bit_size: 2
     array:
-      len: 8
+      len: 4
       stride: 4
     enum: Rule
-fieldset/RamxMemRule0:
-  description: RAMX Memory Rule.
-  fields:
-  - name: rule
-    description: Rule 0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 8
-      stride: 4
-    enum: Rule
-fieldset/RomMemRule:
-  description: ROM Memory Rule.
+fieldset/Rule8:
+  description: Flash Memory Rule.
   fields:
   - name: rule
     description: Rule 0.
@@ -1207,90 +1173,90 @@ fieldset/SecVioMiscInfo:
 enum/LockNsMpu:
   bit_size: 2
   variants:
-  - name: LockNsMpuEq1
-    description: CM33 (CPU0) LOCK_NS_MPU is 1.
-    value: 1
   - name: LockNsMpuEq0
     description: CM33 (CPU0) LOCK_NS_MPU is 0.
     value: 2
+  - name: LockNsMpuEq1
+    description: CM33 (CPU0) LOCK_NS_MPU is 1.
+    value: 1
 enum/LockNsVtor:
   bit_size: 2
   variants:
-  - name: LockNsVtorEq1
-    description: CM33 (CPU0) LOCKNSVTOR is 1.
-    value: 1
   - name: LockNsVtorEq0
     description: CM33 (CPU0) LOCKNSVTOR is 0.
     value: 2
+  - name: LockNsVtorEq1
+    description: CM33 (CPU0) LOCKNSVTOR is 1.
+    value: 1
 enum/LockSMpu:
   bit_size: 2
   variants:
-  - name: LockSMpuEq1
-    description: CM33 (CPU0) LOCK_S_MPU is 1.
-    value: 1
   - name: LockSMpuEq0
     description: CM33 (CPU0) LOCK_S_MPU is 0.
     value: 2
+  - name: LockSMpuEq1
+    description: CM33 (CPU0) LOCK_S_MPU is 1.
+    value: 1
 enum/LockSVtaircr:
   bit_size: 2
   variants:
-  - name: LockSVtaircrEq1
-    description: CM33 (CPU0) LOCK_S_VTAIRCR is 1.
-    value: 1
   - name: LockSVtaircrEq0
     description: CM33 (CPU0) LOCK_S_VTAIRCR is 0.
     value: 2
+  - name: LockSVtaircrEq1
+    description: CM33 (CPU0) LOCK_S_VTAIRCR is 1.
+    value: 1
 enum/LockSau:
   bit_size: 2
   variants:
-  - name: LockSauEq1
-    description: CM33 (CPU0) LOCK_SAU is 1.
-    value: 1
   - name: LockSauEq0
     description: CM33 (CPU0) LOCK_SAU is 0.
     value: 2
+  - name: LockSauEq1
+    description: CM33 (CPU0) LOCK_SAU is 1.
+    value: 1
 enum/MasterSec:
   bit_size: 2
   variants:
   - name: NonsecureNonprivMaster
-    description: Secure and privileged Master.
+    description: Non-secure and non-privileged Master.
     value: 0
   - name: NonsecurePrivMaster
-    description: Secure and non-privileged Master.
+    description: Non-secure and privileged Master.
     value: 1
   - name: SecureNonprivMaster
-    description: Non-secure and privileged Master.
+    description: Secure and non-privileged Master.
     value: 2
   - name: SecurePrivMaster
-    description: Non-secure and non-privileged Master.
+    description: Secure and privileged Master.
     value: 3
 enum/MiscCtrlEnable:
   bit_size: 2
   variants:
-  - name: Enabled
-    description: Enables the privilege checking of non-secure mode access.
-    value: 1
   - name: Disabled
     description: Disables the privilege checking of non-secure mode access.
     value: 2
+  - name: Enabled
+    description: Enables the privilege checking of non-secure mode access.
+    value: 1
 enum/MiscCtrlRegDisableStrictMode:
   bit_size: 2
   variants:
-  - name: Ahbtm
-    description: Master strict mode is disabled and can access memories and peripherals at the same level or below that level.
-    value: 1
   - name: Ahbsm1
-    description: Master strict mode is enabled and can access memories and peripherals at same level only.
+    description: Master can access memories and peripherals at same level only.
     value: 2
+  - name: Ahbtm
+    description: Master can access memories and peripherals at the same level or below that level.
+    value: 1
 enum/MiscCtrlRegDisableViolationAbort:
   bit_size: 2
   variants:
-  - name: NoAbort
-    description: The violation detected by the secure checker will not cause an abort, but a secure_violation_irq (interrupt request) will still be asserted and serviced by ISR.
-    value: 1
   - name: Abort
     description: The violation detected by the secure checker will cause an abort.
     value: 2
+  - name: NoAbort
+    description: The violation detected by the secure checker will not cause an abort, but a secure_violation_irq (interrupt request) will still be asserted and serviced by ISR.
+    value: 1
 enum/MiscCtrlRegIdauAllNs:
   bit_size: 2
   variants:
@@ -1337,20 +1303,35 @@ enum/SecVioInfoMaster:
   bit_size: 5
   variants:
   - name: Cpu0Code
-    description: M33 Code.
+    description: CM33 Code.
     value: 0
   - name: Cpu0Sys
-    description: M33 System.
+    description: CM33 System.
     value: 1
-  - name: Dma0
-    description: DMA0.
+  - name: EDma0
+    description: eDMA0.
     value: 5
-  - name: Dma1
-    description: DMA1.
-    value: 7
+  - name: EDma1
+    description: eDMA1.
+    value: 4
+  - name: Enet
+    description: Ethernet.
+    value: 13
+  - name: Espi
+    description: eSPI.
+    value: 10
   - name: Pkc
     description: PKC.
     value: 12
+  - name: SdmaData
+    description: SMARTDMA Data.
+    value: 3
+  - name: SdmaInstr
+    description: SMARTDMA Instruction.
+    value: 2
+  - name: UsbHs
+    description: USB HS.
+    value: 6
 enum/SecVioInfoWrite:
   bit_size: 1
   variants:

--- a/data/metadata/peripherals/update.sh
+++ b/data/metadata/peripherals/update.sh
@@ -21,12 +21,12 @@ pushd $CURRENT_DIR
 # Manually curated, do not change
 # cp raw/MCXA577/DMA.yaml mcxa/DMA.yaml
 # cp raw/MCXA577/EDMA_TCD.yaml mcxa/EDMA_TCD.yaml
+# cp raw/MCXA577/AHBSC.yaml mcxa/AHBSC.yaml
 
 cp raw/MCXA256/FLEXPWM.yaml mcxa/FLEXPWM.yaml
 cp raw/MCXA256/SPC.yaml mcxa/SPC.yaml
 
 cp raw/MCXA577/ADC.yaml mcxa/ADC.yaml
-cp raw/MCXA577/AHBSC.yaml mcxa/AHBSC.yaml
 cp raw/MCXA577/CDOG.yaml mcxa/CDOG.yaml
 cp raw/MCXA577/CMC.yaml mcxa/CMC.yaml
 cp raw/MCXA577/CRC.yaml mcxa/CRC.yaml

--- a/data/transforms/mcxa/mcxa5/ahbsc.yaml
+++ b/data/transforms/mcxa/mcxa5/ahbsc.yaml
@@ -1,3 +1,5 @@
+# This transform is not being used at this moment because of the bad quality of the peripheral definition in the SVD.
+
 transforms:
   - !Rename
     from: secure_ahb_ctrl::(.+)

--- a/data/transforms/mcxa577.yaml
+++ b/data/transforms/mcxa577.yaml
@@ -8,7 +8,6 @@ includes:
   - mcxa/mcxa5/i3c.yaml
   - mcxa/mcxa5/port.yaml
   - mcxa/mcxa5/rtc.yaml
-  - mcxa/mcxa5/ahbsc.yaml
   - mcxa/mcxa5/scg.yaml
   - mcxa/mcxa5/trng.yaml
 

--- a/nxp-pac/src/meta_peripherals/mcxa/AHBSC.rs
+++ b/nxp-pac/src/meta_peripherals/mcxa/AHBSC.rs
@@ -18,23 +18,12 @@ impl Ahbsc {
     pub const fn as_ptr(&self) -> *mut () {
         self.ptr as _
     }
-    #[doc = "AHB Slave Port 0 Rule."]
-    #[inline(always)]
-    pub const fn ahb_slave_port_p0_slave_rule(
-        self,
-        n: usize,
-    ) -> crate::pac::common::Reg<AhbSlavePortP0SlaveRule, crate::pac::common::RW> {
-        assert!(n < 4usize);
-        unsafe {
-            crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0usize + n * 4usize) as _)
-        }
-    }
     #[doc = "Flash Memory Rule."]
     #[inline(always)]
     pub const fn flash00_mem_rule(
         self,
         n: usize,
-    ) -> crate::pac::common::Reg<Flash00MemRule, crate::pac::common::RW> {
+    ) -> crate::pac::common::Reg<Rule8, crate::pac::common::RW> {
         assert!(n < 4usize);
         unsafe {
             crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x10usize + n * 4usize) as _)
@@ -42,46 +31,31 @@ impl Ahbsc {
     }
     #[doc = "Flash Memory Rule."]
     #[inline(always)]
-    pub const fn flash01_mem_rule0(
+    pub const fn flash01_mem_rule(
         self,
-    ) -> crate::pac::common::Reg<Flash01MemRule0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x20usize) as _) }
+        n: usize,
+    ) -> crate::pac::common::Reg<Rule8, crate::pac::common::RW> {
+        assert!(n < 4usize);
+        unsafe {
+            crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x20usize + n * 4usize) as _)
+        }
+    }
+    #[doc = "Flash IFR0 Rule register."]
+    #[inline(always)]
+    pub const fn flash02_mem_rule(self) -> crate::pac::common::Reg<Rule4, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x30usize) as _) }
     }
     #[doc = "Flash Memory Rule."]
     #[inline(always)]
-    pub const fn flash02_mem_rule0(
-        self,
-    ) -> crate::pac::common::Reg<Flash02MemRule0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x30usize) as _) }
-    }
-    #[doc = "AHB Slave Port 1 Rule."]
-    #[inline(always)]
-    pub const fn ahb_slave_port_p1_slave_rule(
-        self,
-        n: usize,
-    ) -> crate::pac::common::Reg<AhbSlavePortP1SlaveRule, crate::pac::common::RW> {
-        assert!(n < 4usize);
-        unsafe {
-            crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x40usize + n * 4usize) as _)
-        }
+    pub const fn flash03_mem_rule(self) -> crate::pac::common::Reg<Rule4, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x40usize) as _) }
     }
     #[doc = "ROM Memory Rule."]
     #[inline(always)]
     pub const fn rom_mem_rule(
         self,
         n: usize,
-    ) -> crate::pac::common::Reg<RomMemRule, crate::pac::common::RW> {
-        assert!(n < 4usize);
-        unsafe {
-            crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x50usize + n * 4usize) as _)
-        }
-    }
-    #[doc = "AHB Slave Port 2 Rule."]
-    #[inline(always)]
-    pub const fn ahb_slave_port_p2_slave_rule(
-        self,
-        n: usize,
-    ) -> crate::pac::common::Reg<AhbSlavePortP2SlaveRule, crate::pac::common::RW> {
+    ) -> crate::pac::common::Reg<Rule8, crate::pac::common::RW> {
         assert!(n < 4usize);
         unsafe {
             crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x60usize + n * 4usize) as _)
@@ -89,244 +63,244 @@ impl Ahbsc {
     }
     #[doc = "RAMX Memory Rule."]
     #[inline(always)]
-    pub const fn ramx_mem_rule0(
-        self,
-    ) -> crate::pac::common::Reg<RamxMemRule0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x70usize) as _) }
-    }
-    #[doc = "AHB Slave Port 3 Rule."]
-    #[inline(always)]
-    pub const fn ahb_slave_port_p3_slave_rule(
+    pub const fn ramx_mem_rule(
         self,
         n: usize,
-    ) -> crate::pac::common::Reg<AhbSlavePortP3SlaveRule, crate::pac::common::RW> {
+    ) -> crate::pac::common::Reg<Rule8, crate::pac::common::RW> {
         assert!(n < 4usize);
         unsafe {
             crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x80usize + n * 4usize) as _)
         }
     }
-    #[doc = "RAMA Memory Rule."]
+    #[doc = "RAMA Memory Rule 0."]
     #[inline(always)]
     pub const fn rama_mem_rule(
         self,
         n: usize,
-    ) -> crate::pac::common::Reg<RamMemRule, crate::pac::common::RW> {
-        assert!(n < 4usize);
-        unsafe {
-            crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x90usize + n * 4usize) as _)
-        }
-    }
-    #[doc = "AHB Slave Port 4 Rule."]
-    #[inline(always)]
-    pub const fn ahb_slave_port_p4_slave_rule(
-        self,
-        n: usize,
-    ) -> crate::pac::common::Reg<AhbSlavePortP4SlaveRule, crate::pac::common::RW> {
-        assert!(n < 4usize);
+    ) -> crate::pac::common::Reg<Rule8, crate::pac::common::RW> {
+        assert!(n < 8usize);
         unsafe {
             crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xa0usize + n * 4usize) as _)
         }
     }
-    #[doc = "RAMB Memory Rule."]
+    #[doc = "RAMB Memory Rule 0."]
     #[inline(always)]
     pub const fn ramb_mem_rule(
         self,
         n: usize,
-    ) -> crate::pac::common::Reg<RamMemRule, crate::pac::common::RW> {
-        assert!(n < 4usize);
+    ) -> crate::pac::common::Reg<Rule8, crate::pac::common::RW> {
+        assert!(n < 8usize);
         unsafe {
-            crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xb0usize + n * 4usize) as _)
+            crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xd0usize + n * 4usize) as _)
         }
     }
-    #[doc = "AHB Peripheral Slave Port 5 Slave Rule 0."]
+    #[doc = "AHB Slave Port 5 Rule Register."]
     #[inline(always)]
-    pub const fn ahb_peripheral_slave_port_p5_slave_rule0(
+    pub const fn ahb_slave_port_p5_slave_rule0(
         self,
-    ) -> crate::pac::common::Reg<AhbPeripheralSlavePortP5SlaveRule0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xc0usize) as _) }
+    ) -> crate::pac::common::Reg<AhbSlavePortP5slaveRule0, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xf0usize) as _) }
     }
-    #[doc = "AHB Peripheral Slave Port 5 Slave Rule 1."]
-    #[inline(always)]
-    pub const fn ahb_peripheral_slave_port_p5_slave_rule1(
-        self,
-    ) -> crate::pac::common::Reg<AhbPeripheralSlavePortP5SlaveRule1, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xc4usize) as _) }
-    }
-    #[doc = "APB Bridge Group 0 Memory Rule 0."]
+    #[doc = "APB Bridge Group 0 Memory Rule Register 0."]
     #[inline(always)]
     pub const fn apb_peripheral_group0_mem_rule0(
         self,
-    ) -> crate::pac::common::Reg<ApbPeripheralGroup0MemRule0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xd0usize) as _) }
+    ) -> crate::pac::common::Reg<ApbPeripheralGroup0memRule0, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0100usize) as _) }
     }
-    #[doc = "APB Bridge Group 0 Memory Rule 1."]
+    #[doc = "APB Bridge Group 0 Memory Rule Register 1."]
     #[inline(always)]
     pub const fn apb_peripheral_group0_mem_rule1(
         self,
-    ) -> crate::pac::common::Reg<ApbPeripheralGroup0MemRule1, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xd4usize) as _) }
-    }
-    #[doc = "APB Bridge Group 0 Rule 2."]
-    #[inline(always)]
-    pub const fn apb_peripheral_group0_mem_rule2(
-        self,
-    ) -> crate::pac::common::Reg<u32, crate::pac::common::R> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xd8usize) as _) }
-    }
-    #[doc = "APB Bridge Group 0 Memory Rule 3."]
-    #[inline(always)]
-    pub const fn apb_peripheral_group0_mem_rule3(
-        self,
-    ) -> crate::pac::common::Reg<u32, crate::pac::common::R> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xdcusize) as _) }
+    ) -> crate::pac::common::Reg<ApbPeripheralGroup0memRule1, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0104usize) as _) }
     }
     #[doc = "AIPS Bridge Group 0 Memory Rule 0."]
     #[inline(always)]
     pub const fn aips_bridge_group0_mem_rule0(
         self,
-    ) -> crate::pac::common::Reg<AipsBridgeGroup0MemRule0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xe0usize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup0memRule0, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0110usize) as _) }
     }
     #[doc = "AIPS Bridge Group 0 Memory Rule 1."]
     #[inline(always)]
     pub const fn aips_bridge_group0_mem_rule1(
         self,
-    ) -> crate::pac::common::Reg<AipsBridgeGroup0MemRule1, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xe4usize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup0memRule1, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0114usize) as _) }
     }
-    #[doc = "AIPS Bridge Group 0 Memory Rule 2."]
+    #[doc = "AIPS Bridge Group 1 Memory Rule 0."]
     #[inline(always)]
-    pub const fn aips_bridge_group0_mem_rule2(
+    pub const fn aips_bridge_group1_mem_rule0(
         self,
-    ) -> crate::pac::common::Reg<AipsBridgeGroup0MemRule2, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xe8usize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup1memRule0, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0120usize) as _) }
     }
-    #[doc = "AIPS Bridge Group 0 Memory Rule 3."]
+    #[doc = "AIPS Bridge Group 1 Memory Rule 1."]
     #[inline(always)]
-    pub const fn aips_bridge_group0_mem_rule3(
+    pub const fn aips_bridge_group1_mem_rule1(
         self,
-    ) -> crate::pac::common::Reg<AipsBridgeGroup0MemRule3, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xecusize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup1memRule1, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0124usize) as _) }
     }
-    #[doc = "AIPS Bridge Group 2 Memory Rule 0."]
+    #[doc = "AHB Secure Control Peripheral Rule."]
+    #[inline(always)]
+    pub const fn ahb_secure_ctrl_mem_rule0(
+        self,
+    ) -> crate::pac::common::Reg<Rule4, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0130usize) as _) }
+    }
+    #[doc = "AHB Peripheral 0 Memory Rule 1."]
+    #[inline(always)]
+    pub const fn ahb_peripheral0_mem_rule1(
+        self,
+    ) -> crate::pac::common::Reg<AhbPeripheral0memRule1, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0140usize) as _) }
+    }
+    #[doc = "AHB Peripheral 0 Memory Rule 2."]
+    #[inline(always)]
+    pub const fn ahb_peripheral0_mem_rule2(
+        self,
+    ) -> crate::pac::common::Reg<AhbPeripheral0memRule2, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0150usize) as _) }
+    }
+    #[doc = "AHB Peripheral 0 Memory Rule 3."]
+    #[inline(always)]
+    pub const fn ahb_peripheral0_mem_rule3(
+        self,
+    ) -> crate::pac::common::Reg<AhbPeripheral0memRule3, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0160usize) as _) }
+    }
+    #[doc = "AHB Peripheral 0 Memory Rule 4."]
+    #[inline(always)]
+    pub const fn ahb_peripheral0_mem_rule4(
+        self,
+    ) -> crate::pac::common::Reg<AhbPeripheral0memRule4, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0170usize) as _) }
+    }
+    #[doc = "AHB Peripheral 0 Memory Rule 5."]
+    #[inline(always)]
+    pub const fn ahb_peripheral0_mem_rule5(
+        self,
+    ) -> crate::pac::common::Reg<AhbPeripheral0memRule5, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0180usize) as _) }
+    }
+    #[doc = "AIPS Bridge Group 2 Rule 0."]
     #[inline(always)]
     pub const fn aips_bridge_group2_mem_rule0(
         self,
-    ) -> crate::pac::common::Reg<AipsBridgeGroup2MemRule0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xf0usize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule0, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01a0usize) as _) }
     }
-    #[doc = "AIPS Bridge Group 2 Memory Rule 1."]
+    #[doc = "AIPS Bridge Group 2 Rule 1."]
     #[inline(always)]
     pub const fn aips_bridge_group2_mem_rule1(
         self,
-    ) -> crate::pac::common::Reg<AipsBridgeGroup2MemRule1, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xf4usize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule1, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01a4usize) as _) }
     }
-    #[doc = "AIPS Bridge Group 2 Memory Rule 2."]
+    #[doc = "AIPS Bridge Group 2 Rule 2."]
     #[inline(always)]
     pub const fn aips_bridge_group2_mem_rule2(
         self,
-    ) -> crate::pac::common::Reg<AipsBridgeGroup2MemRule2, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xf8usize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule2, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01a8usize) as _) }
     }
-    #[doc = "AIPS Bridge Group 2 Memory Rule 3."]
+    #[doc = "AIPS Bridge Group 2 Rule 3."]
     #[inline(always)]
     pub const fn aips_bridge_group2_mem_rule3(
         self,
-    ) -> crate::pac::common::Reg<AipsBridgeGroup2MemRule3, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xfcusize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule3, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01acusize) as _) }
     }
-    #[doc = "AIPS Bridge Group 3 Rule 0."]
+    #[doc = "AIPS Bridge Group 2 Rule 4."]
     #[inline(always)]
-    pub const fn aips_bridge_group3_mem_rule0(
+    pub const fn aips_bridge_group2_mem_rule4(
         self,
-    ) -> crate::pac::common::Reg<AipsBridgeGroup3MemRule0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0100usize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule4, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01b0usize) as _) }
     }
-    #[doc = "AIPS Bridge Group 3 Memory Rule 1."]
+    #[doc = "AIPS Bridge Group 2 Rule 5."]
     #[inline(always)]
-    pub const fn aips_bridge_group3_mem_rule1(
+    pub const fn aips_bridge_group2_mem_rule5(
         self,
-    ) -> crate::pac::common::Reg<u32, crate::pac::common::R> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0104usize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule5, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01b4usize) as _) }
     }
-    #[doc = "AIPS Bridge Group 3 Rule 2."]
+    #[doc = "AIPS Bridge Group 2 Rule 6."]
     #[inline(always)]
-    pub const fn aips_bridge_group3_mem_rule2(
+    pub const fn aips_bridge_group2_mem_rule6(
         self,
-    ) -> crate::pac::common::Reg<AipsBridgeGroup3MemRule2, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0108usize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule6, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01b8usize) as _) }
     }
-    #[doc = "AIPS Bridge Group 3 Rule 3."]
+    #[doc = "AIPS Bridge Group 2 Rule 7."]
     #[inline(always)]
-    pub const fn aips_bridge_group3_mem_rule3(
+    pub const fn aips_bridge_group2_mem_rule7(
         self,
-    ) -> crate::pac::common::Reg<AipsBridgeGroup3MemRule3, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x010cusize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule7, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01bcusize) as _) }
     }
-    #[doc = "AHB Secure Control Peripheral Rule 0."]
+    #[doc = "AIPS Bridge Group 2 Rule 8."]
     #[inline(always)]
-    pub const fn ahb_secure_ctrl_peripheral_rule0(
+    pub const fn aips_bridge_group2_mem_rule8(
         self,
-    ) -> crate::pac::common::Reg<AhbSecureCtrlPeripheralRule0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0110usize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule8, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01c0usize) as _) }
     }
-    #[doc = "AHB Slave Port 6 Rule."]
+    #[doc = "AIPS Bridge Group 2 Rule 9."]
     #[inline(always)]
-    pub const fn ahb_slave_port_p6_slave_rule(
+    pub const fn aips_bridge_group2_mem_rule9(
         self,
-        n: usize,
-    ) -> crate::pac::common::Reg<AhbSlavePortP6SlaveRule, crate::pac::common::RW> {
-        assert!(n < 4usize);
-        unsafe {
-            crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0120usize + n * 4usize) as _)
-        }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule9, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01c4usize) as _) }
     }
-    #[doc = "AON Domain Peripheral Rule 0."]
+    #[doc = "AIPS Bridge Group 2 Rule 10."]
     #[inline(always)]
-    pub const fn aon_domain_peripheral_mem_rule0(
+    pub const fn aips_bridge_group2_mem_rule10(
         self,
-    ) -> crate::pac::common::Reg<AonDomainPeripheralMemRule0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0130usize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule10, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01c8usize) as _) }
     }
-    #[doc = "AON Domain Peripheral Rule 1."]
+    #[doc = "AIPS Bridge Group 2 Rule 11."]
     #[inline(always)]
-    pub const fn aon_domain_peripheral_mem_rule1(
+    pub const fn aips_bridge_group2_mem_rule11(
         self,
-    ) -> crate::pac::common::Reg<AonDomainPeripheralMemRule1, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0134usize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule11, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01ccusize) as _) }
     }
-    #[doc = "AON Domain Peripheral Rule 2."]
+    #[doc = "AIPS Bridge Group 2 Rule 12."]
     #[inline(always)]
-    pub const fn aon_domain_peripheral_mem_rule2(
+    pub const fn aips_bridge_group2_mem_rule12(
         self,
-    ) -> crate::pac::common::Reg<AonDomainPeripheralMemRule2, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0138usize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule12, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01d0usize) as _) }
     }
-    #[doc = "AON Domain Peripheral Rule 3."]
+    #[doc = "AIPS Bridge Group 2 Rule 13."]
     #[inline(always)]
-    pub const fn aon_domain_peripheral_mem_rule3(
+    pub const fn aips_bridge_group2_mem_rule13(
         self,
-    ) -> crate::pac::common::Reg<AonDomainPeripheralMemRule3, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x013cusize) as _) }
+    ) -> crate::pac::common::Reg<AipsBridgeGroup2memRule13, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01d4usize) as _) }
     }
-    #[doc = "AHB Slave Port 6 Rule."]
+    #[doc = "FLEXSPI0 Region 0 Memory Rule."]
     #[inline(always)]
-    pub const fn ahb_slave_port_p7_slave_rule(
+    pub const fn flexspi0_region0_mem_rule(
         self,
         n: usize,
-    ) -> crate::pac::common::Reg<AhbSlavePortP7SlaveRule, crate::pac::common::RW> {
+    ) -> crate::pac::common::Reg<Rule8, crate::pac::common::RW> {
         assert!(n < 4usize);
         unsafe {
-            crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0140usize + n * 4usize) as _)
+            crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01f0usize + n * 4usize) as _)
         }
     }
-    #[doc = "AON Domain SRAM Memory Rule."]
+    #[doc = "Array of registers: FLEXSPI0_REGION_MEM_RULE."]
     #[inline(always)]
-    pub const fn aon_domain_sram_mem_rule0(
-        self,
-    ) -> crate::pac::common::Reg<AonDomainSramMemRule0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0150usize) as _) }
+    pub const fn flexspi0_region1_6_mem_rule(self, n: usize) -> Flexspi0region16memRule {
+        assert!(n < 6usize);
+        unsafe {
+            Flexspi0region16memRule::from_ptr(self.ptr.wrapping_add(0x0200usize + n * 16usize) as _)
+        }
     }
     #[doc = "Security Violation Address."]
     #[inline(always)]
@@ -386,7 +360,7 @@ impl Ahbsc {
     #[inline(always)]
     pub const fn cpu0_lock_reg(
         self,
-    ) -> crate::pac::common::Reg<Cpu0LockReg, crate::pac::common::RW> {
+    ) -> crate::pac::common::Reg<Cpu0lockReg, crate::pac::common::RW> {
         unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0fecusize) as _) }
     }
     #[doc = "Secure Control Duplicate."]
@@ -404,94 +378,145 @@ impl Ahbsc {
         unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0ffcusize) as _) }
     }
 }
-#[doc = "AHB Peripheral Slave Port 5 Slave Rule 0."]
+#[doc = "Array of registers: FLEXSPI0_REGION_MEM_RULE."]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct Flexspi0region16memRule {
+    ptr: *mut u8,
+}
+unsafe impl Send for Flexspi0region16memRule {}
+unsafe impl Sync for Flexspi0region16memRule {}
+impl Flexspi0region16memRule {
+    #[inline(always)]
+    pub const unsafe fn from_ptr(ptr: *mut ()) -> Self {
+        Self { ptr: ptr as _ }
+    }
+    #[inline(always)]
+    pub const fn as_ptr(&self) -> *mut () {
+        self.ptr as _
+    }
+    #[doc = "FLEXSPI0 Region index Memory Rule."]
+    #[inline(always)]
+    pub const fn flexspi0_region_mem_rule(
+        self,
+    ) -> crate::pac::common::Reg<Rule4, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+    }
+}
+#[doc = "AHB Peripheral 0 Memory Rule 1."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AhbPeripheralSlavePortP5SlaveRule0(pub u32);
-impl AhbPeripheralSlavePortP5SlaveRule0 {
-    #[doc = "AIPS4 slaves."]
+pub struct AhbPeripheral0memRule1(pub u32);
+impl AhbPeripheral0memRule1 {
+    #[doc = "GPIO0."]
     #[must_use]
     #[inline(always)]
-    pub const fn aips4_slaves(&self) -> Rule {
-        let val = (self.0 >> 16usize) & 0x03;
+    pub const fn gpio0(&self) -> Rule {
+        let val = (self.0 >> 0usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "AIPS4 slaves."]
+    #[doc = "GPIO0."]
     #[inline(always)]
-    pub const fn set_aips4_slaves(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
+    pub const fn set_gpio0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
     }
-    #[doc = "CDOG0."]
+    #[doc = "GPIO0 ALIAS."]
     #[must_use]
     #[inline(always)]
-    pub const fn cdog0(&self) -> Rule {
-        let val = (self.0 >> 20usize) & 0x03;
+    pub const fn gpio0_alias(&self) -> Rule {
+        let val = (self.0 >> 4usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "CDOG0."]
+    #[doc = "GPIO0 ALIAS."]
     #[inline(always)]
-    pub const fn set_cdog0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
+    pub const fn set_gpio0_alias(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
     }
-    #[doc = "DEBUG_MAILBOX."]
-    #[must_use]
+}
+impl Default for AhbPeripheral0memRule1 {
     #[inline(always)]
-    pub const fn debug_mailbox(&self) -> Rule {
-        let val = (self.0 >> 24usize) & 0x03;
-        Rule::from_bits(val as u8)
+    fn default() -> AhbPeripheral0memRule1 {
+        AhbPeripheral0memRule1(0)
     }
-    #[doc = "DEBUG_MAILBOX."]
-    #[inline(always)]
-    pub const fn set_debug_mailbox(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
+}
+impl core::fmt::Debug for AhbPeripheral0memRule1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AhbPeripheral0memRule1")
+            .field("gpio0", &self.gpio0())
+            .field("gpio0_alias", &self.gpio0_alias())
+            .finish()
     }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AhbPeripheral0memRule1 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "AhbPeripheral0memRule1 {{ gpio0: {:?}, gpio0_alias: {:?} }}",
+            self.gpio0(),
+            self.gpio0_alias()
+        )
+    }
+}
+#[doc = "AHB Peripheral 0 Memory Rule 2."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct AhbPeripheral0memRule2(pub u32);
+impl AhbPeripheral0memRule2 {
     #[doc = "GPIO1."]
     #[must_use]
     #[inline(always)]
     pub const fn gpio1(&self) -> Rule {
-        let val = (self.0 >> 28usize) & 0x03;
+        let val = (self.0 >> 0usize) & 0x03;
         Rule::from_bits(val as u8)
     }
     #[doc = "GPIO1."]
     #[inline(always)]
     pub const fn set_gpio1(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
+        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
     }
-}
-impl Default for AhbPeripheralSlavePortP5SlaveRule0 {
+    #[doc = "GPIO1 ALIAS."]
+    #[must_use]
     #[inline(always)]
-    fn default() -> AhbPeripheralSlavePortP5SlaveRule0 {
-        AhbPeripheralSlavePortP5SlaveRule0(0)
+    pub const fn gpio1_alias(&self) -> Rule {
+        let val = (self.0 >> 4usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "GPIO1 ALIAS."]
+    #[inline(always)]
+    pub const fn set_gpio1_alias(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
     }
 }
-impl core::fmt::Debug for AhbPeripheralSlavePortP5SlaveRule0 {
+impl Default for AhbPeripheral0memRule2 {
+    #[inline(always)]
+    fn default() -> AhbPeripheral0memRule2 {
+        AhbPeripheral0memRule2(0)
+    }
+}
+impl core::fmt::Debug for AhbPeripheral0memRule2 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AhbPeripheralSlavePortP5SlaveRule0")
-            .field("aips4_slaves", &self.aips4_slaves())
-            .field("cdog0", &self.cdog0())
-            .field("debug_mailbox", &self.debug_mailbox())
+        f.debug_struct("AhbPeripheral0memRule2")
             .field("gpio1", &self.gpio1())
+            .field("gpio1_alias", &self.gpio1_alias())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for AhbPeripheralSlavePortP5SlaveRule0 {
+impl defmt::Format for AhbPeripheral0memRule2 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "AhbPeripheralSlavePortP5SlaveRule0 {{ aips4_slaves: {:?}, cdog0: {:?}, debug_mailbox: {:?}, gpio1: {:?} }}",
-            self.aips4_slaves(),
-            self.cdog0(),
-            self.debug_mailbox(),
-            self.gpio1()
+            "AhbPeripheral0memRule2 {{ gpio1: {:?}, gpio1_alias: {:?} }}",
+            self.gpio1(),
+            self.gpio1_alias()
         )
     }
 }
-#[doc = "AHB Peripheral Slave Port 5 Slave Rule 1."]
+#[doc = "AHB Peripheral 0 Memory Rule 3."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AhbPeripheralSlavePortP5SlaveRule1(pub u32);
-impl AhbPeripheralSlavePortP5SlaveRule1 {
+pub struct AhbPeripheral0memRule3(pub u32);
+impl AhbPeripheral0memRule3 {
     #[doc = "GPIO2."]
     #[must_use]
     #[inline(always)]
@@ -504,791 +529,1268 @@ impl AhbPeripheralSlavePortP5SlaveRule1 {
     pub const fn set_gpio2(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
     }
+    #[doc = "GPIO2 ALIAS."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn gpio2_alias(&self) -> Rule {
+        let val = (self.0 >> 4usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "GPIO2 ALIAS."]
+    #[inline(always)]
+    pub const fn set_gpio2_alias(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+    }
+}
+impl Default for AhbPeripheral0memRule3 {
+    #[inline(always)]
+    fn default() -> AhbPeripheral0memRule3 {
+        AhbPeripheral0memRule3(0)
+    }
+}
+impl core::fmt::Debug for AhbPeripheral0memRule3 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AhbPeripheral0memRule3")
+            .field("gpio2", &self.gpio2())
+            .field("gpio2_alias", &self.gpio2_alias())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AhbPeripheral0memRule3 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "AhbPeripheral0memRule3 {{ gpio2: {:?}, gpio2_alias: {:?} }}",
+            self.gpio2(),
+            self.gpio2_alias()
+        )
+    }
+}
+#[doc = "AHB Peripheral 0 Memory Rule 4."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct AhbPeripheral0memRule4(pub u32);
+impl AhbPeripheral0memRule4 {
     #[doc = "GPIO3."]
     #[must_use]
     #[inline(always)]
     pub const fn gpio3(&self) -> Rule {
-        let val = (self.0 >> 4usize) & 0x03;
+        let val = (self.0 >> 0usize) & 0x03;
         Rule::from_bits(val as u8)
     }
     #[doc = "GPIO3."]
     #[inline(always)]
     pub const fn set_gpio3(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
+    }
+    #[doc = "GPIO3 ALIAS."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn gpio3_alias(&self) -> Rule {
+        let val = (self.0 >> 4usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "GPIO3 ALIAS."]
+    #[inline(always)]
+    pub const fn set_gpio3_alias(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+    }
+}
+impl Default for AhbPeripheral0memRule4 {
+    #[inline(always)]
+    fn default() -> AhbPeripheral0memRule4 {
+        AhbPeripheral0memRule4(0)
+    }
+}
+impl core::fmt::Debug for AhbPeripheral0memRule4 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AhbPeripheral0memRule4")
+            .field("gpio3", &self.gpio3())
+            .field("gpio3_alias", &self.gpio3_alias())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AhbPeripheral0memRule4 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "AhbPeripheral0memRule4 {{ gpio3: {:?}, gpio3_alias: {:?} }}",
+            self.gpio3(),
+            self.gpio3_alias()
+        )
+    }
+}
+#[doc = "AHB Peripheral 0 Memory Rule 5."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct AhbPeripheral0memRule5(pub u32);
+impl AhbPeripheral0memRule5 {
+    #[doc = "GPIO4."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn gpio4(&self) -> Rule {
+        let val = (self.0 >> 0usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "GPIO4."]
+    #[inline(always)]
+    pub const fn set_gpio4(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
+    }
+    #[doc = "GPIO4 ALIAS."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn gpio4_alias(&self) -> Rule {
+        let val = (self.0 >> 4usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "GPIO4 ALIAS."]
+    #[inline(always)]
+    pub const fn set_gpio4_alias(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+    }
+}
+impl Default for AhbPeripheral0memRule5 {
+    #[inline(always)]
+    fn default() -> AhbPeripheral0memRule5 {
+        AhbPeripheral0memRule5(0)
+    }
+}
+impl core::fmt::Debug for AhbPeripheral0memRule5 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AhbPeripheral0memRule5")
+            .field("gpio4", &self.gpio4())
+            .field("gpio4_alias", &self.gpio4_alias())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AhbPeripheral0memRule5 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "AhbPeripheral0memRule5 {{ gpio4: {:?}, gpio4_alias: {:?} }}",
+            self.gpio4(),
+            self.gpio4_alias()
+        )
+    }
+}
+#[doc = "AHB Slave Port 5 Rule Register."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct AhbSlavePortP5slaveRule0(pub u32);
+impl AhbSlavePortP5slaveRule0 {
+    #[doc = "CDOG0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn cdog0(&self) -> Rule {
+        let val = (self.0 >> 12usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "CDOG0."]
+    #[inline(always)]
+    pub const fn set_cdog0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
     }
     #[doc = "CDOG1."]
     #[must_use]
     #[inline(always)]
     pub const fn cdog1(&self) -> Rule {
-        let val = (self.0 >> 8usize) & 0x03;
+        let val = (self.0 >> 16usize) & 0x03;
         Rule::from_bits(val as u8)
     }
     #[doc = "CDOG1."]
     #[inline(always)]
     pub const fn set_cdog1(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
+        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
     }
-}
-impl Default for AhbPeripheralSlavePortP5SlaveRule1 {
+    #[doc = "DEBUG_MAILBOX."]
+    #[must_use]
     #[inline(always)]
-    fn default() -> AhbPeripheralSlavePortP5SlaveRule1 {
-        AhbPeripheralSlavePortP5SlaveRule1(0)
+    pub const fn debug_mailbox(&self) -> Rule {
+        let val = (self.0 >> 20usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DEBUG_MAILBOX."]
+    #[inline(always)]
+    pub const fn set_debug_mailbox(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
+    }
+    #[doc = "Rule 6."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn mau0(&self) -> Rule {
+        let val = (self.0 >> 24usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "Rule 6."]
+    #[inline(always)]
+    pub const fn set_mau0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
     }
 }
-impl core::fmt::Debug for AhbPeripheralSlavePortP5SlaveRule1 {
+impl Default for AhbSlavePortP5slaveRule0 {
+    #[inline(always)]
+    fn default() -> AhbSlavePortP5slaveRule0 {
+        AhbSlavePortP5slaveRule0(0)
+    }
+}
+impl core::fmt::Debug for AhbSlavePortP5slaveRule0 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AhbPeripheralSlavePortP5SlaveRule1")
-            .field("gpio2", &self.gpio2())
-            .field("gpio3", &self.gpio3())
+        f.debug_struct("AhbSlavePortP5slaveRule0")
+            .field("cdog0", &self.cdog0())
             .field("cdog1", &self.cdog1())
+            .field("debug_mailbox", &self.debug_mailbox())
+            .field("mau0", &self.mau0())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for AhbPeripheralSlavePortP5SlaveRule1 {
+impl defmt::Format for AhbSlavePortP5slaveRule0 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "AhbPeripheralSlavePortP5SlaveRule1 {{ gpio2: {:?}, gpio3: {:?}, cdog1: {:?} }}",
-            self.gpio2(),
-            self.gpio3(),
-            self.cdog1()
-        )
-    }
-}
-#[doc = "AHB Secure Control Peripheral Rule 0."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AhbSecureCtrlPeripheralRule0(pub u32);
-impl AhbSecureCtrlPeripheralRule0 {
-    #[doc = "Rule 0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 4usize);
-        let offs = 0usize + n * 4usize;
-        let val = (self.0 >> offs) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "Rule 0."]
-    #[inline(always)]
-    pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 4usize);
-        let offs = 0usize + n * 4usize;
-        self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
-    }
-}
-impl Default for AhbSecureCtrlPeripheralRule0 {
-    #[inline(always)]
-    fn default() -> AhbSecureCtrlPeripheralRule0 {
-        AhbSecureCtrlPeripheralRule0(0)
-    }
-}
-impl core::fmt::Debug for AhbSecureCtrlPeripheralRule0 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AhbSecureCtrlPeripheralRule0")
-            .field("rule[0]", &self.rule(0usize))
-            .field("rule[1]", &self.rule(1usize))
-            .field("rule[2]", &self.rule(2usize))
-            .field("rule[3]", &self.rule(3usize))
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AhbSecureCtrlPeripheralRule0 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AhbSecureCtrlPeripheralRule0 {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?} }}",
-            self.rule(0usize),
-            self.rule(1usize),
-            self.rule(2usize),
-            self.rule(3usize)
-        )
-    }
-}
-#[doc = "AHB Slave Port 0 Rule."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AhbSlavePortP0SlaveRule(pub u32);
-impl AhbSlavePortP0SlaveRule {
-    #[doc = "Rule 0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        let val = (self.0 >> offs) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "Rule 0."]
-    #[inline(always)]
-    pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
-    }
-}
-impl Default for AhbSlavePortP0SlaveRule {
-    #[inline(always)]
-    fn default() -> AhbSlavePortP0SlaveRule {
-        AhbSlavePortP0SlaveRule(0)
-    }
-}
-impl core::fmt::Debug for AhbSlavePortP0SlaveRule {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AhbSlavePortP0SlaveRule")
-            .field("rule[0]", &self.rule(0usize))
-            .field("rule[1]", &self.rule(1usize))
-            .field("rule[2]", &self.rule(2usize))
-            .field("rule[3]", &self.rule(3usize))
-            .field("rule[4]", &self.rule(4usize))
-            .field("rule[5]", &self.rule(5usize))
-            .field("rule[6]", &self.rule(6usize))
-            .field("rule[7]", &self.rule(7usize))
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AhbSlavePortP0SlaveRule {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AhbSlavePortP0SlaveRule {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?}, rule[4]: {:?}, rule[5]: {:?}, rule[6]: {:?}, rule[7]: {:?} }}",
-            self.rule(0usize),
-            self.rule(1usize),
-            self.rule(2usize),
-            self.rule(3usize),
-            self.rule(4usize),
-            self.rule(5usize),
-            self.rule(6usize),
-            self.rule(7usize)
-        )
-    }
-}
-#[doc = "AHB Slave Port 1 Rule."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AhbSlavePortP1SlaveRule(pub u32);
-impl AhbSlavePortP1SlaveRule {
-    #[doc = "Rule 0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        let val = (self.0 >> offs) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "Rule 0."]
-    #[inline(always)]
-    pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
-    }
-}
-impl Default for AhbSlavePortP1SlaveRule {
-    #[inline(always)]
-    fn default() -> AhbSlavePortP1SlaveRule {
-        AhbSlavePortP1SlaveRule(0)
-    }
-}
-impl core::fmt::Debug for AhbSlavePortP1SlaveRule {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AhbSlavePortP1SlaveRule")
-            .field("rule[0]", &self.rule(0usize))
-            .field("rule[1]", &self.rule(1usize))
-            .field("rule[2]", &self.rule(2usize))
-            .field("rule[3]", &self.rule(3usize))
-            .field("rule[4]", &self.rule(4usize))
-            .field("rule[5]", &self.rule(5usize))
-            .field("rule[6]", &self.rule(6usize))
-            .field("rule[7]", &self.rule(7usize))
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AhbSlavePortP1SlaveRule {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AhbSlavePortP1SlaveRule {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?}, rule[4]: {:?}, rule[5]: {:?}, rule[6]: {:?}, rule[7]: {:?} }}",
-            self.rule(0usize),
-            self.rule(1usize),
-            self.rule(2usize),
-            self.rule(3usize),
-            self.rule(4usize),
-            self.rule(5usize),
-            self.rule(6usize),
-            self.rule(7usize)
-        )
-    }
-}
-#[doc = "AHB Slave Port 2 Rule."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AhbSlavePortP2SlaveRule(pub u32);
-impl AhbSlavePortP2SlaveRule {
-    #[doc = "Rule 0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        let val = (self.0 >> offs) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "Rule 0."]
-    #[inline(always)]
-    pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
-    }
-}
-impl Default for AhbSlavePortP2SlaveRule {
-    #[inline(always)]
-    fn default() -> AhbSlavePortP2SlaveRule {
-        AhbSlavePortP2SlaveRule(0)
-    }
-}
-impl core::fmt::Debug for AhbSlavePortP2SlaveRule {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AhbSlavePortP2SlaveRule")
-            .field("rule[0]", &self.rule(0usize))
-            .field("rule[1]", &self.rule(1usize))
-            .field("rule[2]", &self.rule(2usize))
-            .field("rule[3]", &self.rule(3usize))
-            .field("rule[4]", &self.rule(4usize))
-            .field("rule[5]", &self.rule(5usize))
-            .field("rule[6]", &self.rule(6usize))
-            .field("rule[7]", &self.rule(7usize))
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AhbSlavePortP2SlaveRule {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AhbSlavePortP2SlaveRule {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?}, rule[4]: {:?}, rule[5]: {:?}, rule[6]: {:?}, rule[7]: {:?} }}",
-            self.rule(0usize),
-            self.rule(1usize),
-            self.rule(2usize),
-            self.rule(3usize),
-            self.rule(4usize),
-            self.rule(5usize),
-            self.rule(6usize),
-            self.rule(7usize)
-        )
-    }
-}
-#[doc = "AHB Slave Port 3 Rule."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AhbSlavePortP3SlaveRule(pub u32);
-impl AhbSlavePortP3SlaveRule {
-    #[doc = "Rule 0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        let val = (self.0 >> offs) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "Rule 0."]
-    #[inline(always)]
-    pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
-    }
-}
-impl Default for AhbSlavePortP3SlaveRule {
-    #[inline(always)]
-    fn default() -> AhbSlavePortP3SlaveRule {
-        AhbSlavePortP3SlaveRule(0)
-    }
-}
-impl core::fmt::Debug for AhbSlavePortP3SlaveRule {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AhbSlavePortP3SlaveRule")
-            .field("rule[0]", &self.rule(0usize))
-            .field("rule[1]", &self.rule(1usize))
-            .field("rule[2]", &self.rule(2usize))
-            .field("rule[3]", &self.rule(3usize))
-            .field("rule[4]", &self.rule(4usize))
-            .field("rule[5]", &self.rule(5usize))
-            .field("rule[6]", &self.rule(6usize))
-            .field("rule[7]", &self.rule(7usize))
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AhbSlavePortP3SlaveRule {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AhbSlavePortP3SlaveRule {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?}, rule[4]: {:?}, rule[5]: {:?}, rule[6]: {:?}, rule[7]: {:?} }}",
-            self.rule(0usize),
-            self.rule(1usize),
-            self.rule(2usize),
-            self.rule(3usize),
-            self.rule(4usize),
-            self.rule(5usize),
-            self.rule(6usize),
-            self.rule(7usize)
-        )
-    }
-}
-#[doc = "AHB Slave Port 4 Rule."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AhbSlavePortP4SlaveRule(pub u32);
-impl AhbSlavePortP4SlaveRule {
-    #[doc = "Rule 0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        let val = (self.0 >> offs) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "Rule 0."]
-    #[inline(always)]
-    pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
-    }
-}
-impl Default for AhbSlavePortP4SlaveRule {
-    #[inline(always)]
-    fn default() -> AhbSlavePortP4SlaveRule {
-        AhbSlavePortP4SlaveRule(0)
-    }
-}
-impl core::fmt::Debug for AhbSlavePortP4SlaveRule {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AhbSlavePortP4SlaveRule")
-            .field("rule[0]", &self.rule(0usize))
-            .field("rule[1]", &self.rule(1usize))
-            .field("rule[2]", &self.rule(2usize))
-            .field("rule[3]", &self.rule(3usize))
-            .field("rule[4]", &self.rule(4usize))
-            .field("rule[5]", &self.rule(5usize))
-            .field("rule[6]", &self.rule(6usize))
-            .field("rule[7]", &self.rule(7usize))
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AhbSlavePortP4SlaveRule {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AhbSlavePortP4SlaveRule {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?}, rule[4]: {:?}, rule[5]: {:?}, rule[6]: {:?}, rule[7]: {:?} }}",
-            self.rule(0usize),
-            self.rule(1usize),
-            self.rule(2usize),
-            self.rule(3usize),
-            self.rule(4usize),
-            self.rule(5usize),
-            self.rule(6usize),
-            self.rule(7usize)
-        )
-    }
-}
-#[doc = "AHB Slave Port 6 Rule."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AhbSlavePortP6SlaveRule(pub u32);
-impl AhbSlavePortP6SlaveRule {
-    #[doc = "Rule 0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        let val = (self.0 >> offs) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "Rule 0."]
-    #[inline(always)]
-    pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
-    }
-}
-impl Default for AhbSlavePortP6SlaveRule {
-    #[inline(always)]
-    fn default() -> AhbSlavePortP6SlaveRule {
-        AhbSlavePortP6SlaveRule(0)
-    }
-}
-impl core::fmt::Debug for AhbSlavePortP6SlaveRule {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AhbSlavePortP6SlaveRule")
-            .field("rule[0]", &self.rule(0usize))
-            .field("rule[1]", &self.rule(1usize))
-            .field("rule[2]", &self.rule(2usize))
-            .field("rule[3]", &self.rule(3usize))
-            .field("rule[4]", &self.rule(4usize))
-            .field("rule[5]", &self.rule(5usize))
-            .field("rule[6]", &self.rule(6usize))
-            .field("rule[7]", &self.rule(7usize))
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AhbSlavePortP6SlaveRule {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AhbSlavePortP6SlaveRule {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?}, rule[4]: {:?}, rule[5]: {:?}, rule[6]: {:?}, rule[7]: {:?} }}",
-            self.rule(0usize),
-            self.rule(1usize),
-            self.rule(2usize),
-            self.rule(3usize),
-            self.rule(4usize),
-            self.rule(5usize),
-            self.rule(6usize),
-            self.rule(7usize)
-        )
-    }
-}
-#[doc = "AHB Slave Port 6 Rule."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AhbSlavePortP7SlaveRule(pub u32);
-impl AhbSlavePortP7SlaveRule {
-    #[doc = "Rule 0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        let val = (self.0 >> offs) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "Rule 0."]
-    #[inline(always)]
-    pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
-    }
-}
-impl Default for AhbSlavePortP7SlaveRule {
-    #[inline(always)]
-    fn default() -> AhbSlavePortP7SlaveRule {
-        AhbSlavePortP7SlaveRule(0)
-    }
-}
-impl core::fmt::Debug for AhbSlavePortP7SlaveRule {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AhbSlavePortP7SlaveRule")
-            .field("rule[0]", &self.rule(0usize))
-            .field("rule[1]", &self.rule(1usize))
-            .field("rule[2]", &self.rule(2usize))
-            .field("rule[3]", &self.rule(3usize))
-            .field("rule[4]", &self.rule(4usize))
-            .field("rule[5]", &self.rule(5usize))
-            .field("rule[6]", &self.rule(6usize))
-            .field("rule[7]", &self.rule(7usize))
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AhbSlavePortP7SlaveRule {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AhbSlavePortP7SlaveRule {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?}, rule[4]: {:?}, rule[5]: {:?}, rule[6]: {:?}, rule[7]: {:?} }}",
-            self.rule(0usize),
-            self.rule(1usize),
-            self.rule(2usize),
-            self.rule(3usize),
-            self.rule(4usize),
-            self.rule(5usize),
-            self.rule(6usize),
-            self.rule(7usize)
+            "AhbSlavePortP5slaveRule0 {{ cdog0: {:?}, cdog1: {:?}, debug_mailbox: {:?}, mau0: {:?} }}",
+            self.cdog0(),
+            self.cdog1(),
+            self.debug_mailbox(),
+            self.mau0()
         )
     }
 }
 #[doc = "AIPS Bridge Group 0 Memory Rule 0."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AipsBridgeGroup0MemRule0(pub u32);
-impl AipsBridgeGroup0MemRule0 {
-    #[doc = "eDMA_0_MP."]
+pub struct AipsBridgeGroup0memRule0(pub u32);
+impl AipsBridgeGroup0memRule0 {
+    #[doc = "EWM0."]
     #[must_use]
     #[inline(always)]
-    pub const fn e_dma_0_mp(&self) -> Rule {
+    pub const fn ewm0(&self) -> Rule {
         let val = (self.0 >> 0usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "eDMA_0_MP."]
+    #[doc = "EWM0."]
     #[inline(always)]
-    pub const fn set_e_dma_0_mp(&mut self, val: Rule) {
+    pub const fn set_ewm0(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
     }
-    #[doc = "eDMA_0_TCD0."]
+    #[doc = "ROMCP."]
     #[must_use]
     #[inline(always)]
-    pub const fn e_dma_0_tcd0(&self) -> Rule {
+    pub const fn romcp(&self) -> Rule {
         let val = (self.0 >> 4usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "eDMA_0_TCD0."]
+    #[doc = "ROMCP."]
     #[inline(always)]
-    pub const fn set_e_dma_0_tcd0(&mut self, val: Rule) {
+    pub const fn set_romcp(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
     }
-    #[doc = "eDMA_0_TCD1."]
+    #[doc = "PKC0."]
     #[must_use]
     #[inline(always)]
-    pub const fn e_dma_0_tcd1(&self) -> Rule {
+    pub const fn pkc0(&self) -> Rule {
         let val = (self.0 >> 8usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "eDMA_0_TCD1."]
+    #[doc = "PKC0."]
     #[inline(always)]
-    pub const fn set_e_dma_0_tcd1(&mut self, val: Rule) {
+    pub const fn set_pkc0(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
     }
-    #[doc = "eDMA_0_TCD2."]
+    #[doc = "DMA_1_MP."]
     #[must_use]
     #[inline(always)]
-    pub const fn e_dma_0_tcd2(&self) -> Rule {
+    pub const fn dma_1_mp(&self) -> Rule {
         let val = (self.0 >> 12usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "eDMA_0_TCD2."]
+    #[doc = "DMA_1_MP."]
     #[inline(always)]
-    pub const fn set_e_dma_0_tcd2(&mut self, val: Rule) {
+    pub const fn set_dma_1_mp(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
     }
-    #[doc = "FLEXSPI0 Registers."]
+    #[doc = "DMA_1_CH0."]
     #[must_use]
     #[inline(always)]
-    pub const fn e_dma_0_tcd3(&self) -> Rule {
+    pub const fn dma_1_ch0(&self) -> Rule {
         let val = (self.0 >> 16usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "FLEXSPI0 Registers."]
+    #[doc = "DMA_1_CH0."]
     #[inline(always)]
-    pub const fn set_e_dma_0_tcd3(&mut self, val: Rule) {
+    pub const fn set_dma_1_ch0(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
     }
-    #[doc = "eDMA_0_TCD4 (Reserved)."]
+    #[doc = "DMA_1_CH1."]
     #[must_use]
     #[inline(always)]
-    pub const fn e_dma_0_tcd4(&self) -> Rule {
+    pub const fn dma_1_ch1(&self) -> Rule {
         let val = (self.0 >> 20usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "eDMA_0_TCD4 (Reserved)."]
+    #[doc = "DMA_1_CH1."]
     #[inline(always)]
-    pub const fn set_e_dma_0_tcd4(&mut self, val: Rule) {
+    pub const fn set_dma_1_ch1(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
     }
-    #[doc = "eDMA_0_TCD5 (Reserved)."]
+    #[doc = "DMA_1_CH2."]
     #[must_use]
     #[inline(always)]
-    pub const fn e_dma_0_tcd5(&self) -> Rule {
+    pub const fn dma_1_ch2(&self) -> Rule {
         let val = (self.0 >> 24usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "eDMA_0_TCD5 (Reserved)."]
+    #[doc = "DMA_1_CH2."]
     #[inline(always)]
-    pub const fn set_e_dma_0_tcd5(&mut self, val: Rule) {
+    pub const fn set_dma_1_ch2(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
     }
-    #[doc = "eDMA_0_TCD6 (Reserved)."]
+    #[doc = "DMA_1_CH3."]
     #[must_use]
     #[inline(always)]
-    pub const fn e_dma_0_tcd6(&self) -> Rule {
+    pub const fn dma_1_ch3(&self) -> Rule {
         let val = (self.0 >> 28usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "eDMA_0_TCD6 (Reserved)."]
+    #[doc = "DMA_1_CH3."]
     #[inline(always)]
-    pub const fn set_e_dma_0_tcd6(&mut self, val: Rule) {
+    pub const fn set_dma_1_ch3(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
     }
 }
-impl Default for AipsBridgeGroup0MemRule0 {
+impl Default for AipsBridgeGroup0memRule0 {
     #[inline(always)]
-    fn default() -> AipsBridgeGroup0MemRule0 {
-        AipsBridgeGroup0MemRule0(0)
+    fn default() -> AipsBridgeGroup0memRule0 {
+        AipsBridgeGroup0memRule0(0)
     }
 }
-impl core::fmt::Debug for AipsBridgeGroup0MemRule0 {
+impl core::fmt::Debug for AipsBridgeGroup0memRule0 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AipsBridgeGroup0MemRule0")
-            .field("e_dma_0_mp", &self.e_dma_0_mp())
-            .field("e_dma_0_tcd0", &self.e_dma_0_tcd0())
-            .field("e_dma_0_tcd1", &self.e_dma_0_tcd1())
-            .field("e_dma_0_tcd2", &self.e_dma_0_tcd2())
-            .field("e_dma_0_tcd3", &self.e_dma_0_tcd3())
-            .field("e_dma_0_tcd4", &self.e_dma_0_tcd4())
-            .field("e_dma_0_tcd5", &self.e_dma_0_tcd5())
-            .field("e_dma_0_tcd6", &self.e_dma_0_tcd6())
+        f.debug_struct("AipsBridgeGroup0memRule0")
+            .field("ewm0", &self.ewm0())
+            .field("romcp", &self.romcp())
+            .field("pkc0", &self.pkc0())
+            .field("dma_1_mp", &self.dma_1_mp())
+            .field("dma_1_ch0", &self.dma_1_ch0())
+            .field("dma_1_ch1", &self.dma_1_ch1())
+            .field("dma_1_ch2", &self.dma_1_ch2())
+            .field("dma_1_ch3", &self.dma_1_ch3())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for AipsBridgeGroup0MemRule0 {
+impl defmt::Format for AipsBridgeGroup0memRule0 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "AipsBridgeGroup0MemRule0 {{ e_dma_0_mp: {:?}, e_dma_0_tcd0: {:?}, e_dma_0_tcd1: {:?}, e_dma_0_tcd2: {:?}, e_dma_0_tcd3: {:?}, e_dma_0_tcd4: {:?}, e_dma_0_tcd5: {:?}, e_dma_0_tcd6: {:?} }}",
-            self.e_dma_0_mp(),
-            self.e_dma_0_tcd0(),
-            self.e_dma_0_tcd1(),
-            self.e_dma_0_tcd2(),
-            self.e_dma_0_tcd3(),
-            self.e_dma_0_tcd4(),
-            self.e_dma_0_tcd5(),
-            self.e_dma_0_tcd6()
+            "AipsBridgeGroup0memRule0 {{ ewm0: {:?}, romcp: {:?}, pkc0: {:?}, dma_1_mp: {:?}, dma_1_ch0: {:?}, dma_1_ch1: {:?}, dma_1_ch2: {:?}, dma_1_ch3: {:?} }}",
+            self.ewm0(),
+            self.romcp(),
+            self.pkc0(),
+            self.dma_1_mp(),
+            self.dma_1_ch0(),
+            self.dma_1_ch1(),
+            self.dma_1_ch2(),
+            self.dma_1_ch3()
         )
     }
 }
 #[doc = "AIPS Bridge Group 0 Memory Rule 1."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AipsBridgeGroup0MemRule1(pub u32);
-impl AipsBridgeGroup0MemRule1 {
-    #[doc = "eDMA_0_TCD7 (Reserved)."]
+pub struct AipsBridgeGroup0memRule1(pub u32);
+impl AipsBridgeGroup0memRule1 {
+    #[doc = "ENET0_0."]
     #[must_use]
     #[inline(always)]
-    pub const fn e_dma_0_tcd7(&self) -> Rule {
-        let val = (self.0 >> 0usize) & 0x03;
+    pub const fn enet0_0(&self) -> Rule {
+        let val = (self.0 >> 16usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "eDMA_0_TCD7 (Reserved)."]
+    #[doc = "ENET0_0."]
     #[inline(always)]
-    pub const fn set_e_dma_0_tcd7(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
+    pub const fn set_enet0_0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
     }
-    #[doc = "AOI0."]
+    #[doc = "ENET0_1."]
     #[must_use]
     #[inline(always)]
-    pub const fn aoi0(&self) -> Rule {
-        let val = (self.0 >> 4usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "AOI0."]
-    #[inline(always)]
-    pub const fn set_aoi0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
-    }
-    #[doc = "CRC0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn crc0(&self) -> Rule {
-        let val = (self.0 >> 8usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "CRC0."]
-    #[inline(always)]
-    pub const fn set_crc0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
-    }
-    #[doc = "CMC0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn cmc0(&self) -> Rule {
-        let val = (self.0 >> 12usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "CMC0."]
-    #[inline(always)]
-    pub const fn set_cmc0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
-    }
-    #[doc = "ERM0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn erm0(&self) -> Rule {
+    pub const fn enet0_1(&self) -> Rule {
         let val = (self.0 >> 20usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "ERM0."]
+    #[doc = "ENET0_1."]
     #[inline(always)]
-    pub const fn set_erm0(&mut self, val: Rule) {
+    pub const fn set_enet0_1(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
     }
-    #[doc = "MBC0."]
+    #[doc = "eSPI."]
     #[must_use]
     #[inline(always)]
-    pub const fn mbc0(&self) -> Rule {
-        let val = (self.0 >> 24usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "MBC0."]
-    #[inline(always)]
-    pub const fn set_mbc0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
-    }
-    #[doc = "SCG0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn scg0(&self) -> Rule {
+    pub const fn e_spi(&self) -> Rule {
         let val = (self.0 >> 28usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "SCG0."]
+    #[doc = "eSPI."]
     #[inline(always)]
-    pub const fn set_scg0(&mut self, val: Rule) {
+    pub const fn set_e_spi(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
     }
 }
-impl Default for AipsBridgeGroup0MemRule1 {
+impl Default for AipsBridgeGroup0memRule1 {
     #[inline(always)]
-    fn default() -> AipsBridgeGroup0MemRule1 {
-        AipsBridgeGroup0MemRule1(0)
+    fn default() -> AipsBridgeGroup0memRule1 {
+        AipsBridgeGroup0memRule1(0)
     }
 }
-impl core::fmt::Debug for AipsBridgeGroup0MemRule1 {
+impl core::fmt::Debug for AipsBridgeGroup0memRule1 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AipsBridgeGroup0MemRule1")
-            .field("e_dma_0_tcd7", &self.e_dma_0_tcd7())
-            .field("aoi0", &self.aoi0())
-            .field("crc0", &self.crc0())
-            .field("cmc0", &self.cmc0())
-            .field("erm0", &self.erm0())
-            .field("mbc0", &self.mbc0())
-            .field("scg0", &self.scg0())
+        f.debug_struct("AipsBridgeGroup0memRule1")
+            .field("enet0_0", &self.enet0_0())
+            .field("enet0_1", &self.enet0_1())
+            .field("e_spi", &self.e_spi())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for AipsBridgeGroup0MemRule1 {
+impl defmt::Format for AipsBridgeGroup0memRule1 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "AipsBridgeGroup0MemRule1 {{ e_dma_0_tcd7: {:?}, aoi0: {:?}, crc0: {:?}, cmc0: {:?}, erm0: {:?}, mbc0: {:?}, scg0: {:?} }}",
-            self.e_dma_0_tcd7(),
-            self.aoi0(),
-            self.crc0(),
-            self.cmc0(),
-            self.erm0(),
-            self.mbc0(),
-            self.scg0()
+            "AipsBridgeGroup0memRule1 {{ enet0_0: {:?}, enet0_1: {:?}, e_spi: {:?} }}",
+            self.enet0_0(),
+            self.enet0_1(),
+            self.e_spi()
         )
     }
 }
-#[doc = "AIPS Bridge Group 0 Memory Rule 2."]
+#[doc = "AIPS Bridge Group 1 Memory Rule 0."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AipsBridgeGroup0MemRule2(pub u32);
-impl AipsBridgeGroup0MemRule2 {
+pub struct AipsBridgeGroup1memRule0(pub u32);
+impl AipsBridgeGroup1memRule0 {
+    #[doc = "FLEXSPI0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn flexspi0(&self) -> Rule {
+        let val = (self.0 >> 0usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "FLEXSPI0."]
+    #[inline(always)]
+    pub const fn set_flexspi0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
+    }
+    #[doc = "LPSPI2."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn lpspi2(&self) -> Rule {
+        let val = (self.0 >> 4usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "LPSPI2."]
+    #[inline(always)]
+    pub const fn set_lpspi2(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+    }
+    #[doc = "LPSPI3."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn lpspi3(&self) -> Rule {
+        let val = (self.0 >> 8usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "LPSPI3."]
+    #[inline(always)]
+    pub const fn set_lpspi3(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
+    }
+    #[doc = "LPSPI4."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn lpspi4(&self) -> Rule {
+        let val = (self.0 >> 12usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "LPSPI4."]
+    #[inline(always)]
+    pub const fn set_lpspi4(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
+    }
+    #[doc = "LPSPI5."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn lpspi5(&self) -> Rule {
+        let val = (self.0 >> 16usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "LPSPI5."]
+    #[inline(always)]
+    pub const fn set_lpspi5(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
+    }
+}
+impl Default for AipsBridgeGroup1memRule0 {
+    #[inline(always)]
+    fn default() -> AipsBridgeGroup1memRule0 {
+        AipsBridgeGroup1memRule0(0)
+    }
+}
+impl core::fmt::Debug for AipsBridgeGroup1memRule0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AipsBridgeGroup1memRule0")
+            .field("flexspi0", &self.flexspi0())
+            .field("lpspi2", &self.lpspi2())
+            .field("lpspi3", &self.lpspi3())
+            .field("lpspi4", &self.lpspi4())
+            .field("lpspi5", &self.lpspi5())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AipsBridgeGroup1memRule0 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "AipsBridgeGroup1memRule0 {{ flexspi0: {:?}, lpspi2: {:?}, lpspi3: {:?}, lpspi4: {:?}, lpspi5: {:?} }}",
+            self.flexspi0(),
+            self.lpspi2(),
+            self.lpspi3(),
+            self.lpspi4(),
+            self.lpspi5()
+        )
+    }
+}
+#[doc = "AIPS Bridge Group 1 Memory Rule 1."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct AipsBridgeGroup1memRule1(pub u32);
+impl AipsBridgeGroup1memRule1 {
+    #[doc = "SPI_FILETER0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn spi_fileter0(&self) -> Rule {
+        let val = (self.0 >> 16usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "SPI_FILETER0."]
+    #[inline(always)]
+    pub const fn set_spi_fileter0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
+    }
+    #[doc = "10BASE_T1S0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn t1s0(&self) -> Rule {
+        let val = (self.0 >> 20usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "10BASE_T1S0."]
+    #[inline(always)]
+    pub const fn set_t1s0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
+    }
+    #[doc = "USB1."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn usb1(&self) -> Rule {
+        let val = (self.0 >> 24usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "USB1."]
+    #[inline(always)]
+    pub const fn set_usb1(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
+    }
+    #[doc = "USB1_PHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn usb1_phy(&self) -> Rule {
+        let val = (self.0 >> 28usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "USB1_PHY."]
+    #[inline(always)]
+    pub const fn set_usb1_phy(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
+    }
+}
+impl Default for AipsBridgeGroup1memRule1 {
+    #[inline(always)]
+    fn default() -> AipsBridgeGroup1memRule1 {
+        AipsBridgeGroup1memRule1(0)
+    }
+}
+impl core::fmt::Debug for AipsBridgeGroup1memRule1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AipsBridgeGroup1memRule1")
+            .field("spi_fileter0", &self.spi_fileter0())
+            .field("t1s0", &self.t1s0())
+            .field("usb1", &self.usb1())
+            .field("usb1_phy", &self.usb1_phy())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AipsBridgeGroup1memRule1 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "AipsBridgeGroup1memRule1 {{ spi_fileter0: {:?}, t1s0: {:?}, usb1: {:?}, usb1_phy: {:?} }}",
+            self.spi_fileter0(),
+            self.t1s0(),
+            self.usb1(),
+            self.usb1_phy()
+        )
+    }
+}
+#[doc = "AIPS Bridge Group 2 Rule 0."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct AipsBridgeGroup2memRule0(pub u32);
+impl AipsBridgeGroup2memRule0 {
+    #[doc = "DMA_0_MP."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma_0_mp(&self) -> Rule {
+        let val = (self.0 >> 0usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DMA_0_MP."]
+    #[inline(always)]
+    pub const fn set_dma_0_mp(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
+    }
+    #[doc = "DMA_0_CH0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma_0_ch0(&self) -> Rule {
+        let val = (self.0 >> 4usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DMA_0_CH0."]
+    #[inline(always)]
+    pub const fn set_dma_0_ch0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+    }
+    #[doc = "DMA_0_CH1."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma_0_ch1(&self) -> Rule {
+        let val = (self.0 >> 8usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DMA_0_CH1."]
+    #[inline(always)]
+    pub const fn set_dma_0_ch1(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
+    }
+    #[doc = "DMA_0_CH2."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma_0_ch2(&self) -> Rule {
+        let val = (self.0 >> 12usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DMA_0_CH2."]
+    #[inline(always)]
+    pub const fn set_dma_0_ch2(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
+    }
+    #[doc = "DMA_0_CH3."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma_0_ch3(&self) -> Rule {
+        let val = (self.0 >> 16usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DMA_0_CH3."]
+    #[inline(always)]
+    pub const fn set_dma_0_ch3(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
+    }
+    #[doc = "DMA_0_CH4."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma_0_ch4(&self) -> Rule {
+        let val = (self.0 >> 20usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DMA_0_CH4."]
+    #[inline(always)]
+    pub const fn set_dma_0_ch4(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
+    }
+    #[doc = "DMA_0_CH5."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma_0_ch5(&self) -> Rule {
+        let val = (self.0 >> 24usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DMA_0_CH5."]
+    #[inline(always)]
+    pub const fn set_dma_0_ch5(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
+    }
+    #[doc = "DMA_0_CH6."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma_0_ch6(&self) -> Rule {
+        let val = (self.0 >> 28usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DMA_0_CH6."]
+    #[inline(always)]
+    pub const fn set_dma_0_ch6(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
+    }
+}
+impl Default for AipsBridgeGroup2memRule0 {
+    #[inline(always)]
+    fn default() -> AipsBridgeGroup2memRule0 {
+        AipsBridgeGroup2memRule0(0)
+    }
+}
+impl core::fmt::Debug for AipsBridgeGroup2memRule0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AipsBridgeGroup2memRule0")
+            .field("dma_0_mp", &self.dma_0_mp())
+            .field("dma_0_ch0", &self.dma_0_ch0())
+            .field("dma_0_ch1", &self.dma_0_ch1())
+            .field("dma_0_ch2", &self.dma_0_ch2())
+            .field("dma_0_ch3", &self.dma_0_ch3())
+            .field("dma_0_ch4", &self.dma_0_ch4())
+            .field("dma_0_ch5", &self.dma_0_ch5())
+            .field("dma_0_ch6", &self.dma_0_ch6())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AipsBridgeGroup2memRule0 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "AipsBridgeGroup2memRule0 {{ dma_0_mp: {:?}, dma_0_ch0: {:?}, dma_0_ch1: {:?}, dma_0_ch2: {:?}, dma_0_ch3: {:?}, dma_0_ch4: {:?}, dma_0_ch5: {:?}, dma_0_ch6: {:?} }}",
+            self.dma_0_mp(),
+            self.dma_0_ch0(),
+            self.dma_0_ch1(),
+            self.dma_0_ch2(),
+            self.dma_0_ch3(),
+            self.dma_0_ch4(),
+            self.dma_0_ch5(),
+            self.dma_0_ch6()
+        )
+    }
+}
+#[doc = "AIPS Bridge Group 2 Rule 1."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct AipsBridgeGroup2memRule1(pub u32);
+impl AipsBridgeGroup2memRule1 {
+    #[doc = "DMA_0_CH7."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma_0_ch7(&self) -> Rule {
+        let val = (self.0 >> 0usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DMA_0_CH7."]
+    #[inline(always)]
+    pub const fn set_dma_0_ch7(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
+    }
+    #[doc = "DMA_0_CH8."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma_0_ch8(&self) -> Rule {
+        let val = (self.0 >> 4usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DMA_0_CH8."]
+    #[inline(always)]
+    pub const fn set_dma_0_ch8(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+    }
+    #[doc = "DMA_0_CH9."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma_0_ch9(&self) -> Rule {
+        let val = (self.0 >> 8usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DMA_0_CH9."]
+    #[inline(always)]
+    pub const fn set_dma_0_ch9(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
+    }
+    #[doc = "DMA_0_CH10."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma_0_ch10(&self) -> Rule {
+        let val = (self.0 >> 12usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DMA_0_CH10."]
+    #[inline(always)]
+    pub const fn set_dma_0_ch10(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
+    }
+    #[doc = "DMA_0_CH11."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma_0_ch11(&self) -> Rule {
+        let val = (self.0 >> 16usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DMA_0_CH11."]
+    #[inline(always)]
+    pub const fn set_dma_0_ch11(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
+    }
+}
+impl Default for AipsBridgeGroup2memRule1 {
+    #[inline(always)]
+    fn default() -> AipsBridgeGroup2memRule1 {
+        AipsBridgeGroup2memRule1(0)
+    }
+}
+impl core::fmt::Debug for AipsBridgeGroup2memRule1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AipsBridgeGroup2memRule1")
+            .field("dma_0_ch7", &self.dma_0_ch7())
+            .field("dma_0_ch8", &self.dma_0_ch8())
+            .field("dma_0_ch9", &self.dma_0_ch9())
+            .field("dma_0_ch10", &self.dma_0_ch10())
+            .field("dma_0_ch11", &self.dma_0_ch11())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AipsBridgeGroup2memRule1 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "AipsBridgeGroup2memRule1 {{ dma_0_ch7: {:?}, dma_0_ch8: {:?}, dma_0_ch9: {:?}, dma_0_ch10: {:?}, dma_0_ch11: {:?} }}",
+            self.dma_0_ch7(),
+            self.dma_0_ch8(),
+            self.dma_0_ch9(),
+            self.dma_0_ch10(),
+            self.dma_0_ch11()
+        )
+    }
+}
+#[doc = "AIPS Bridge Group 2 Rule 10."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct AipsBridgeGroup2memRule10(pub u32);
+impl AipsBridgeGroup2memRule10 {
+    #[doc = "CAN1 Region 0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn can1_region0(&self) -> Rule {
+        let val = (self.0 >> 0usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "CAN1 Region 0."]
+    #[inline(always)]
+    pub const fn set_can1_region0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
+    }
+    #[doc = "CAN1 Region 1."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn can1_region1(&self) -> Rule {
+        let val = (self.0 >> 4usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "CAN1 Region 1."]
+    #[inline(always)]
+    pub const fn set_can1_region1(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+    }
+    #[doc = "CAN1 Region 2."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn can1_region2(&self) -> Rule {
+        let val = (self.0 >> 8usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "CAN1 Region 2."]
+    #[inline(always)]
+    pub const fn set_can1_region2(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
+    }
+    #[doc = "CAN1 Region 3."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn can1_region3(&self) -> Rule {
+        let val = (self.0 >> 12usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "CAN1 Region 3."]
+    #[inline(always)]
+    pub const fn set_can1_region3(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
+    }
+    #[doc = "LPI2C2."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn lpi2c2(&self) -> Rule {
+        let val = (self.0 >> 16usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "LPI2C2."]
+    #[inline(always)]
+    pub const fn set_lpi2c2(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
+    }
+    #[doc = "LPI2C3."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn lpi2c3(&self) -> Rule {
+        let val = (self.0 >> 20usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "LPI2C3."]
+    #[inline(always)]
+    pub const fn set_lpi2c3(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
+    }
+    #[doc = "LPI2C4."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn lpi2c4(&self) -> Rule {
+        let val = (self.0 >> 24usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "LPI2C4."]
+    #[inline(always)]
+    pub const fn set_lpi2c4(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
+    }
+}
+impl Default for AipsBridgeGroup2memRule10 {
+    #[inline(always)]
+    fn default() -> AipsBridgeGroup2memRule10 {
+        AipsBridgeGroup2memRule10(0)
+    }
+}
+impl core::fmt::Debug for AipsBridgeGroup2memRule10 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AipsBridgeGroup2memRule10")
+            .field("can1_region0", &self.can1_region0())
+            .field("can1_region1", &self.can1_region1())
+            .field("can1_region2", &self.can1_region2())
+            .field("can1_region3", &self.can1_region3())
+            .field("lpi2c2", &self.lpi2c2())
+            .field("lpi2c3", &self.lpi2c3())
+            .field("lpi2c4", &self.lpi2c4())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AipsBridgeGroup2memRule10 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "AipsBridgeGroup2memRule10 {{ can1_region0: {:?}, can1_region1: {:?}, can1_region2: {:?}, can1_region3: {:?}, lpi2c2: {:?}, lpi2c3: {:?}, lpi2c4: {:?} }}",
+            self.can1_region0(),
+            self.can1_region1(),
+            self.can1_region2(),
+            self.can1_region3(),
+            self.lpi2c2(),
+            self.lpi2c3(),
+            self.lpi2c4()
+        )
+    }
+}
+#[doc = "AIPS Bridge Group 2 Rule 11."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct AipsBridgeGroup2memRule11(pub u32);
+impl AipsBridgeGroup2memRule11 {
+    #[doc = "LPUART5."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn lpuart5(&self) -> Rule {
+        let val = (self.0 >> 8usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "LPUART5."]
+    #[inline(always)]
+    pub const fn set_lpuart5(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
+    }
+    #[doc = "I3C3."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn i3c3(&self) -> Rule {
+        let val = (self.0 >> 24usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "I3C3."]
+    #[inline(always)]
+    pub const fn set_i3c3(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
+    }
+    #[doc = "GPIO5."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn gpio5(&self) -> Rule {
+        let val = (self.0 >> 28usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "GPIO5."]
+    #[inline(always)]
+    pub const fn set_gpio5(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
+    }
+}
+impl Default for AipsBridgeGroup2memRule11 {
+    #[inline(always)]
+    fn default() -> AipsBridgeGroup2memRule11 {
+        AipsBridgeGroup2memRule11(0)
+    }
+}
+impl core::fmt::Debug for AipsBridgeGroup2memRule11 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AipsBridgeGroup2memRule11")
+            .field("lpuart5", &self.lpuart5())
+            .field("i3c3", &self.i3c3())
+            .field("gpio5", &self.gpio5())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AipsBridgeGroup2memRule11 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "AipsBridgeGroup2memRule11 {{ lpuart5: {:?}, i3c3: {:?}, gpio5: {:?} }}",
+            self.lpuart5(),
+            self.i3c3(),
+            self.gpio5()
+        )
+    }
+}
+#[doc = "AIPS Bridge Group 2 Rule 12."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct AipsBridgeGroup2memRule12(pub u32);
+impl AipsBridgeGroup2memRule12 {
+    #[doc = "GPIO5_ALIAS."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn gpio5_alias(&self) -> Rule {
+        let val = (self.0 >> 0usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "GPIO5_ALIAS."]
+    #[inline(always)]
+    pub const fn set_gpio5_alias(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
+    }
+    #[doc = "PORT5."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn port5(&self) -> Rule {
+        let val = (self.0 >> 12usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "PORT5."]
+    #[inline(always)]
+    pub const fn set_port5(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
+    }
+    #[doc = "DGDET0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dgdet0(&self) -> Rule {
+        let val = (self.0 >> 20usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "DGDET0."]
+    #[inline(always)]
+    pub const fn set_dgdet0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
+    }
+    #[doc = "ITRC0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn itrc0(&self) -> Rule {
+        let val = (self.0 >> 28usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "ITRC0."]
+    #[inline(always)]
+    pub const fn set_itrc0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
+    }
+}
+impl Default for AipsBridgeGroup2memRule12 {
+    #[inline(always)]
+    fn default() -> AipsBridgeGroup2memRule12 {
+        AipsBridgeGroup2memRule12(0)
+    }
+}
+impl core::fmt::Debug for AipsBridgeGroup2memRule12 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AipsBridgeGroup2memRule12")
+            .field("gpio5_alias", &self.gpio5_alias())
+            .field("port5", &self.port5())
+            .field("dgdet0", &self.dgdet0())
+            .field("itrc0", &self.itrc0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AipsBridgeGroup2memRule12 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "AipsBridgeGroup2memRule12 {{ gpio5_alias: {:?}, port5: {:?}, dgdet0: {:?}, itrc0: {:?} }}",
+            self.gpio5_alias(),
+            self.port5(),
+            self.dgdet0(),
+            self.itrc0()
+        )
+    }
+}
+#[doc = "AIPS Bridge Group 2 Rule 13."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct AipsBridgeGroup2memRule13(pub u32);
+impl AipsBridgeGroup2memRule13 {
+    #[doc = "GLIKEY0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn glikey0(&self) -> Rule {
+        let val = (self.0 >> 0usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "GLIKEY0."]
+    #[inline(always)]
+    pub const fn set_glikey0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
+    }
+    #[doc = "TDET0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn tdet0(&self) -> Rule {
+        let val = (self.0 >> 4usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "TDET0."]
+    #[inline(always)]
+    pub const fn set_tdet0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+    }
+    #[doc = "SECCON."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn seccon(&self) -> Rule {
+        let val = (self.0 >> 8usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "SECCON."]
+    #[inline(always)]
+    pub const fn set_seccon(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
+    }
+    #[doc = "SGI0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn sgi0(&self) -> Rule {
+        let val = (self.0 >> 12usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "SGI0."]
+    #[inline(always)]
+    pub const fn set_sgi0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
+    }
+    #[doc = "TRNG0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn trng0(&self) -> Rule {
+        let val = (self.0 >> 16usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "TRNG0."]
+    #[inline(always)]
+    pub const fn set_trng0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
+    }
+    #[doc = "UDF0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn udf0(&self) -> Rule {
+        let val = (self.0 >> 20usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "UDF0."]
+    #[inline(always)]
+    pub const fn set_udf0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
+    }
+    #[doc = "RTC0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn rtc0(&self) -> Rule {
+        let val = (self.0 >> 24usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "RTC0."]
+    #[inline(always)]
+    pub const fn set_rtc0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
+    }
+}
+impl Default for AipsBridgeGroup2memRule13 {
+    #[inline(always)]
+    fn default() -> AipsBridgeGroup2memRule13 {
+        AipsBridgeGroup2memRule13(0)
+    }
+}
+impl core::fmt::Debug for AipsBridgeGroup2memRule13 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AipsBridgeGroup2memRule13")
+            .field("glikey0", &self.glikey0())
+            .field("tdet0", &self.tdet0())
+            .field("seccon", &self.seccon())
+            .field("sgi0", &self.sgi0())
+            .field("trng0", &self.trng0())
+            .field("udf0", &self.udf0())
+            .field("rtc0", &self.rtc0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AipsBridgeGroup2memRule13 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "AipsBridgeGroup2memRule13 {{ glikey0: {:?}, tdet0: {:?}, seccon: {:?}, sgi0: {:?}, trng0: {:?}, udf0: {:?}, rtc0: {:?} }}",
+            self.glikey0(),
+            self.tdet0(),
+            self.seccon(),
+            self.sgi0(),
+            self.trng0(),
+            self.udf0(),
+            self.rtc0()
+        )
+    }
+}
+#[doc = "AIPS Bridge Group 2 Rule 2."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct AipsBridgeGroup2memRule2(pub u32);
+impl AipsBridgeGroup2memRule2 {
     #[doc = "SYSCON."]
     #[must_use]
     #[inline(always)]
@@ -1301,125 +1803,99 @@ impl AipsBridgeGroup0MemRule2 {
     pub const fn set_syscon(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
     }
-    #[doc = "WUU0."]
+    #[doc = "WUU."]
     #[must_use]
     #[inline(always)]
-    pub const fn wuu0(&self) -> Rule {
+    pub const fn wuu(&self) -> Rule {
         let val = (self.0 >> 8usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "WUU0."]
+    #[doc = "WUU."]
     #[inline(always)]
-    pub const fn set_wuu0(&mut self, val: Rule) {
+    pub const fn set_wuu(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
     }
-    #[doc = "FMC0."]
+    #[doc = "VBAT."]
     #[must_use]
     #[inline(always)]
-    pub const fn fmc0(&self) -> Rule {
+    pub const fn vbat(&self) -> Rule {
+        let val = (self.0 >> 12usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "VBAT."]
+    #[inline(always)]
+    pub const fn set_vbat(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
+    }
+    #[doc = "FMC."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn fmc(&self) -> Rule {
         let val = (self.0 >> 16usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "FMC0."]
+    #[doc = "FMC."]
     #[inline(always)]
-    pub const fn set_fmc0(&mut self, val: Rule) {
+    pub const fn set_fmc(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
     }
-    #[doc = "FMU0."]
+    #[doc = "FMU."]
     #[must_use]
     #[inline(always)]
-    pub const fn fmu0(&self) -> Rule {
+    pub const fn fmu(&self) -> Rule {
         let val = (self.0 >> 20usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "FMU0."]
+    #[doc = "FMU."]
     #[inline(always)]
-    pub const fn set_fmu0(&mut self, val: Rule) {
+    pub const fn set_fmu(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
     }
-    #[doc = "FMU0_TST."]
-    #[must_use]
+}
+impl Default for AipsBridgeGroup2memRule2 {
     #[inline(always)]
-    pub const fn fmu0_tst(&self) -> Rule {
-        let val = (self.0 >> 24usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "FMU0_TST."]
-    #[inline(always)]
-    pub const fn set_fmu0_tst(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
-    }
-    #[doc = "BCANXL (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn bcanxl(&self) -> Rule {
-        let val = (self.0 >> 28usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "BCANXL (Reserved)."]
-    #[inline(always)]
-    pub const fn set_bcanxl(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
+    fn default() -> AipsBridgeGroup2memRule2 {
+        AipsBridgeGroup2memRule2(0)
     }
 }
-impl Default for AipsBridgeGroup0MemRule2 {
-    #[inline(always)]
-    fn default() -> AipsBridgeGroup0MemRule2 {
-        AipsBridgeGroup0MemRule2(0)
-    }
-}
-impl core::fmt::Debug for AipsBridgeGroup0MemRule2 {
+impl core::fmt::Debug for AipsBridgeGroup2memRule2 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AipsBridgeGroup0MemRule2")
+        f.debug_struct("AipsBridgeGroup2memRule2")
             .field("syscon", &self.syscon())
-            .field("wuu0", &self.wuu0())
-            .field("fmc0", &self.fmc0())
-            .field("fmu0", &self.fmu0())
-            .field("fmu0_tst", &self.fmu0_tst())
-            .field("bcanxl", &self.bcanxl())
+            .field("wuu", &self.wuu())
+            .field("vbat", &self.vbat())
+            .field("fmc", &self.fmc())
+            .field("fmu", &self.fmu())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for AipsBridgeGroup0MemRule2 {
+impl defmt::Format for AipsBridgeGroup2memRule2 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "AipsBridgeGroup0MemRule2 {{ syscon: {:?}, wuu0: {:?}, fmc0: {:?}, fmu0: {:?}, fmu0_tst: {:?}, bcanxl: {:?} }}",
+            "AipsBridgeGroup2memRule2 {{ syscon: {:?}, wuu: {:?}, vbat: {:?}, fmc: {:?}, fmu: {:?} }}",
             self.syscon(),
-            self.wuu0(),
-            self.fmc0(),
-            self.fmu0(),
-            self.fmu0_tst(),
-            self.bcanxl()
+            self.wuu(),
+            self.vbat(),
+            self.fmc(),
+            self.fmu()
         )
     }
 }
-#[doc = "AIPS Bridge Group 0 Memory Rule 3."]
+#[doc = "AIPS Bridge Group 2 Rule 3."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AipsBridgeGroup0MemRule3(pub u32);
-impl AipsBridgeGroup0MemRule3 {
-    #[doc = "CANDMA (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn candma(&self) -> Rule {
-        let val = (self.0 >> 0usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "CANDMA (Reserved)."]
-    #[inline(always)]
-    pub const fn set_candma(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
-    }
-    #[doc = "FLEXIO (Reserved)."]
+pub struct AipsBridgeGroup2memRule3(pub u32);
+impl AipsBridgeGroup2memRule3 {
+    #[doc = "FLEXIO."]
     #[must_use]
     #[inline(always)]
     pub const fn flexio(&self) -> Rule {
         let val = (self.0 >> 4usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "FLEXIO (Reserved)."]
+    #[doc = "FLEXIO."]
     #[inline(always)]
     pub const fn set_flexio(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
@@ -1472,16 +1948,16 @@ impl AipsBridgeGroup0MemRule3 {
     pub const fn set_lpspi1(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
     }
-    #[doc = "LPSPI2 (Reserved)."]
+    #[doc = "I3C2."]
     #[must_use]
     #[inline(always)]
-    pub const fn lpspi2(&self) -> Rule {
+    pub const fn i3c2(&self) -> Rule {
         let val = (self.0 >> 24usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "LPSPI2 (Reserved)."]
+    #[doc = "I3C2."]
     #[inline(always)]
-    pub const fn set_lpspi2(&mut self, val: Rule) {
+    pub const fn set_i3c2(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
     }
     #[doc = "LPUART0."]
@@ -1497,48 +1973,46 @@ impl AipsBridgeGroup0MemRule3 {
         self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
     }
 }
-impl Default for AipsBridgeGroup0MemRule3 {
+impl Default for AipsBridgeGroup2memRule3 {
     #[inline(always)]
-    fn default() -> AipsBridgeGroup0MemRule3 {
-        AipsBridgeGroup0MemRule3(0)
+    fn default() -> AipsBridgeGroup2memRule3 {
+        AipsBridgeGroup2memRule3(0)
     }
 }
-impl core::fmt::Debug for AipsBridgeGroup0MemRule3 {
+impl core::fmt::Debug for AipsBridgeGroup2memRule3 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AipsBridgeGroup0MemRule3")
-            .field("candma", &self.candma())
+        f.debug_struct("AipsBridgeGroup2memRule3")
             .field("flexio", &self.flexio())
             .field("lpi2c0", &self.lpi2c0())
             .field("lpi2c1", &self.lpi2c1())
             .field("lpspi0", &self.lpspi0())
             .field("lpspi1", &self.lpspi1())
-            .field("lpspi2", &self.lpspi2())
+            .field("i3c2", &self.i3c2())
             .field("lpuart0", &self.lpuart0())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for AipsBridgeGroup0MemRule3 {
+impl defmt::Format for AipsBridgeGroup2memRule3 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "AipsBridgeGroup0MemRule3 {{ candma: {:?}, flexio: {:?}, lpi2c0: {:?}, lpi2c1: {:?}, lpspi0: {:?}, lpspi1: {:?}, lpspi2: {:?}, lpuart0: {:?} }}",
-            self.candma(),
+            "AipsBridgeGroup2memRule3 {{ flexio: {:?}, lpi2c0: {:?}, lpi2c1: {:?}, lpspi0: {:?}, lpspi1: {:?}, i3c2: {:?}, lpuart0: {:?} }}",
             self.flexio(),
             self.lpi2c0(),
             self.lpi2c1(),
             self.lpspi0(),
             self.lpspi1(),
-            self.lpspi2(),
+            self.i3c2(),
             self.lpuart0()
         )
     }
 }
-#[doc = "AIPS Bridge Group 2 Memory Rule 0."]
+#[doc = "AIPS Bridge Group 2 Rule 4."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AipsBridgeGroup2MemRule0(pub u32);
-impl AipsBridgeGroup2MemRule0 {
+pub struct AipsBridgeGroup2memRule4(pub u32);
+impl AipsBridgeGroup2memRule4 {
     #[doc = "LPUART1."]
     #[must_use]
     #[inline(always)]
@@ -1551,280 +2025,168 @@ impl AipsBridgeGroup2MemRule0 {
     pub const fn set_lpuart1(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
     }
-    #[doc = "LPUART2 (Reserved)."]
+    #[doc = "LPUART2."]
     #[must_use]
     #[inline(always)]
     pub const fn lpuart2(&self) -> Rule {
         let val = (self.0 >> 4usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "LPUART2 (Reserved)."]
+    #[doc = "LPUART2."]
     #[inline(always)]
     pub const fn set_lpuart2(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
     }
-    #[doc = "LPUART3 (Reserved)."]
+    #[doc = "LPUART3."]
     #[must_use]
     #[inline(always)]
     pub const fn lpuart3(&self) -> Rule {
         let val = (self.0 >> 8usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "LPUART3 (Reserved)."]
+    #[doc = "LPUART3."]
     #[inline(always)]
     pub const fn set_lpuart3(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
     }
-    #[doc = "LPUART4 (Reserved)."]
+    #[doc = "LPUART4."]
     #[must_use]
     #[inline(always)]
     pub const fn lpuart4(&self) -> Rule {
         let val = (self.0 >> 12usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "LPUART4 (Reserved)."]
+    #[doc = "LPUART4."]
     #[inline(always)]
     pub const fn set_lpuart4(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
     }
-    #[doc = "USB_FS_OTG (Reserved)."]
-    #[must_use]
+}
+impl Default for AipsBridgeGroup2memRule4 {
     #[inline(always)]
-    pub const fn usb_fs_otg(&self) -> Rule {
-        let val = (self.0 >> 16usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "USB_FS_OTG (Reserved)."]
-    #[inline(always)]
-    pub const fn set_usb_fs_otg(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
-    }
-    #[doc = "USB_FS_DCD (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn usb_fs_dcd(&self) -> Rule {
-        let val = (self.0 >> 20usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "USB_FS_DCD (Reserved)."]
-    #[inline(always)]
-    pub const fn set_usb_fs_dcd(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
-    }
-    #[doc = "USB_TYPEC_PD (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn usb_typec_pd(&self) -> Rule {
-        let val = (self.0 >> 24usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "USB_TYPEC_PD (Reserved)."]
-    #[inline(always)]
-    pub const fn set_usb_typec_pd(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
-    }
-    #[doc = "QUAD_DECODER0 (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn quad_decoder0(&self) -> Rule {
-        let val = (self.0 >> 28usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "QUAD_DECODER0 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_quad_decoder0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
+    fn default() -> AipsBridgeGroup2memRule4 {
+        AipsBridgeGroup2memRule4(0)
     }
 }
-impl Default for AipsBridgeGroup2MemRule0 {
-    #[inline(always)]
-    fn default() -> AipsBridgeGroup2MemRule0 {
-        AipsBridgeGroup2MemRule0(0)
-    }
-}
-impl core::fmt::Debug for AipsBridgeGroup2MemRule0 {
+impl core::fmt::Debug for AipsBridgeGroup2memRule4 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AipsBridgeGroup2MemRule0")
+        f.debug_struct("AipsBridgeGroup2memRule4")
             .field("lpuart1", &self.lpuart1())
             .field("lpuart2", &self.lpuart2())
             .field("lpuart3", &self.lpuart3())
             .field("lpuart4", &self.lpuart4())
-            .field("usb_fs_otg", &self.usb_fs_otg())
-            .field("usb_fs_dcd", &self.usb_fs_dcd())
-            .field("usb_typec_pd", &self.usb_typec_pd())
-            .field("quad_decoder0", &self.quad_decoder0())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for AipsBridgeGroup2MemRule0 {
+impl defmt::Format for AipsBridgeGroup2memRule4 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "AipsBridgeGroup2MemRule0 {{ lpuart1: {:?}, lpuart2: {:?}, lpuart3: {:?}, lpuart4: {:?}, usb_fs_otg: {:?}, usb_fs_dcd: {:?}, usb_typec_pd: {:?}, quad_decoder0: {:?} }}",
+            "AipsBridgeGroup2memRule4 {{ lpuart1: {:?}, lpuart2: {:?}, lpuart3: {:?}, lpuart4: {:?} }}",
             self.lpuart1(),
             self.lpuart2(),
             self.lpuart3(),
-            self.lpuart4(),
-            self.usb_fs_otg(),
-            self.usb_fs_dcd(),
-            self.usb_typec_pd(),
-            self.quad_decoder0()
+            self.lpuart4()
         )
     }
 }
-#[doc = "AIPS Bridge Group 2 Memory Rule 1."]
+#[doc = "AIPS Bridge Group 2 Rule 5."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AipsBridgeGroup2MemRule1(pub u32);
-impl AipsBridgeGroup2MemRule1 {
-    #[doc = "QUAD_DECODER1 (Reserved)."]
+pub struct AipsBridgeGroup2memRule5(pub u32);
+impl AipsBridgeGroup2memRule5 {
+    #[doc = "LPTMR."]
     #[must_use]
     #[inline(always)]
-    pub const fn quad_decoder1(&self) -> Rule {
-        let val = (self.0 >> 0usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "QUAD_DECODER1 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_quad_decoder1(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
-    }
-    #[doc = "FLEXPWM0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn flexpwm0(&self) -> Rule {
-        let val = (self.0 >> 4usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "FLEXPWM0."]
-    #[inline(always)]
-    pub const fn set_flexpwm0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
-    }
-    #[doc = "FLEXPWM1 (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn flexpwm1(&self) -> Rule {
-        let val = (self.0 >> 8usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "FLEXPWM1 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_flexpwm1(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
-    }
-    #[doc = "LPTMR0 (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn lptmr0(&self) -> Rule {
+    pub const fn lptmr(&self) -> Rule {
         let val = (self.0 >> 12usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "LPTMR0 (Reserved)."]
+    #[doc = "LPTMR."]
     #[inline(always)]
-    pub const fn set_lptmr0(&mut self, val: Rule) {
+    pub const fn set_lptmr(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
     }
-    #[doc = "LPTMR1 (Reserved)."]
+    #[doc = "OSTIMER."]
     #[must_use]
     #[inline(always)]
-    pub const fn lptmr1(&self) -> Rule {
-        let val = (self.0 >> 16usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "LPTMR1 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_lptmr1(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
-    }
-    #[doc = "OSTIMER0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn ostimer0(&self) -> Rule {
+    pub const fn ostimer(&self) -> Rule {
         let val = (self.0 >> 20usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "OSTIMER0."]
+    #[doc = "OSTIMER."]
     #[inline(always)]
-    pub const fn set_ostimer0(&mut self, val: Rule) {
+    pub const fn set_ostimer(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
     }
-    #[doc = "WAKE_TIMER (Reserved)."]
+    #[doc = "WAKE_TIMER."]
     #[must_use]
     #[inline(always)]
     pub const fn wake_timer(&self) -> Rule {
         let val = (self.0 >> 24usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "WAKE_TIMER (Reserved)."]
+    #[doc = "WAKE_TIMER."]
     #[inline(always)]
     pub const fn set_wake_timer(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
     }
-    #[doc = "HSADC0."]
+    #[doc = "ADC0."]
     #[must_use]
     #[inline(always)]
-    pub const fn hsadc0(&self) -> Rule {
+    pub const fn adc0(&self) -> Rule {
         let val = (self.0 >> 28usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "HSADC0."]
+    #[doc = "ADC0."]
     #[inline(always)]
-    pub const fn set_hsadc0(&mut self, val: Rule) {
+    pub const fn set_adc0(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
     }
 }
-impl Default for AipsBridgeGroup2MemRule1 {
+impl Default for AipsBridgeGroup2memRule5 {
     #[inline(always)]
-    fn default() -> AipsBridgeGroup2MemRule1 {
-        AipsBridgeGroup2MemRule1(0)
+    fn default() -> AipsBridgeGroup2memRule5 {
+        AipsBridgeGroup2memRule5(0)
     }
 }
-impl core::fmt::Debug for AipsBridgeGroup2MemRule1 {
+impl core::fmt::Debug for AipsBridgeGroup2memRule5 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AipsBridgeGroup2MemRule1")
-            .field("quad_decoder1", &self.quad_decoder1())
-            .field("flexpwm0", &self.flexpwm0())
-            .field("flexpwm1", &self.flexpwm1())
-            .field("lptmr0", &self.lptmr0())
-            .field("lptmr1", &self.lptmr1())
-            .field("ostimer0", &self.ostimer0())
+        f.debug_struct("AipsBridgeGroup2memRule5")
+            .field("lptmr", &self.lptmr())
+            .field("ostimer", &self.ostimer())
             .field("wake_timer", &self.wake_timer())
-            .field("hsadc0", &self.hsadc0())
+            .field("adc0", &self.adc0())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for AipsBridgeGroup2MemRule1 {
+impl defmt::Format for AipsBridgeGroup2memRule5 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "AipsBridgeGroup2MemRule1 {{ quad_decoder1: {:?}, flexpwm0: {:?}, flexpwm1: {:?}, lptmr0: {:?}, lptmr1: {:?}, ostimer0: {:?}, wake_timer: {:?}, hsadc0: {:?} }}",
-            self.quad_decoder1(),
-            self.flexpwm0(),
-            self.flexpwm1(),
-            self.lptmr0(),
-            self.lptmr1(),
-            self.ostimer0(),
+            "AipsBridgeGroup2memRule5 {{ lptmr: {:?}, ostimer: {:?}, wake_timer: {:?}, adc0: {:?} }}",
+            self.lptmr(),
+            self.ostimer(),
             self.wake_timer(),
-            self.hsadc0()
+            self.adc0()
         )
     }
 }
-#[doc = "AIPS Bridge Group 2 Memory Rule 2."]
+#[doc = "AIPS Bridge Group 2 Rule 6."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AipsBridgeGroup2MemRule2(pub u32);
-impl AipsBridgeGroup2MemRule2 {
-    #[doc = "ADC1 (Reserved)."]
+pub struct AipsBridgeGroup2memRule6(pub u32);
+impl AipsBridgeGroup2memRule6 {
+    #[doc = "ADC1."]
     #[must_use]
     #[inline(always)]
     pub const fn adc1(&self) -> Rule {
         let val = (self.0 >> 0usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "ADC1 (Reserved)."]
+    #[doc = "ADC1."]
     #[inline(always)]
     pub const fn set_adc1(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
@@ -1841,771 +2203,412 @@ impl AipsBridgeGroup2MemRule2 {
     pub const fn set_cmp0(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
     }
-    #[doc = "CMP1 (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn cmp1(&self) -> Rule {
-        let val = (self.0 >> 8usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "CMP1 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_cmp1(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
-    }
-    #[doc = "CMP2 (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn cmp2(&self) -> Rule {
-        let val = (self.0 >> 12usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "CMP2 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_cmp2(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
-    }
-    #[doc = "DAC0 (Reserved)."]
+    #[doc = "DAC0."]
     #[must_use]
     #[inline(always)]
     pub const fn dac0(&self) -> Rule {
         let val = (self.0 >> 16usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "DAC0 (Reserved)."]
+    #[doc = "DAC0."]
     #[inline(always)]
     pub const fn set_dac0(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
     }
-    #[doc = "DAC1 (Reserved)."]
+    #[doc = "DAC1."]
     #[must_use]
     #[inline(always)]
     pub const fn dac1(&self) -> Rule {
         let val = (self.0 >> 20usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "DAC1 (Reserved)."]
+    #[doc = "DAC1."]
     #[inline(always)]
     pub const fn set_dac1(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
     }
-    #[doc = "DAC2 (Reserved)."]
-    #[must_use]
+}
+impl Default for AipsBridgeGroup2memRule6 {
     #[inline(always)]
-    pub const fn dac2(&self) -> Rule {
-        let val = (self.0 >> 24usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "DAC2 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_dac2(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
-    }
-    #[doc = "OPAMP0 (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn opamp0(&self) -> Rule {
-        let val = (self.0 >> 28usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "OPAMP0 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_opamp0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
+    fn default() -> AipsBridgeGroup2memRule6 {
+        AipsBridgeGroup2memRule6(0)
     }
 }
-impl Default for AipsBridgeGroup2MemRule2 {
-    #[inline(always)]
-    fn default() -> AipsBridgeGroup2MemRule2 {
-        AipsBridgeGroup2MemRule2(0)
-    }
-}
-impl core::fmt::Debug for AipsBridgeGroup2MemRule2 {
+impl core::fmt::Debug for AipsBridgeGroup2memRule6 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AipsBridgeGroup2MemRule2")
+        f.debug_struct("AipsBridgeGroup2memRule6")
             .field("adc1", &self.adc1())
             .field("cmp0", &self.cmp0())
-            .field("cmp1", &self.cmp1())
-            .field("cmp2", &self.cmp2())
             .field("dac0", &self.dac0())
             .field("dac1", &self.dac1())
-            .field("dac2", &self.dac2())
-            .field("opamp0", &self.opamp0())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for AipsBridgeGroup2MemRule2 {
+impl defmt::Format for AipsBridgeGroup2memRule6 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "AipsBridgeGroup2MemRule2 {{ adc1: {:?}, cmp0: {:?}, cmp1: {:?}, cmp2: {:?}, dac0: {:?}, dac1: {:?}, dac2: {:?}, opamp0: {:?} }}",
+            "AipsBridgeGroup2memRule6 {{ adc1: {:?}, cmp0: {:?}, dac0: {:?}, dac1: {:?} }}",
             self.adc1(),
             self.cmp0(),
-            self.cmp1(),
-            self.cmp2(),
             self.dac0(),
-            self.dac1(),
-            self.dac2(),
-            self.opamp0()
+            self.dac1()
         )
     }
 }
-#[doc = "AIPS Bridge Group 2 Memory Rule 3."]
+#[doc = "AIPS Bridge Group 2 Rule 7."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AipsBridgeGroup2MemRule3(pub u32);
-impl AipsBridgeGroup2MemRule3 {
-    #[doc = "OPAMP1 (Reserved)."]
+pub struct AipsBridgeGroup2memRule7(pub u32);
+impl AipsBridgeGroup2memRule7 {
+    #[doc = "VREF0."]
     #[must_use]
     #[inline(always)]
-    pub const fn opamp1(&self) -> Rule {
-        let val = (self.0 >> 0usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "OPAMP1 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_opamp1(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
-    }
-    #[doc = "OPAMP2 (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn opamp2(&self) -> Rule {
-        let val = (self.0 >> 4usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "OPAMP2 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_opamp2(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
-    }
-    #[doc = "SD_ADC0 (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn sd_adc0(&self) -> Rule {
-        let val = (self.0 >> 8usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "SD_ADC0 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_sd_adc0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
-    }
-    #[doc = "DGO_GPIO1_3 (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn dgo_gpio1_3(&self) -> Rule {
+    pub const fn vref0(&self) -> Rule {
         let val = (self.0 >> 12usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "DGO_GPIO1_3 (Reserved)."]
+    #[doc = "VREF0."]
     #[inline(always)]
-    pub const fn set_dgo_gpio1_3(&mut self, val: Rule) {
+    pub const fn set_vref0(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
-    }
-    #[doc = "PORT1."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn port1(&self) -> Rule {
-        let val = (self.0 >> 16usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "PORT1."]
-    #[inline(always)]
-    pub const fn set_port1(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
-    }
-    #[doc = "PORT2."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn port2(&self) -> Rule {
-        let val = (self.0 >> 20usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "PORT2."]
-    #[inline(always)]
-    pub const fn set_port2(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
-    }
-    #[doc = "PORT3."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn port3(&self) -> Rule {
-        let val = (self.0 >> 24usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "PORT3."]
-    #[inline(always)]
-    pub const fn set_port3(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
-    }
-    #[doc = "PORT4 (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn port4(&self) -> Rule {
-        let val = (self.0 >> 28usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "PORT4 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_port4(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
-    }
-}
-impl Default for AipsBridgeGroup2MemRule3 {
-    #[inline(always)]
-    fn default() -> AipsBridgeGroup2MemRule3 {
-        AipsBridgeGroup2MemRule3(0)
-    }
-}
-impl core::fmt::Debug for AipsBridgeGroup2MemRule3 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AipsBridgeGroup2MemRule3")
-            .field("opamp1", &self.opamp1())
-            .field("opamp2", &self.opamp2())
-            .field("sd_adc0", &self.sd_adc0())
-            .field("dgo_gpio1_3", &self.dgo_gpio1_3())
-            .field("port1", &self.port1())
-            .field("port2", &self.port2())
-            .field("port3", &self.port3())
-            .field("port4", &self.port4())
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AipsBridgeGroup2MemRule3 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AipsBridgeGroup2MemRule3 {{ opamp1: {:?}, opamp2: {:?}, sd_adc0: {:?}, dgo_gpio1_3: {:?}, port1: {:?}, port2: {:?}, port3: {:?}, port4: {:?} }}",
-            self.opamp1(),
-            self.opamp2(),
-            self.sd_adc0(),
-            self.dgo_gpio1_3(),
-            self.port1(),
-            self.port2(),
-            self.port3(),
-            self.port4()
-        )
-    }
-}
-#[doc = "AIPS Bridge Group 3 Rule 0."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AipsBridgeGroup3MemRule0(pub u32);
-impl AipsBridgeGroup3MemRule0 {
-    #[doc = "PORT5 (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn port5(&self) -> Rule {
-        let val = (self.0 >> 0usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "PORT5 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_port5(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
-    }
-    #[doc = "SAI (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn sai(&self) -> Rule {
-        let val = (self.0 >> 4usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "SAI (Reserved)."]
-    #[inline(always)]
-    pub const fn set_sai(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
-    }
-    #[doc = "SEGMENT_LCD (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn segment_lcd(&self) -> Rule {
-        let val = (self.0 >> 8usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "SEGMENT_LCD (Reserved)."]
-    #[inline(always)]
-    pub const fn set_segment_lcd(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
-    }
-    #[doc = "TSI (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn tsi(&self) -> Rule {
-        let val = (self.0 >> 12usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "TSI (Reserved)."]
-    #[inline(always)]
-    pub const fn set_tsi(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
-    }
-    #[doc = "MU0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn mu0(&self) -> Rule {
-        let val = (self.0 >> 16usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "MU0."]
-    #[inline(always)]
-    pub const fn set_mu0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
-    }
-    #[doc = "MU1 (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn mu1(&self) -> Rule {
-        let val = (self.0 >> 20usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "MU1 (Reserved)."]
-    #[inline(always)]
-    pub const fn set_mu1(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
-    }
-}
-impl Default for AipsBridgeGroup3MemRule0 {
-    #[inline(always)]
-    fn default() -> AipsBridgeGroup3MemRule0 {
-        AipsBridgeGroup3MemRule0(0)
-    }
-}
-impl core::fmt::Debug for AipsBridgeGroup3MemRule0 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AipsBridgeGroup3MemRule0")
-            .field("port5", &self.port5())
-            .field("sai", &self.sai())
-            .field("segment_lcd", &self.segment_lcd())
-            .field("tsi", &self.tsi())
-            .field("mu0", &self.mu0())
-            .field("mu1", &self.mu1())
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AipsBridgeGroup3MemRule0 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AipsBridgeGroup3MemRule0 {{ port5: {:?}, sai: {:?}, segment_lcd: {:?}, tsi: {:?}, mu0: {:?}, mu1: {:?} }}",
-            self.port5(),
-            self.sai(),
-            self.segment_lcd(),
-            self.tsi(),
-            self.mu0(),
-            self.mu1()
-        )
-    }
-}
-#[doc = "AIPS Bridge Group 3 Rule 2."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AipsBridgeGroup3MemRule2(pub u32);
-impl AipsBridgeGroup3MemRule2 {
-    #[doc = "PKC0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn pkc0(&self) -> Rule {
-        let val = (self.0 >> 0usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "PKC0."]
-    #[inline(always)]
-    pub const fn set_pkc0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
-    }
-    #[doc = "SGI0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn sgi0(&self) -> Rule {
-        let val = (self.0 >> 4usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "SGI0."]
-    #[inline(always)]
-    pub const fn set_sgi0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
-    }
-    #[doc = "TRNG0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn trng0(&self) -> Rule {
-        let val = (self.0 >> 8usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "TRNG0."]
-    #[inline(always)]
-    pub const fn set_trng0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
-    }
-    #[doc = "CAN0 RULE0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn udf0(&self) -> Rule {
-        let val = (self.0 >> 12usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "CAN0 RULE0."]
-    #[inline(always)]
-    pub const fn set_udf0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
-    }
-    #[doc = "eDMA_1_MP."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn e_mda_1_mp(&self) -> Rule {
-        let val = (self.0 >> 28usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "eDMA_1_MP."]
-    #[inline(always)]
-    pub const fn set_e_mda_1_mp(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
-    }
-}
-impl Default for AipsBridgeGroup3MemRule2 {
-    #[inline(always)]
-    fn default() -> AipsBridgeGroup3MemRule2 {
-        AipsBridgeGroup3MemRule2(0)
-    }
-}
-impl core::fmt::Debug for AipsBridgeGroup3MemRule2 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AipsBridgeGroup3MemRule2")
-            .field("pkc0", &self.pkc0())
-            .field("sgi0", &self.sgi0())
-            .field("trng0", &self.trng0())
-            .field("udf0", &self.udf0())
-            .field("e_mda_1_mp", &self.e_mda_1_mp())
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AipsBridgeGroup3MemRule2 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AipsBridgeGroup3MemRule2 {{ pkc0: {:?}, sgi0: {:?}, trng0: {:?}, udf0: {:?}, e_mda_1_mp: {:?} }}",
-            self.pkc0(),
-            self.sgi0(),
-            self.trng0(),
-            self.udf0(),
-            self.e_mda_1_mp()
-        )
-    }
-}
-#[doc = "AIPS Bridge Group 3 Rule 3."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AipsBridgeGroup3MemRule3(pub u32);
-impl AipsBridgeGroup3MemRule3 {
-    #[doc = "eDMA_1_TCD0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn e_dma_1_tcd0(&self) -> Rule {
-        let val = (self.0 >> 0usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "eDMA_1_TCD0."]
-    #[inline(always)]
-    pub const fn set_e_dma_1_tcd0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
-    }
-    #[doc = "eDMA_1_TCD1."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn e_dma_1_tcd1(&self) -> Rule {
-        let val = (self.0 >> 4usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "eDMA_1_TCD1."]
-    #[inline(always)]
-    pub const fn set_e_dma_1_tcd1(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
-    }
-    #[doc = "eDMA_1_TCD2."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn e_dma_1_tcd2(&self) -> Rule {
-        let val = (self.0 >> 8usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "eDMA_1_TCD2."]
-    #[inline(always)]
-    pub const fn set_e_dma_1_tcd2(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
-    }
-    #[doc = "eDMA_1_TCD3."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn e_dma_1_tcd3(&self) -> Rule {
-        let val = (self.0 >> 12usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "eDMA_1_TCD3."]
-    #[inline(always)]
-    pub const fn set_e_dma_1_tcd3(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
-    }
-}
-impl Default for AipsBridgeGroup3MemRule3 {
-    #[inline(always)]
-    fn default() -> AipsBridgeGroup3MemRule3 {
-        AipsBridgeGroup3MemRule3(0)
-    }
-}
-impl core::fmt::Debug for AipsBridgeGroup3MemRule3 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AipsBridgeGroup3MemRule3")
-            .field("e_dma_1_tcd0", &self.e_dma_1_tcd0())
-            .field("e_dma_1_tcd1", &self.e_dma_1_tcd1())
-            .field("e_dma_1_tcd2", &self.e_dma_1_tcd2())
-            .field("e_dma_1_tcd3", &self.e_dma_1_tcd3())
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AipsBridgeGroup3MemRule3 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AipsBridgeGroup3MemRule3 {{ e_dma_1_tcd0: {:?}, e_dma_1_tcd1: {:?}, e_dma_1_tcd2: {:?}, e_dma_1_tcd3: {:?} }}",
-            self.e_dma_1_tcd0(),
-            self.e_dma_1_tcd1(),
-            self.e_dma_1_tcd2(),
-            self.e_dma_1_tcd3()
-        )
-    }
-}
-#[doc = "AON Domain Peripheral Rule 0."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AonDomainPeripheralMemRule0(pub u32);
-impl AonDomainPeripheralMemRule0 {
-    #[doc = "LPI2C."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn lpi2c(&self) -> Rule {
-        let val = (self.0 >> 0usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "LPI2C."]
-    #[inline(always)]
-    pub const fn set_lpi2c(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
-    }
-    #[doc = "LPI2C (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule1(&self) -> Rule {
-        let val = (self.0 >> 4usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "LPI2C (Reserved)."]
-    #[inline(always)]
-    pub const fn set_rule1(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
-    }
-    #[doc = "LPUART."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn lpuart(&self) -> Rule {
-        let val = (self.0 >> 8usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "LPUART."]
-    #[inline(always)]
-    pub const fn set_lpuart(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
-    }
-    #[doc = "LPUART (Reserved)."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule3(&self) -> Rule {
-        let val = (self.0 >> 12usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "LPUART (Reserved)."]
-    #[inline(always)]
-    pub const fn set_rule3(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
-    }
-    #[doc = "MUB."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn mub(&self) -> Rule {
-        let val = (self.0 >> 16usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "MUB."]
-    #[inline(always)]
-    pub const fn set_mub(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
     }
     #[doc = "PORT0."]
     #[must_use]
     #[inline(always)]
     pub const fn port0(&self) -> Rule {
-        let val = (self.0 >> 20usize) & 0x03;
+        let val = (self.0 >> 16usize) & 0x03;
         Rule::from_bits(val as u8)
     }
     #[doc = "PORT0."]
     #[inline(always)]
     pub const fn set_port0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
+    }
+    #[doc = "PORT1."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn port1(&self) -> Rule {
+        let val = (self.0 >> 20usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "PORT1."]
+    #[inline(always)]
+    pub const fn set_port1(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
     }
-    #[doc = "ACMP."]
+    #[doc = "PORT2."]
     #[must_use]
     #[inline(always)]
-    pub const fn acmp(&self) -> Rule {
+    pub const fn port2(&self) -> Rule {
         let val = (self.0 >> 24usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "ACMP."]
+    #[doc = "PORT2."]
     #[inline(always)]
-    pub const fn set_acmp(&mut self, val: Rule) {
+    pub const fn set_port2(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
     }
-    #[doc = "ACMP (Reserved)."]
+    #[doc = "PORT3."]
     #[must_use]
     #[inline(always)]
-    pub const fn rule7(&self) -> Rule {
+    pub const fn port3(&self) -> Rule {
         let val = (self.0 >> 28usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "ACMP (Reserved)."]
+    #[doc = "PORT3."]
     #[inline(always)]
-    pub const fn set_rule7(&mut self, val: Rule) {
+    pub const fn set_port3(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
     }
 }
-impl Default for AonDomainPeripheralMemRule0 {
+impl Default for AipsBridgeGroup2memRule7 {
     #[inline(always)]
-    fn default() -> AonDomainPeripheralMemRule0 {
-        AonDomainPeripheralMemRule0(0)
+    fn default() -> AipsBridgeGroup2memRule7 {
+        AipsBridgeGroup2memRule7(0)
     }
 }
-impl core::fmt::Debug for AonDomainPeripheralMemRule0 {
+impl core::fmt::Debug for AipsBridgeGroup2memRule7 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AonDomainPeripheralMemRule0")
-            .field("lpi2c", &self.lpi2c())
-            .field("rule1", &self.rule1())
-            .field("lpuart", &self.lpuart())
-            .field("rule3", &self.rule3())
-            .field("mub", &self.mub())
+        f.debug_struct("AipsBridgeGroup2memRule7")
+            .field("vref0", &self.vref0())
             .field("port0", &self.port0())
-            .field("acmp", &self.acmp())
-            .field("rule7", &self.rule7())
+            .field("port1", &self.port1())
+            .field("port2", &self.port2())
+            .field("port3", &self.port3())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for AonDomainPeripheralMemRule0 {
+impl defmt::Format for AipsBridgeGroup2memRule7 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "AonDomainPeripheralMemRule0 {{ lpi2c: {:?}, rule1: {:?}, lpuart: {:?}, rule3: {:?}, mub: {:?}, port0: {:?}, acmp: {:?}, rule7: {:?} }}",
-            self.lpi2c(),
-            self.rule1(),
-            self.lpuart(),
-            self.rule3(),
-            self.mub(),
+            "AipsBridgeGroup2memRule7 {{ vref0: {:?}, port0: {:?}, port1: {:?}, port2: {:?}, port3: {:?} }}",
+            self.vref0(),
             self.port0(),
-            self.acmp(),
-            self.rule7()
+            self.port1(),
+            self.port2(),
+            self.port3()
         )
     }
 }
-#[doc = "AON Domain Peripheral Rule 1."]
+#[doc = "AIPS Bridge Group 2 Rule 8."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AonDomainPeripheralMemRule1(pub u32);
-impl AonDomainPeripheralMemRule1 {
-    #[doc = "LPTIMER."]
+pub struct AipsBridgeGroup2memRule8(pub u32);
+impl AipsBridgeGroup2memRule8 {
+    #[doc = "PORT4."]
     #[must_use]
     #[inline(always)]
-    pub const fn lptimer(&self) -> Rule {
+    pub const fn port4(&self) -> Rule {
         let val = (self.0 >> 0usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "LPTIMER."]
+    #[doc = "PORT4."]
     #[inline(always)]
-    pub const fn set_lptimer(&mut self, val: Rule) {
+    pub const fn set_port4(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
     }
-    #[doc = "QTMR32_0."]
+    #[doc = "TSI0."]
     #[must_use]
     #[inline(always)]
-    pub const fn qtmr32_0(&self) -> Rule {
+    pub const fn tsi0(&self) -> Rule {
+        let val = (self.0 >> 12usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "TSI0."]
+    #[inline(always)]
+    pub const fn set_tsi0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
+    }
+    #[doc = "AOI0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn aoi0(&self) -> Rule {
+        let val = (self.0 >> 16usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "AOI0."]
+    #[inline(always)]
+    pub const fn set_aoi0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
+    }
+    #[doc = "CRC0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn crc0(&self) -> Rule {
+        let val = (self.0 >> 20usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "CRC0."]
+    #[inline(always)]
+    pub const fn set_crc0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
+    }
+    #[doc = "CMC."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn cmc(&self) -> Rule {
         let val = (self.0 >> 24usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "QTMR32_0."]
+    #[doc = "CMC."]
     #[inline(always)]
-    pub const fn set_qtmr32_0(&mut self, val: Rule) {
+    pub const fn set_cmc(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
     }
-    #[doc = "QTMR32_1."]
+    #[doc = "EIM."]
     #[must_use]
     #[inline(always)]
-    pub const fn qtmr32_1(&self) -> Rule {
+    pub const fn eim(&self) -> Rule {
         let val = (self.0 >> 28usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "QTMR32_1."]
+    #[doc = "EIM."]
     #[inline(always)]
-    pub const fn set_qtmr32_1(&mut self, val: Rule) {
+    pub const fn set_eim(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
     }
 }
-impl Default for AonDomainPeripheralMemRule1 {
+impl Default for AipsBridgeGroup2memRule8 {
     #[inline(always)]
-    fn default() -> AonDomainPeripheralMemRule1 {
-        AonDomainPeripheralMemRule1(0)
+    fn default() -> AipsBridgeGroup2memRule8 {
+        AipsBridgeGroup2memRule8(0)
     }
 }
-impl core::fmt::Debug for AonDomainPeripheralMemRule1 {
+impl core::fmt::Debug for AipsBridgeGroup2memRule8 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AonDomainPeripheralMemRule1")
-            .field("lptimer", &self.lptimer())
-            .field("qtmr32_0", &self.qtmr32_0())
-            .field("qtmr32_1", &self.qtmr32_1())
+        f.debug_struct("AipsBridgeGroup2memRule8")
+            .field("port4", &self.port4())
+            .field("tsi0", &self.tsi0())
+            .field("aoi0", &self.aoi0())
+            .field("crc0", &self.crc0())
+            .field("cmc", &self.cmc())
+            .field("eim", &self.eim())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for AonDomainPeripheralMemRule1 {
+impl defmt::Format for AipsBridgeGroup2memRule8 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "AonDomainPeripheralMemRule1 {{ lptimer: {:?}, qtmr32_0: {:?}, qtmr32_1: {:?} }}",
-            self.lptimer(),
-            self.qtmr32_0(),
-            self.qtmr32_1()
+            "AipsBridgeGroup2memRule8 {{ port4: {:?}, tsi0: {:?}, aoi0: {:?}, crc0: {:?}, cmc: {:?}, eim: {:?} }}",
+            self.port4(),
+            self.tsi0(),
+            self.aoi0(),
+            self.crc0(),
+            self.cmc(),
+            self.eim()
         )
     }
 }
-#[doc = "AON Domain Peripheral Rule 2."]
+#[doc = "AIPS Bridge Group 2 Rule 9."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AonDomainPeripheralMemRule2(pub u32);
-impl AonDomainPeripheralMemRule2 {
-    #[doc = "GP_GPR."]
+pub struct AipsBridgeGroup2memRule9(pub u32);
+impl AipsBridgeGroup2memRule9 {
+    #[doc = "ERM."]
     #[must_use]
     #[inline(always)]
-    pub const fn gp_gpr(&self) -> Rule {
+    pub const fn erm(&self) -> Rule {
         let val = (self.0 >> 0usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "GP_GPR."]
+    #[doc = "ERM."]
     #[inline(always)]
-    pub const fn set_gp_gpr(&mut self, val: Rule) {
+    pub const fn set_erm(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
     }
+    #[doc = "MBC."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn mbc(&self) -> Rule {
+        let val = (self.0 >> 4usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "MBC."]
+    #[inline(always)]
+    pub const fn set_mbc(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+    }
+    #[doc = "SCG."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn scg(&self) -> Rule {
+        let val = (self.0 >> 8usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "SCG."]
+    #[inline(always)]
+    pub const fn set_scg(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
+    }
+    #[doc = "SPC."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn spc(&self) -> Rule {
+        let val = (self.0 >> 12usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "SPC."]
+    #[inline(always)]
+    pub const fn set_spc(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
+    }
+    #[doc = "CAN0 Region 0."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn can0_region0(&self) -> Rule {
+        let val = (self.0 >> 16usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "CAN0 Region 0."]
+    #[inline(always)]
+    pub const fn set_can0_region0(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
+    }
+    #[doc = "CAN0 Region 1."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn can0_region1(&self) -> Rule {
+        let val = (self.0 >> 20usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "CAN0 Region 1."]
+    #[inline(always)]
+    pub const fn set_can0_region1(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
+    }
+    #[doc = "CAN0 Region 2."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn can0_region2(&self) -> Rule {
+        let val = (self.0 >> 24usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "CAN0 Region 2."]
+    #[inline(always)]
+    pub const fn set_can0_region2(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
+    }
+    #[doc = "CAN0 Region 3."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn can0_region3(&self) -> Rule {
+        let val = (self.0 >> 28usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "CAN0 Region 3."]
+    #[inline(always)]
+    pub const fn set_can0_region3(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
+    }
+}
+impl Default for AipsBridgeGroup2memRule9 {
+    #[inline(always)]
+    fn default() -> AipsBridgeGroup2memRule9 {
+        AipsBridgeGroup2memRule9(0)
+    }
+}
+impl core::fmt::Debug for AipsBridgeGroup2memRule9 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AipsBridgeGroup2memRule9")
+            .field("erm", &self.erm())
+            .field("mbc", &self.mbc())
+            .field("scg", &self.scg())
+            .field("spc", &self.spc())
+            .field("can0_region0", &self.can0_region0())
+            .field("can0_region1", &self.can0_region1())
+            .field("can0_region2", &self.can0_region2())
+            .field("can0_region3", &self.can0_region3())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AipsBridgeGroup2memRule9 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "AipsBridgeGroup2memRule9 {{ erm: {:?}, mbc: {:?}, scg: {:?}, spc: {:?}, can0_region0: {:?}, can0_region1: {:?}, can0_region2: {:?}, can0_region3: {:?} }}",
+            self.erm(),
+            self.mbc(),
+            self.scg(),
+            self.spc(),
+            self.can0_region0(),
+            self.can0_region1(),
+            self.can0_region2(),
+            self.can0_region3()
+        )
+    }
+}
+#[doc = "APB Bridge Group 0 Memory Rule Register 0."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ApbPeripheralGroup0memRule0(pub u32);
+impl ApbPeripheralGroup0memRule0 {
     #[doc = "INPUTMUX."]
     #[must_use]
     #[inline(always)]
@@ -2618,260 +2621,29 @@ impl AonDomainPeripheralMemRule2 {
     pub const fn set_inputmux(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
     }
-    #[doc = "LPADC."]
+    #[doc = "I3C0."]
     #[must_use]
     #[inline(always)]
-    pub const fn lpadc(&self) -> Rule {
+    pub const fn i3c0(&self) -> Rule {
         let val = (self.0 >> 8usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "LPADC."]
+    #[doc = "I3C0."]
     #[inline(always)]
-    pub const fn set_lpadc(&mut self, val: Rule) {
+    pub const fn set_i3c0(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
     }
-    #[doc = "SGLCD0."]
+    #[doc = "I3C1."]
     #[must_use]
     #[inline(always)]
-    pub const fn sglcd(&self) -> Rule {
-        let val = (self.0 >> 16usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "SGLCD0."]
-    #[inline(always)]
-    pub const fn set_sglcd(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
-    }
-    #[doc = "KPP."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn kpp(&self) -> Rule {
-        let val = (self.0 >> 20usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "KPP."]
-    #[inline(always)]
-    pub const fn set_kpp(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
-    }
-    #[doc = "KPP."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn advc2(&self) -> Rule {
-        let val = (self.0 >> 28usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "KPP."]
-    #[inline(always)]
-    pub const fn set_advc2(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
-    }
-}
-impl Default for AonDomainPeripheralMemRule2 {
-    #[inline(always)]
-    fn default() -> AonDomainPeripheralMemRule2 {
-        AonDomainPeripheralMemRule2(0)
-    }
-}
-impl core::fmt::Debug for AonDomainPeripheralMemRule2 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AonDomainPeripheralMemRule2")
-            .field("gp_gpr", &self.gp_gpr())
-            .field("inputmux", &self.inputmux())
-            .field("lpadc", &self.lpadc())
-            .field("sglcd", &self.sglcd())
-            .field("kpp", &self.kpp())
-            .field("advc2", &self.advc2())
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AonDomainPeripheralMemRule2 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AonDomainPeripheralMemRule2 {{ gp_gpr: {:?}, inputmux: {:?}, lpadc: {:?}, sglcd: {:?}, kpp: {:?}, advc2: {:?} }}",
-            self.gp_gpr(),
-            self.inputmux(),
-            self.lpadc(),
-            self.sglcd(),
-            self.kpp(),
-            self.advc2()
-        )
-    }
-}
-#[doc = "AON Domain Peripheral Rule 3."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AonDomainPeripheralMemRule3(pub u32);
-impl AonDomainPeripheralMemRule3 {
-    #[doc = "PMIC_CTRL."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn pmic_ctrl(&self) -> Rule {
-        let val = (self.0 >> 0usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "PMIC_CTRL."]
-    #[inline(always)]
-    pub const fn set_pmic_ctrl(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
-    }
-    #[doc = "CGU."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn cgu(&self) -> Rule {
-        let val = (self.0 >> 4usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "CGU."]
-    #[inline(always)]
-    pub const fn set_cgu(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
-    }
-    #[doc = "SMM."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn smm(&self) -> Rule {
-        let val = (self.0 >> 8usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "SMM."]
-    #[inline(always)]
-    pub const fn set_smm(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
-    }
-    #[doc = "LPCMP."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn lpcmp(&self) -> Rule {
+    pub const fn i3c1(&self) -> Rule {
         let val = (self.0 >> 12usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "LPCMP."]
+    #[doc = "I3C1."]
     #[inline(always)]
-    pub const fn set_lpcmp(&mut self, val: Rule) {
+    pub const fn set_i3c1(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
-    }
-    #[doc = "AON_GPIO."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn aon_gpio(&self) -> Rule {
-        let val = (self.0 >> 28usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "AON_GPIO."]
-    #[inline(always)]
-    pub const fn set_aon_gpio(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
-    }
-}
-impl Default for AonDomainPeripheralMemRule3 {
-    #[inline(always)]
-    fn default() -> AonDomainPeripheralMemRule3 {
-        AonDomainPeripheralMemRule3(0)
-    }
-}
-impl core::fmt::Debug for AonDomainPeripheralMemRule3 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AonDomainPeripheralMemRule3")
-            .field("pmic_ctrl", &self.pmic_ctrl())
-            .field("cgu", &self.cgu())
-            .field("smm", &self.smm())
-            .field("lpcmp", &self.lpcmp())
-            .field("aon_gpio", &self.aon_gpio())
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AonDomainPeripheralMemRule3 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AonDomainPeripheralMemRule3 {{ pmic_ctrl: {:?}, cgu: {:?}, smm: {:?}, lpcmp: {:?}, aon_gpio: {:?} }}",
-            self.pmic_ctrl(),
-            self.cgu(),
-            self.smm(),
-            self.lpcmp(),
-            self.aon_gpio()
-        )
-    }
-}
-#[doc = "AON Domain SRAM Memory Rule."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct AonDomainSramMemRule0(pub u32);
-impl AonDomainSramMemRule0 {
-    #[doc = "Rule 0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        let val = (self.0 >> offs) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "Rule 0."]
-    #[inline(always)]
-    pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
-    }
-}
-impl Default for AonDomainSramMemRule0 {
-    #[inline(always)]
-    fn default() -> AonDomainSramMemRule0 {
-        AonDomainSramMemRule0(0)
-    }
-}
-impl core::fmt::Debug for AonDomainSramMemRule0 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("AonDomainSramMemRule0")
-            .field("rule[0]", &self.rule(0usize))
-            .field("rule[1]", &self.rule(1usize))
-            .field("rule[2]", &self.rule(2usize))
-            .field("rule[3]", &self.rule(3usize))
-            .field("rule[4]", &self.rule(4usize))
-            .field("rule[5]", &self.rule(5usize))
-            .field("rule[6]", &self.rule(6usize))
-            .field("rule[7]", &self.rule(7usize))
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for AonDomainSramMemRule0 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "AonDomainSramMemRule0 {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?}, rule[4]: {:?}, rule[5]: {:?}, rule[6]: {:?}, rule[7]: {:?} }}",
-            self.rule(0usize),
-            self.rule(1usize),
-            self.rule(2usize),
-            self.rule(3usize),
-            self.rule(4usize),
-            self.rule(5usize),
-            self.rule(6usize),
-            self.rule(7usize)
-        )
-    }
-}
-#[doc = "APB Bridge Group 0 Memory Rule 0."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct ApbPeripheralGroup0MemRule0(pub u32);
-impl ApbPeripheralGroup0MemRule0 {
-    #[doc = "INPUTMUX0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn inputmux0(&self) -> Rule {
-        let val = (self.0 >> 4usize) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "INPUTMUX0."]
-    #[inline(always)]
-    pub const fn set_inputmux0(&mut self, val: Rule) {
-        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
     }
     #[doc = "CTIMER0."]
     #[must_use]
@@ -2909,63 +2681,93 @@ impl ApbPeripheralGroup0MemRule0 {
     pub const fn set_ctimer2(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
     }
-}
-impl Default for ApbPeripheralGroup0MemRule0 {
+    #[doc = "CTIMER3."]
+    #[must_use]
     #[inline(always)]
-    fn default() -> ApbPeripheralGroup0MemRule0 {
-        ApbPeripheralGroup0MemRule0(0)
+    pub const fn ctimer3(&self) -> Rule {
+        let val = (self.0 >> 28usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "CTIMER3."]
+    #[inline(always)]
+    pub const fn set_ctimer3(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 28usize)) | (((val.to_bits() as u32) & 0x03) << 28usize);
     }
 }
-impl core::fmt::Debug for ApbPeripheralGroup0MemRule0 {
+impl Default for ApbPeripheralGroup0memRule0 {
+    #[inline(always)]
+    fn default() -> ApbPeripheralGroup0memRule0 {
+        ApbPeripheralGroup0memRule0(0)
+    }
+}
+impl core::fmt::Debug for ApbPeripheralGroup0memRule0 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("ApbPeripheralGroup0MemRule0")
-            .field("inputmux0", &self.inputmux0())
+        f.debug_struct("ApbPeripheralGroup0memRule0")
+            .field("inputmux", &self.inputmux())
+            .field("i3c0", &self.i3c0())
+            .field("i3c1", &self.i3c1())
             .field("ctimer0", &self.ctimer0())
             .field("ctimer1", &self.ctimer1())
             .field("ctimer2", &self.ctimer2())
+            .field("ctimer3", &self.ctimer3())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for ApbPeripheralGroup0MemRule0 {
+impl defmt::Format for ApbPeripheralGroup0memRule0 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "ApbPeripheralGroup0MemRule0 {{ inputmux0: {:?}, ctimer0: {:?}, ctimer1: {:?}, ctimer2: {:?} }}",
-            self.inputmux0(),
+            "ApbPeripheralGroup0memRule0 {{ inputmux: {:?}, i3c0: {:?}, i3c1: {:?}, ctimer0: {:?}, ctimer1: {:?}, ctimer2: {:?}, ctimer3: {:?} }}",
+            self.inputmux(),
+            self.i3c0(),
+            self.i3c1(),
             self.ctimer0(),
             self.ctimer1(),
-            self.ctimer2()
+            self.ctimer2(),
+            self.ctimer3()
         )
     }
 }
-#[doc = "APB Bridge Group 0 Memory Rule 1."]
+#[doc = "APB Bridge Group 0 Memory Rule Register 1."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct ApbPeripheralGroup0MemRule1(pub u32);
-impl ApbPeripheralGroup0MemRule1 {
-    #[doc = "FREQME00."]
+pub struct ApbPeripheralGroup0memRule1(pub u32);
+impl ApbPeripheralGroup0memRule1 {
+    #[doc = "CTIMER4."]
     #[must_use]
     #[inline(always)]
-    pub const fn freqme00(&self) -> Rule {
+    pub const fn ctimer4(&self) -> Rule {
+        let val = (self.0 >> 0usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "CTIMER4."]
+    #[inline(always)]
+    pub const fn set_ctimer4(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
+    }
+    #[doc = "FREQME."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn freqme(&self) -> Rule {
         let val = (self.0 >> 4usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "FREQME00."]
+    #[doc = "FREQME."]
     #[inline(always)]
-    pub const fn set_freqme00(&mut self, val: Rule) {
+    pub const fn set_freqme(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
     }
-    #[doc = "UTICK0."]
+    #[doc = "UTCIK0."]
     #[must_use]
     #[inline(always)]
-    pub const fn utick0(&self) -> Rule {
+    pub const fn utick(&self) -> Rule {
         let val = (self.0 >> 12usize) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "UTICK0."]
+    #[doc = "UTCIK0."]
     #[inline(always)]
-    pub const fn set_utick0(&mut self, val: Rule) {
+    pub const fn set_utick(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 12usize)) | (((val.to_bits() as u32) & 0x03) << 12usize);
     }
     #[doc = "WWDT0."]
@@ -2980,39 +2782,69 @@ impl ApbPeripheralGroup0MemRule1 {
     pub const fn set_wwdt0(&mut self, val: Rule) {
         self.0 = (self.0 & !(0x03 << 16usize)) | (((val.to_bits() as u32) & 0x03) << 16usize);
     }
-}
-impl Default for ApbPeripheralGroup0MemRule1 {
+    #[doc = "WWDT1."]
+    #[must_use]
     #[inline(always)]
-    fn default() -> ApbPeripheralGroup0MemRule1 {
-        ApbPeripheralGroup0MemRule1(0)
+    pub const fn wwdt1(&self) -> Rule {
+        let val = (self.0 >> 20usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "WWDT1."]
+    #[inline(always)]
+    pub const fn set_wwdt1(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
+    }
+    #[doc = "SmartDMA."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn smartdma(&self) -> Rule {
+        let val = (self.0 >> 24usize) & 0x03;
+        Rule::from_bits(val as u8)
+    }
+    #[doc = "SmartDMA."]
+    #[inline(always)]
+    pub const fn set_smartdma(&mut self, val: Rule) {
+        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
     }
 }
-impl core::fmt::Debug for ApbPeripheralGroup0MemRule1 {
+impl Default for ApbPeripheralGroup0memRule1 {
+    #[inline(always)]
+    fn default() -> ApbPeripheralGroup0memRule1 {
+        ApbPeripheralGroup0memRule1(0)
+    }
+}
+impl core::fmt::Debug for ApbPeripheralGroup0memRule1 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("ApbPeripheralGroup0MemRule1")
-            .field("freqme00", &self.freqme00())
-            .field("utick0", &self.utick0())
+        f.debug_struct("ApbPeripheralGroup0memRule1")
+            .field("ctimer4", &self.ctimer4())
+            .field("freqme", &self.freqme())
+            .field("utick", &self.utick())
             .field("wwdt0", &self.wwdt0())
+            .field("wwdt1", &self.wwdt1())
+            .field("smartdma", &self.smartdma())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for ApbPeripheralGroup0MemRule1 {
+impl defmt::Format for ApbPeripheralGroup0memRule1 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "ApbPeripheralGroup0MemRule1 {{ freqme00: {:?}, utick0: {:?}, wwdt0: {:?} }}",
-            self.freqme00(),
-            self.utick0(),
-            self.wwdt0()
+            "ApbPeripheralGroup0memRule1 {{ ctimer4: {:?}, freqme: {:?}, utick: {:?}, wwdt0: {:?}, wwdt1: {:?}, smartdma: {:?} }}",
+            self.ctimer4(),
+            self.freqme(),
+            self.utick(),
+            self.wwdt0(),
+            self.wwdt1(),
+            self.smartdma()
         )
     }
 }
 #[doc = "Miscellaneous CPU0 Control Signals."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct Cpu0LockReg(pub u32);
-impl Cpu0LockReg {
+pub struct Cpu0lockReg(pub u32);
+impl Cpu0lockReg {
     #[doc = "LOCK_NS_VTOR."]
     #[must_use]
     #[inline(always)]
@@ -3074,15 +2906,15 @@ impl Cpu0LockReg {
         self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
     }
 }
-impl Default for Cpu0LockReg {
+impl Default for Cpu0lockReg {
     #[inline(always)]
-    fn default() -> Cpu0LockReg {
-        Cpu0LockReg(0)
+    fn default() -> Cpu0lockReg {
+        Cpu0lockReg(0)
     }
 }
-impl core::fmt::Debug for Cpu0LockReg {
+impl core::fmt::Debug for Cpu0lockReg {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("Cpu0LockReg")
+        f.debug_struct("Cpu0lockReg")
             .field("lock_ns_vtor", &self.lock_ns_vtor())
             .field("lock_ns_mpu", &self.lock_ns_mpu())
             .field("lock_s_vtaircr", &self.lock_s_vtaircr())
@@ -3092,11 +2924,11 @@ impl core::fmt::Debug for Cpu0LockReg {
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for Cpu0LockReg {
+impl defmt::Format for Cpu0lockReg {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "Cpu0LockReg {{ lock_ns_vtor: {:?}, lock_ns_mpu: {:?}, lock_s_vtaircr: {:?}, lock_s_mpu: {:?}, lock_sau: {:?} }}",
+            "Cpu0lockReg {{ lock_ns_vtor: {:?}, lock_ns_mpu: {:?}, lock_s_vtaircr: {:?}, lock_s_mpu: {:?}, lock_sau: {:?} }}",
             self.lock_ns_vtor(),
             self.lock_ns_mpu(),
             self.lock_s_vtaircr(),
@@ -3105,207 +2937,82 @@ impl defmt::Format for Cpu0LockReg {
         )
     }
 }
-#[doc = "Flash Memory Rule."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct Flash00MemRule(pub u32);
-impl Flash00MemRule {
-    #[doc = "Rule 0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        let val = (self.0 >> offs) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "Rule 0."]
-    #[inline(always)]
-    pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
-    }
-}
-impl Default for Flash00MemRule {
-    #[inline(always)]
-    fn default() -> Flash00MemRule {
-        Flash00MemRule(0)
-    }
-}
-impl core::fmt::Debug for Flash00MemRule {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("Flash00MemRule")
-            .field("rule[0]", &self.rule(0usize))
-            .field("rule[1]", &self.rule(1usize))
-            .field("rule[2]", &self.rule(2usize))
-            .field("rule[3]", &self.rule(3usize))
-            .field("rule[4]", &self.rule(4usize))
-            .field("rule[5]", &self.rule(5usize))
-            .field("rule[6]", &self.rule(6usize))
-            .field("rule[7]", &self.rule(7usize))
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for Flash00MemRule {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "Flash00MemRule {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?}, rule[4]: {:?}, rule[5]: {:?}, rule[6]: {:?}, rule[7]: {:?} }}",
-            self.rule(0usize),
-            self.rule(1usize),
-            self.rule(2usize),
-            self.rule(3usize),
-            self.rule(4usize),
-            self.rule(5usize),
-            self.rule(6usize),
-            self.rule(7usize)
-        )
-    }
-}
-#[doc = "Flash Memory Rule."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct Flash01MemRule0(pub u32);
-impl Flash01MemRule0 {
-    #[doc = "Rule 0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 4usize);
-        let offs = 0usize + n * 4usize;
-        let val = (self.0 >> offs) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "Rule 0."]
-    #[inline(always)]
-    pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 4usize);
-        let offs = 0usize + n * 4usize;
-        self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
-    }
-}
-impl Default for Flash01MemRule0 {
-    #[inline(always)]
-    fn default() -> Flash01MemRule0 {
-        Flash01MemRule0(0)
-    }
-}
-impl core::fmt::Debug for Flash01MemRule0 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("Flash01MemRule0")
-            .field("rule[0]", &self.rule(0usize))
-            .field("rule[1]", &self.rule(1usize))
-            .field("rule[2]", &self.rule(2usize))
-            .field("rule[3]", &self.rule(3usize))
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for Flash01MemRule0 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "Flash01MemRule0 {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?} }}",
-            self.rule(0usize),
-            self.rule(1usize),
-            self.rule(2usize),
-            self.rule(3usize)
-        )
-    }
-}
-#[doc = "Flash Memory Rule."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct Flash02MemRule0(pub u32);
-impl Flash02MemRule0 {
-    #[doc = "Rule 0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 4usize);
-        let offs = 0usize + n * 4usize;
-        let val = (self.0 >> offs) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "Rule 0."]
-    #[inline(always)]
-    pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 4usize);
-        let offs = 0usize + n * 4usize;
-        self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
-    }
-}
-impl Default for Flash02MemRule0 {
-    #[inline(always)]
-    fn default() -> Flash02MemRule0 {
-        Flash02MemRule0(0)
-    }
-}
-impl core::fmt::Debug for Flash02MemRule0 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("Flash02MemRule0")
-            .field("rule[0]", &self.rule(0usize))
-            .field("rule[1]", &self.rule(1usize))
-            .field("rule[2]", &self.rule(2usize))
-            .field("rule[3]", &self.rule(3usize))
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for Flash02MemRule0 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "Flash02MemRule0 {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?} }}",
-            self.rule(0usize),
-            self.rule(1usize),
-            self.rule(2usize),
-            self.rule(3usize)
-        )
-    }
-}
 #[doc = "Master Secure Level."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct MasterSecAntiPolReg(pub u32);
 impl MasterSecAntiPolReg {
-    #[doc = "DMA0."]
+    #[doc = "SMARTDMA Data."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn smartdma(&self) -> MasterSec {
+        let val = (self.0 >> 4usize) & 0x03;
+        MasterSec::from_bits(val as u8)
+    }
+    #[doc = "SMARTDMA Data."]
+    #[inline(always)]
+    pub const fn set_smartdma(&mut self, val: MasterSec) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+    }
+    #[doc = "eDMA0."]
     #[must_use]
     #[inline(always)]
     pub const fn dma0(&self) -> MasterSec {
-        let val = (self.0 >> 2usize) & 0x03;
+        let val = (self.0 >> 6usize) & 0x03;
         MasterSec::from_bits(val as u8)
     }
-    #[doc = "DMA0."]
+    #[doc = "eDMA0."]
     #[inline(always)]
     pub const fn set_dma0(&mut self, val: MasterSec) {
-        self.0 = (self.0 & !(0x03 << 2usize)) | (((val.to_bits() as u32) & 0x03) << 2usize);
+        self.0 = (self.0 & !(0x03 << 6usize)) | (((val.to_bits() as u32) & 0x03) << 6usize);
+    }
+    #[doc = "eDMA1."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma1(&self) -> MasterSec {
+        let val = (self.0 >> 8usize) & 0x03;
+        MasterSec::from_bits(val as u8)
+    }
+    #[doc = "eDMA1."]
+    #[inline(always)]
+    pub const fn set_dma1(&mut self, val: MasterSec) {
+        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
     }
     #[doc = "PKC."]
     #[must_use]
     #[inline(always)]
     pub const fn pkc(&self) -> MasterSec {
-        let val = (self.0 >> 4usize) & 0x03;
+        let val = (self.0 >> 10usize) & 0x03;
         MasterSec::from_bits(val as u8)
     }
     #[doc = "PKC."]
     #[inline(always)]
     pub const fn set_pkc(&mut self, val: MasterSec) {
-        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+        self.0 = (self.0 & !(0x03 << 10usize)) | (((val.to_bits() as u32) & 0x03) << 10usize);
     }
-    #[doc = "DMA1."]
+    #[doc = "ENET0."]
     #[must_use]
     #[inline(always)]
-    pub const fn dma1(&self) -> MasterSec {
-        let val = (self.0 >> 6usize) & 0x03;
+    pub const fn enet0(&self) -> MasterSec {
+        let val = (self.0 >> 24usize) & 0x03;
         MasterSec::from_bits(val as u8)
     }
-    #[doc = "DMA1."]
+    #[doc = "ENET0."]
     #[inline(always)]
-    pub const fn set_dma1(&mut self, val: MasterSec) {
-        self.0 = (self.0 & !(0x03 << 6usize)) | (((val.to_bits() as u32) & 0x03) << 6usize);
+    pub const fn set_enet0(&mut self, val: MasterSec) {
+        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
+    }
+    #[doc = "USB1."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn usb1(&self) -> MasterSec {
+        let val = (self.0 >> 26usize) & 0x03;
+        MasterSec::from_bits(val as u8)
+    }
+    #[doc = "USB1."]
+    #[inline(always)]
+    pub const fn set_usb1(&mut self, val: MasterSec) {
+        self.0 = (self.0 & !(0x03 << 26usize)) | (((val.to_bits() as u32) & 0x03) << 26usize);
     }
 }
 impl Default for MasterSecAntiPolReg {
@@ -3317,9 +3024,12 @@ impl Default for MasterSecAntiPolReg {
 impl core::fmt::Debug for MasterSecAntiPolReg {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("MasterSecAntiPolReg")
+            .field("smartdma", &self.smartdma())
             .field("dma0", &self.dma0())
-            .field("pkc", &self.pkc())
             .field("dma1", &self.dma1())
+            .field("pkc", &self.pkc())
+            .field("enet0", &self.enet0())
+            .field("usb1", &self.usb1())
             .finish()
     }
 }
@@ -3328,10 +3038,13 @@ impl defmt::Format for MasterSecAntiPolReg {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "MasterSecAntiPolReg {{ dma0: {:?}, pkc: {:?}, dma1: {:?} }}",
+            "MasterSecAntiPolReg {{ smartdma: {:?}, dma0: {:?}, dma1: {:?}, pkc: {:?}, enet0: {:?}, usb1: {:?} }}",
+            self.smartdma(),
             self.dma0(),
+            self.dma1(),
             self.pkc(),
-            self.dma1()
+            self.enet0(),
+            self.usb1()
         )
     }
 }
@@ -3340,41 +3053,77 @@ impl defmt::Format for MasterSecAntiPolReg {
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct MasterSecLevel(pub u32);
 impl MasterSecLevel {
-    #[doc = "DMA0."]
+    #[doc = "SMARTDMA Data."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn smartdma(&self) -> MasterSec {
+        let val = (self.0 >> 4usize) & 0x03;
+        MasterSec::from_bits(val as u8)
+    }
+    #[doc = "SMARTDMA Data."]
+    #[inline(always)]
+    pub const fn set_smartdma(&mut self, val: MasterSec) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+    }
+    #[doc = "eDMA0."]
     #[must_use]
     #[inline(always)]
     pub const fn dma0(&self) -> MasterSec {
-        let val = (self.0 >> 2usize) & 0x03;
+        let val = (self.0 >> 6usize) & 0x03;
         MasterSec::from_bits(val as u8)
     }
-    #[doc = "DMA0."]
+    #[doc = "eDMA0."]
     #[inline(always)]
     pub const fn set_dma0(&mut self, val: MasterSec) {
-        self.0 = (self.0 & !(0x03 << 2usize)) | (((val.to_bits() as u32) & 0x03) << 2usize);
+        self.0 = (self.0 & !(0x03 << 6usize)) | (((val.to_bits() as u32) & 0x03) << 6usize);
+    }
+    #[doc = "eDMA1."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn dma1(&self) -> MasterSec {
+        let val = (self.0 >> 8usize) & 0x03;
+        MasterSec::from_bits(val as u8)
+    }
+    #[doc = "eDMA1."]
+    #[inline(always)]
+    pub const fn set_dma1(&mut self, val: MasterSec) {
+        self.0 = (self.0 & !(0x03 << 8usize)) | (((val.to_bits() as u32) & 0x03) << 8usize);
     }
     #[doc = "PKC."]
     #[must_use]
     #[inline(always)]
     pub const fn pkc(&self) -> MasterSec {
-        let val = (self.0 >> 4usize) & 0x03;
+        let val = (self.0 >> 10usize) & 0x03;
         MasterSec::from_bits(val as u8)
     }
     #[doc = "PKC."]
     #[inline(always)]
     pub const fn set_pkc(&mut self, val: MasterSec) {
-        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+        self.0 = (self.0 & !(0x03 << 10usize)) | (((val.to_bits() as u32) & 0x03) << 10usize);
     }
-    #[doc = "DMA1."]
+    #[doc = "ENET0."]
     #[must_use]
     #[inline(always)]
-    pub const fn dma1(&self) -> MasterSec {
-        let val = (self.0 >> 6usize) & 0x03;
+    pub const fn enet0(&self) -> MasterSec {
+        let val = (self.0 >> 24usize) & 0x03;
         MasterSec::from_bits(val as u8)
     }
-    #[doc = "DMA1."]
+    #[doc = "ENET0."]
     #[inline(always)]
-    pub const fn set_dma1(&mut self, val: MasterSec) {
-        self.0 = (self.0 & !(0x03 << 6usize)) | (((val.to_bits() as u32) & 0x03) << 6usize);
+    pub const fn set_enet0(&mut self, val: MasterSec) {
+        self.0 = (self.0 & !(0x03 << 24usize)) | (((val.to_bits() as u32) & 0x03) << 24usize);
+    }
+    #[doc = "USB1."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn usb1(&self) -> MasterSec {
+        let val = (self.0 >> 26usize) & 0x03;
+        MasterSec::from_bits(val as u8)
+    }
+    #[doc = "USB1."]
+    #[inline(always)]
+    pub const fn set_usb1(&mut self, val: MasterSec) {
+        self.0 = (self.0 & !(0x03 << 26usize)) | (((val.to_bits() as u32) & 0x03) << 26usize);
     }
 }
 impl Default for MasterSecLevel {
@@ -3386,9 +3135,12 @@ impl Default for MasterSecLevel {
 impl core::fmt::Debug for MasterSecLevel {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("MasterSecLevel")
+            .field("smartdma", &self.smartdma())
             .field("dma0", &self.dma0())
-            .field("pkc", &self.pkc())
             .field("dma1", &self.dma1())
+            .field("pkc", &self.pkc())
+            .field("enet0", &self.enet0())
+            .field("usb1", &self.usb1())
             .finish()
     }
 }
@@ -3397,10 +3149,13 @@ impl defmt::Format for MasterSecLevel {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "MasterSecLevel {{ dma0: {:?}, pkc: {:?}, dma1: {:?} }}",
+            "MasterSecLevel {{ smartdma: {:?}, dma0: {:?}, dma1: {:?}, pkc: {:?}, enet0: {:?}, usb1: {:?} }}",
+            self.smartdma(),
             self.dma0(),
+            self.dma1(),
             self.pkc(),
-            self.dma1()
+            self.enet0(),
+            self.usb1()
         )
     }
 }
@@ -3654,70 +3409,62 @@ impl defmt::Format for MiscCtrlReg {
         )
     }
 }
-#[doc = "RAMA Memory Rule."]
+#[doc = "AHB Secure Control Peripheral Rule."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct RamMemRule(pub u32);
-impl RamMemRule {
-    #[doc = "Rule 0."]
+pub struct Rule4(pub u32);
+impl Rule4 {
+    #[doc = "AHBSC."]
     #[must_use]
     #[inline(always)]
     pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 8usize);
+        assert!(n < 4usize);
         let offs = 0usize + n * 4usize;
         let val = (self.0 >> offs) & 0x03;
         Rule::from_bits(val as u8)
     }
-    #[doc = "Rule 0."]
+    #[doc = "AHBSC."]
     #[inline(always)]
     pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 8usize);
+        assert!(n < 4usize);
         let offs = 0usize + n * 4usize;
         self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
     }
 }
-impl Default for RamMemRule {
+impl Default for Rule4 {
     #[inline(always)]
-    fn default() -> RamMemRule {
-        RamMemRule(0)
+    fn default() -> Rule4 {
+        Rule4(0)
     }
 }
-impl core::fmt::Debug for RamMemRule {
+impl core::fmt::Debug for Rule4 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("RamMemRule")
+        f.debug_struct("Rule4")
             .field("rule[0]", &self.rule(0usize))
             .field("rule[1]", &self.rule(1usize))
             .field("rule[2]", &self.rule(2usize))
             .field("rule[3]", &self.rule(3usize))
-            .field("rule[4]", &self.rule(4usize))
-            .field("rule[5]", &self.rule(5usize))
-            .field("rule[6]", &self.rule(6usize))
-            .field("rule[7]", &self.rule(7usize))
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for RamMemRule {
+impl defmt::Format for Rule4 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "RamMemRule {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?}, rule[4]: {:?}, rule[5]: {:?}, rule[6]: {:?}, rule[7]: {:?} }}",
+            "Rule4 {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?} }}",
             self.rule(0usize),
             self.rule(1usize),
             self.rule(2usize),
-            self.rule(3usize),
-            self.rule(4usize),
-            self.rule(5usize),
-            self.rule(6usize),
-            self.rule(7usize)
+            self.rule(3usize)
         )
     }
 }
-#[doc = "RAMX Memory Rule."]
+#[doc = "Flash Memory Rule."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct RamxMemRule0(pub u32);
-impl RamxMemRule0 {
+pub struct Rule8(pub u32);
+impl Rule8 {
     #[doc = "Rule 0."]
     #[must_use]
     #[inline(always)]
@@ -3735,15 +3482,15 @@ impl RamxMemRule0 {
         self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
     }
 }
-impl Default for RamxMemRule0 {
+impl Default for Rule8 {
     #[inline(always)]
-    fn default() -> RamxMemRule0 {
-        RamxMemRule0(0)
+    fn default() -> Rule8 {
+        Rule8(0)
     }
 }
-impl core::fmt::Debug for RamxMemRule0 {
+impl core::fmt::Debug for Rule8 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("RamxMemRule0")
+        f.debug_struct("Rule8")
             .field("rule[0]", &self.rule(0usize))
             .field("rule[1]", &self.rule(1usize))
             .field("rule[2]", &self.rule(2usize))
@@ -3756,70 +3503,11 @@ impl core::fmt::Debug for RamxMemRule0 {
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for RamxMemRule0 {
+impl defmt::Format for Rule8 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "RamxMemRule0 {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?}, rule[4]: {:?}, rule[5]: {:?}, rule[6]: {:?}, rule[7]: {:?} }}",
-            self.rule(0usize),
-            self.rule(1usize),
-            self.rule(2usize),
-            self.rule(3usize),
-            self.rule(4usize),
-            self.rule(5usize),
-            self.rule(6usize),
-            self.rule(7usize)
-        )
-    }
-}
-#[doc = "ROM Memory Rule."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct RomMemRule(pub u32);
-impl RomMemRule {
-    #[doc = "Rule 0."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn rule(&self, n: usize) -> Rule {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        let val = (self.0 >> offs) & 0x03;
-        Rule::from_bits(val as u8)
-    }
-    #[doc = "Rule 0."]
-    #[inline(always)]
-    pub const fn set_rule(&mut self, n: usize, val: Rule) {
-        assert!(n < 8usize);
-        let offs = 0usize + n * 4usize;
-        self.0 = (self.0 & !(0x03 << offs)) | (((val.to_bits() as u32) & 0x03) << offs);
-    }
-}
-impl Default for RomMemRule {
-    #[inline(always)]
-    fn default() -> RomMemRule {
-        RomMemRule(0)
-    }
-}
-impl core::fmt::Debug for RomMemRule {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("RomMemRule")
-            .field("rule[0]", &self.rule(0usize))
-            .field("rule[1]", &self.rule(1usize))
-            .field("rule[2]", &self.rule(2usize))
-            .field("rule[3]", &self.rule(3usize))
-            .field("rule[4]", &self.rule(4usize))
-            .field("rule[5]", &self.rule(5usize))
-            .field("rule[6]", &self.rule(6usize))
-            .field("rule[7]", &self.rule(7usize))
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for RomMemRule {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "RomMemRule {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?}, rule[4]: {:?}, rule[5]: {:?}, rule[6]: {:?}, rule[7]: {:?} }}",
+            "Rule8 {{ rule[0]: {:?}, rule[1]: {:?}, rule[2]: {:?}, rule[3]: {:?}, rule[4]: {:?}, rule[5]: {:?}, rule[6]: {:?}, rule[7]: {:?} }}",
             self.rule(0usize),
             self.rule(1usize),
             self.rule(2usize),
@@ -4293,13 +3981,13 @@ impl From<LockSau> for u8 {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MasterSec {
-    #[doc = "Secure and privileged Master."]
-    NonsecureNonprivMaster = 0x0,
-    #[doc = "Secure and non-privileged Master."]
-    NonsecurePrivMaster = 0x01,
-    #[doc = "Non-secure and privileged Master."]
-    SecureNonprivMaster = 0x02,
     #[doc = "Non-secure and non-privileged Master."]
+    NonsecureNonprivMaster = 0x0,
+    #[doc = "Non-secure and privileged Master."]
+    NonsecurePrivMaster = 0x01,
+    #[doc = "Secure and non-privileged Master."]
+    SecureNonprivMaster = 0x02,
+    #[doc = "Secure and privileged Master."]
     SecurePrivMaster = 0x03,
 }
 impl MasterSec {
@@ -4362,9 +4050,9 @@ impl From<MiscCtrlEnable> for u8 {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MiscCtrlRegDisableStrictMode {
     _RESERVED_0 = 0x0,
-    #[doc = "Master strict mode is disabled and can access memories and peripherals at the same level or below that level."]
+    #[doc = "Master can access memories and peripherals at the same level or below that level."]
     Ahbtm = 0x01,
-    #[doc = "Master strict mode is enabled and can access memories and peripherals at same level only."]
+    #[doc = "Master can access memories and peripherals at same level only."]
     Ahbsm1 = 0x02,
     _RESERVED_3 = 0x03,
 }
@@ -4559,25 +4247,30 @@ impl From<SecVioInfoDataAccess> for u8 {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SecVioInfoMaster {
-    #[doc = "M33 Code."]
+    #[doc = "CM33 Code."]
     Cpu0Code = 0x0,
-    #[doc = "M33 System."]
+    #[doc = "CM33 System."]
     Cpu0Sys = 0x01,
-    _RESERVED_2 = 0x02,
-    _RESERVED_3 = 0x03,
-    _RESERVED_4 = 0x04,
-    #[doc = "DMA0."]
-    Dma0 = 0x05,
-    _RESERVED_6 = 0x06,
-    #[doc = "DMA1."]
-    Dma1 = 0x07,
+    #[doc = "SMARTDMA Instruction."]
+    SdmaInstr = 0x02,
+    #[doc = "SMARTDMA Data."]
+    SdmaData = 0x03,
+    #[doc = "eDMA1."]
+    EDma1 = 0x04,
+    #[doc = "eDMA0."]
+    EDma0 = 0x05,
+    #[doc = "USB HS."]
+    UsbHs = 0x06,
+    _RESERVED_7 = 0x07,
     _RESERVED_8 = 0x08,
     _RESERVED_9 = 0x09,
-    _RESERVED_a = 0x0a,
+    #[doc = "eSPI."]
+    Espi = 0x0a,
     _RESERVED_b = 0x0b,
     #[doc = "PKC."]
     Pkc = 0x0c,
-    _RESERVED_d = 0x0d,
+    #[doc = "Ethernet."]
+    Enet = 0x0d,
     _RESERVED_e = 0x0e,
     _RESERVED_f = 0x0f,
     _RESERVED_10 = 0x10,


### PR DESCRIPTION
The current mcux-soc-svd contains a very incorrect version of the AHBSC for the MCXA577. Manually add our older version of the AHBSC from mcux-soc-svd @ 13bbf70.