### PR TITLE
Add gate metadata

### DIFF
--- a/data/metadata/MCXA2xx.json
+++ b/data/metadata/MCXA2xx.json
@@ -818,6 +818,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "AdcConfig"
+      },
       "dma_muxing": [
         {
           "signal": "ADC0FifoRequest",
@@ -1021,6 +1026,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "AdcConfig"
+      },
       "dma_muxing": [
         {
           "signal": "ADC1FifoRequest",
@@ -1392,7 +1402,11 @@
       "name": "CRC0",
       "address": "0x4008A000",
       "block": "mcxa/CRC",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc0",
+        "reset": "mrcc_glb_rst0"
+      }
     },
     {
       "name": "CTIMER0",
@@ -1840,6 +1854,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_cc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "CTimerConfig"
+      },
       "dma_muxing": [
         {
           "signal": "CTIMER0M0",
@@ -2239,6 +2258,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_cc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "CTimerConfig"
+      },
       "dma_muxing": [
         {
           "signal": "CTIMER1M0",
@@ -2654,6 +2678,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_cc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "CTimerConfig"
+      },
       "dma_muxing": [
         {
           "signal": "CTIMER2M0",
@@ -3065,6 +3094,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_cc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "CTimerConfig"
+      },
       "dma_muxing": [
         {
           "signal": "CTIMER3M0",
@@ -3472,6 +3506,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_cc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "CTimerConfig"
+      },
       "dma_muxing": [
         {
           "signal": "CTIMER4M0",
@@ -3555,7 +3594,11 @@
       "name": "DMA0",
       "address": "0x40080000",
       "block": "mcxa/DMA::DMA8",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0"
+      }
     },
     {
       "name": "EIM0",
@@ -5207,6 +5250,10 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc2",
+        "reset": "mrcc_glb_rst2"
+      },
       "dma_muxing": [
         {
           "signal": "GPIO0PinEvent0",
@@ -5428,6 +5475,10 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc2",
+        "reset": "mrcc_glb_rst2"
+      },
       "dma_muxing": [
         {
           "signal": "GPIO1PinEvent0",
@@ -5685,6 +5736,10 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc2",
+        "reset": "mrcc_glb_rst2"
+      },
       "dma_muxing": [
         {
           "signal": "GPIO2PinEvent0",
@@ -5987,6 +6042,10 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc2",
+        "reset": "mrcc_glb_rst2"
+      },
       "dma_muxing": [
         {
           "signal": "GPIO3PinEvent0",
@@ -6073,6 +6132,10 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc2",
+        "reset": "mrcc_glb_rst2"
+      },
       "dma_muxing": [
         {
           "signal": "GPIO4PinEvent0",
@@ -6134,6 +6197,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_cc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "I3cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "I3C0Rx",
@@ -6151,7 +6219,11 @@
       "name": "INPUTMUX0",
       "address": "0x40001000",
       "block": "mcxa/INPUTMUX",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc0",
+        "reset": "mrcc_glb_rst0"
+      }
     },
     {
       "name": "ISPMODE",
@@ -6230,6 +6302,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "Lpi2cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPI2C0Rx",
@@ -6301,6 +6378,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "Lpi2cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPI2C1Rx",
@@ -6381,6 +6463,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "Lpi2cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPI2C2Rx",
@@ -6453,6 +6540,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "Lpi2cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPI2C3Rx",
@@ -6563,6 +6655,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "LpspiConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPSPI0Rx",
@@ -6677,6 +6774,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "LpspiConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPSPI1Rx",
@@ -6796,6 +6898,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "LpuartConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPUART0Rx",
@@ -6903,6 +7010,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "LpuartConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPUART1Rx",
@@ -7014,6 +7126,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "LpuartConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPUART2Rx",
@@ -7101,6 +7218,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "LpuartConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPUART3Rx",
@@ -7196,6 +7318,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "LpuartConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPUART4Rx",
@@ -7299,6 +7426,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "LpuartConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPUART5Rx",
@@ -7373,7 +7505,12 @@
       "name": "OSTIMER0",
       "address": "0x400AD000",
       "block": "mcxa/OSTIMER",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "OsTimerConfig"
+      }
     },
     {
       "name": "PKC0",
@@ -7385,31 +7522,51 @@
       "name": "PORT0",
       "address": "0x400BC000",
       "block": "mcxa/PORT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1"
+      }
     },
     {
       "name": "PORT1",
       "address": "0x400BD000",
       "block": "mcxa/PORT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1"
+      }
     },
     {
       "name": "PORT2",
       "address": "0x400BE000",
       "block": "mcxa/PORT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1"
+      }
     },
     {
       "name": "PORT3",
       "address": "0x400BF000",
       "block": "mcxa/PORT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1"
+      }
     },
     {
       "name": "PORT4",
       "address": "0x400C0000",
       "block": "mcxa/PORT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1"
+      }
     },
     {
       "name": "EQDC0",
@@ -8768,7 +8925,11 @@
       "name": "TRNG0",
       "address": "0x400EC000",
       "block": "mcxa/TRNG",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1"
+      }
     },
     {
       "name": "UDF0",
@@ -9156,7 +9317,11 @@
       "name": "WWDT0",
       "address": "0x4000C000",
       "block": "mcxa/WWDT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "config": "Clk1MConfig"
+      }
     },
     {
       "name": "XTAL48M",

--- a/data/metadata/MCXA5xx.json
+++ b/data/metadata/MCXA5xx.json
@@ -951,6 +951,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "AdcConfig"
+      },
       "dma_muxing": [
         {
           "signal": "ADC0FifoRequest",
@@ -1145,6 +1150,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "AdcConfig"
+      },
       "dma_muxing": [
         {
           "signal": "ADC1FifoRequest",
@@ -1419,7 +1429,11 @@
       "name": "CRC0",
       "address": "0x400C5000",
       "block": "mcxa/CRC",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc0",
+        "reset": "mrcc_glb_rst0"
+      }
     },
     {
       "name": "CTIMER0",
@@ -1891,6 +1905,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "CTimerConfig"
+      },
       "dma_muxing": [
         {
           "signal": "CTIMER0M0",
@@ -2314,6 +2333,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "CTimerConfig"
+      },
       "dma_muxing": [
         {
           "signal": "CTIMER1M0",
@@ -2753,6 +2777,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "CTimerConfig"
+      },
       "dma_muxing": [
         {
           "signal": "CTIMER2M0",
@@ -3196,6 +3225,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "CTimerConfig"
+      },
       "dma_muxing": [
         {
           "signal": "CTIMER3M0",
@@ -3627,6 +3661,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "CTimerConfig"
+      },
       "dma_muxing": [
         {
           "signal": "CTIMER4M0",
@@ -3734,13 +3773,21 @@
       "name": "DMA0",
       "address": "0x40080000",
       "block": "mcxa/DMA::DMA12",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0"
+      }
     },
     {
       "name": "DMA1",
       "address": "0x40013000",
       "block": "mcxa/DMA::DMA4",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0"
+      }
     },
     {
       "name": "EIM0",
@@ -5091,6 +5138,10 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc3",
+        "reset": "mrcc_glb_rst3"
+      },
       "dma_muxing": [
         {
           "signal": "GPIO0PinEvent0",
@@ -5312,6 +5363,10 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc3",
+        "reset": "mrcc_glb_rst3"
+      },
       "dma_muxing": [
         {
           "signal": "GPIO1PinEvent0",
@@ -5605,6 +5660,10 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc3",
+        "reset": "mrcc_glb_rst3"
+      },
       "dma_muxing": [
         {
           "signal": "GPIO2PinEvent0",
@@ -5871,6 +5930,10 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc3",
+        "reset": "mrcc_glb_rst3"
+      },
       "dma_muxing": [
         {
           "signal": "GPIO3PinEvent0",
@@ -6011,6 +6074,10 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc3",
+        "reset": "mrcc_glb_rst3"
+      },
       "dma_muxing": [
         {
           "signal": "GPIO4PinEvent0",
@@ -6115,6 +6182,9 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_cc3"
+      },
       "dma_muxing": [
         {
           "signal": "GPIO5PinEvent0",
@@ -6168,6 +6238,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc2",
+        "reset": "mrcc_glb_rst2",
+        "config": "I3cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "I3C0Rx",
@@ -6261,6 +6336,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc2",
+        "reset": "mrcc_glb_rst2",
+        "config": "I3cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "I3C1Rx",
@@ -6319,6 +6399,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc2",
+        "reset": "mrcc_glb_rst2",
+        "config": "I3cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "I3C2Rx",
@@ -6377,6 +6462,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc2",
+        "reset": "mrcc_glb_rst2",
+        "config": "I3cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "I3C3Rx",
@@ -6394,7 +6484,11 @@
       "name": "INPUTMUX0",
       "address": "0x40001000",
       "block": "mcxa/INPUTMUX",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc0",
+        "reset": "mrcc_glb_rst0"
+      }
     },
     {
       "name": "ISPMODE",
@@ -6490,6 +6584,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "Lpi2cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPI2C0Rx",
@@ -6561,6 +6660,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "Lpi2cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPI2C1Rx",
@@ -6641,6 +6745,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "Lpi2cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPI2C2Rx",
@@ -6749,6 +6858,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "Lpi2cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPI2C3Rx",
@@ -6865,6 +6979,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "Lpi2cConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPI2C4Rx",
@@ -6975,6 +7094,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "LpspiConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPSPI0Rx",
@@ -7089,6 +7213,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "LpspiConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPSPI1Rx",
@@ -7199,6 +7328,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "LpspiConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPSPI2Rx",
@@ -7337,6 +7471,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "LpspiConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPSPI3Rx",
@@ -7447,6 +7586,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "LpspiConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPSPI4Rx",
@@ -7557,6 +7701,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc1",
+        "reset": "mrcc_glb_rst1",
+        "config": "LpspiConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPSPI5Rx",
@@ -7695,6 +7844,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "LpuartConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPUART0Rx",
@@ -7802,6 +7956,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "LpuartConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPUART1Rx",
@@ -7913,6 +8072,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "LpuartConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPUART2Rx",
@@ -8000,6 +8164,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "LpuartConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPUART3Rx",
@@ -8083,6 +8252,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "LpuartConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPUART4Rx",
@@ -8186,6 +8360,11 @@
           ]
         }
       ],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "LpuartConfig"
+      },
       "dma_muxing": [
         {
           "signal": "LPUART5Rx",
@@ -8208,7 +8387,12 @@
       "name": "OSTIMER0",
       "address": "0x400AD000",
       "block": "mcxa/OSTIMER",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc0",
+        "reset": "mrcc_glb_rst0",
+        "config": "OsTimerConfig"
+      }
     },
     {
       "name": "PF",
@@ -8341,37 +8525,60 @@
       "name": "PORT0",
       "address": "0x400BC000",
       "block": "mcxa/PORT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1"
+      }
     },
     {
       "name": "PORT1",
       "address": "0x400BD000",
       "block": "mcxa/PORT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1"
+      }
     },
     {
       "name": "PORT2",
       "address": "0x400BE000",
       "block": "mcxa/PORT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1"
+      }
     },
     {
       "name": "PORT3",
       "address": "0x400BF000",
       "block": "mcxa/PORT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1"
+      }
     },
     {
       "name": "PORT4",
       "address": "0x400C0000",
       "block": "mcxa/PORT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc1",
+        "reset": "mrcc_glb_rst1"
+      }
     },
     {
       "name": "PORT5",
       "address": "0x400E3000",
       "block": "mcxa/PORT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_cc1"
+      }
     },
     {
       "name": "RESET",
@@ -9392,7 +9599,11 @@
       "name": "TRNG0",
       "address": "0x400EC000",
       "block": "mcxa/TRNG",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_acc4",
+        "reset": "mrcc_glb_rst4"
+      }
     },
     {
       "name": "TSI0",
@@ -10708,13 +10919,21 @@
       "name": "WWDT0",
       "address": "0x4000C000",
       "block": "mcxa/WWDT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "config": "Clk1MConfig"
+      }
     },
     {
       "name": "WWDT1",
       "address": "0x4000D000",
       "block": "mcxa/WWDT",
-      "signals": []
+      "signals": [],
+      "gate": {
+        "enable": "mrcc_glb_acc0",
+        "config": "Clk1MConfig"
+      }
     },
     {
       "name": "XTAL32K",

--- a/data/metadata/schema.json
+++ b/data/metadata/schema.json
@@ -145,15 +145,13 @@
               "description": "The name of the register that resets the peripheral",
               "type": "string"
             },
-            "bit": {
-              "description": "The name of the bit that's relevant for this peripheral in the specified registers",
+            "config": {
+              "description": "The name of the config type used for setting up the clocks",
               "type": "string"
             }
           },
           "required": [
-            "enable",
-            "reset",
-            "bit"
+            "enable"
           ]
         }
       },

--- a/data/metadata/schema.json
+++ b/data/metadata/schema.json
@@ -132,6 +132,29 @@
         "only_in": {
           "description": "A regular expression to specify which chips this peripheral is available for. This can be used to define a superset chip and share most mappings with subset chips",
           "type": "string"
+        },
+        "gate": {
+          "description": "Clock & reset control for the peripheral",
+          "type": "object",
+          "properties": {
+            "enable": {
+              "description": "The name of the register that gates/enables the clock to the peripheral",
+              "type": "string"
+            },
+            "reset": {
+              "description": "The name of the register that resets the peripheral",
+              "type": "string"
+            },
+            "bit": {
+              "description": "The name of the bit that's relevant for this peripheral in the specified registers",
+              "type": "string"
+            }
+          },
+          "required": [
+            "enable",
+            "reset",
+            "bit"
+          ]
         }
       },
       "required": [

--- a/generator/src/commands/generate.rs
+++ b/generator/src/commands/generate.rs
@@ -66,17 +66,22 @@ fn generate_chip(current_dir: &Path, feature: &ChipDescription) -> anyhow::Resul
     for core in feature.cores {
         let chips_dir = pac_dir.join("src").join("chips");
 
+        let metadata = match feature.metadata {
+            Some(metadata_file) => Some(
+                crate::metadata::generate(
+                    &chips_dir,
+                    &metadata_dir.join(metadata_file).with_extension("json"),
+                    core,
+                )
+                .context("Generating metadata")?,
+            ),
+            None => None,
+        };
+
         if feature.metapac {
-            let Some(metadata_file) = feature.metadata else {
+            let Some(metadata) = metadata else {
                 bail!("Metadata should not be empty when using metapac");
             };
-
-            let metadata = crate::metadata::generate(
-                &chips_dir,
-                &metadata_dir.join(metadata_file).with_extension("json"),
-                core,
-            )
-            .context("Generating metadata")?;
 
             crate::metapac::generate_core(current_dir, core, metadata)
                 .context(format!("Assembling metapac for {core}"))?

--- a/generator/src/metadata.rs
+++ b/generator/src/metadata.rs
@@ -63,6 +63,7 @@ pub struct Peripheral {
     #[serde(default)]
     pub dma_muxing: Vec<DmaMux>,
     pub only_in: Option<String>,
+    pub gate: Option<Gate>,
 }
 
 impl Peripheral {
@@ -128,6 +129,13 @@ pub struct DmaMux {
     pub signal: String,
     pub mux: String,
     pub request: u8,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Gate {
+    pub enable: String,
+    pub reset: String,
+    pub bit: String,
 }
 
 fn generate_metadata(name: &str, metadata: &Metadata) -> TokenStream {
@@ -247,6 +255,19 @@ fn generate_metadata(name: &str, metadata: &Metadata) -> TokenStream {
 
         let driver_name = peripheral.peripheral_block.as_deref().unwrap_or_default();
 
+        let gate = match peripheral.gate.as_ref() {
+            Some(Gate { enable, reset, bit }) => {
+                quote! {
+                    Some(Gate {
+                        enable: #enable,
+                        reset: #reset,
+                        bit: #bit,
+                    })
+                }
+            }
+            None => quote! { None },
+        };
+
         quote! {
             Peripheral {
                 name: #name,
@@ -255,6 +276,7 @@ fn generate_metadata(name: &str, metadata: &Metadata) -> TokenStream {
                 signals: &[#(#signals),*],
                 flexcomm: #flexcomm,
                 dma_muxing: &[#(#dma_muxing),*],
+                gate: #gate,
             }
         }
     });

--- a/generator/src/metadata.rs
+++ b/generator/src/metadata.rs
@@ -134,8 +134,8 @@ pub struct DmaMux {
 #[derive(Debug, Clone, Deserialize)]
 pub struct Gate {
     pub enable: String,
-    pub reset: String,
-    pub bit: String,
+    pub reset: Option<String>,
+    pub config: Option<String>,
 }
 
 fn generate_metadata(name: &str, metadata: &Metadata) -> TokenStream {
@@ -256,12 +256,25 @@ fn generate_metadata(name: &str, metadata: &Metadata) -> TokenStream {
         let driver_name = peripheral.peripheral_block.as_deref().unwrap_or_default();
 
         let gate = match peripheral.gate.as_ref() {
-            Some(Gate { enable, reset, bit }) => {
+            Some(Gate {
+                enable,
+                reset,
+                config,
+            }) => {
+                let reset = match reset {
+                    Some(reset) => quote! { Some(#reset) },
+                    None => quote! { None },
+                };
+                let config = match config {
+                    Some(config) => quote! { Some(#config) },
+                    None => quote! { None },
+                };
+
                 quote! {
                     Some(Gate {
                         enable: #enable,
                         reset: #reset,
-                        bit: #bit,
+                        config: #config,
                     })
                 }
             }

--- a/nxp-pac/src/chips/lpc55s16/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s16/metadata.rs
@@ -9,266 +9,332 @@ pub const PINS: &[Pin] = &[
     Pin {
         name: "PIO0_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_20",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_21",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_22",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_23",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_24",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_25",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_26",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_27",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_28",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_29",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_30",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_31",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_20",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_21",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_22",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_23",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_24",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_25",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_26",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_27",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_28",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_29",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_30",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_31",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "VREFP",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "VREFN",
         iomuxc: None,
+        feature: None,
     },
 ];
 pub const PERIPHERALS: &[Peripheral] = &[
@@ -395,6 +461,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO0",
@@ -692,6 +759,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO1",
@@ -989,6 +1057,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM0",
@@ -997,6 +1066,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM1",
@@ -1005,6 +1075,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM2",
@@ -1013,6 +1084,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM3",
@@ -1021,6 +1093,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM4",
@@ -1029,6 +1102,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM5",
@@ -1037,6 +1111,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM6",
@@ -1045,6 +1120,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM7",
@@ -1053,6 +1129,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "USART0",
@@ -1168,6 +1245,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 5,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART1",
@@ -1206,6 +1284,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 7,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART2",
@@ -1244,6 +1323,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 11,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART3",
@@ -1282,6 +1362,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 9,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART4",
@@ -1320,6 +1401,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 13,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART5",
@@ -1358,6 +1440,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 15,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART6",
@@ -1396,6 +1479,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 17,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART7",
@@ -1434,6 +1518,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 19,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "SCT0",
@@ -1639,6 +1724,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[

--- a/nxp-pac/src/chips/lpc55s69_cm33_core0/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s69_cm33_core0/metadata.rs
@@ -9,266 +9,332 @@ pub const PINS: &[Pin] = &[
     Pin {
         name: "PIO0_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_20",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_21",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_22",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_23",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_24",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_25",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_26",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_27",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_28",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_29",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_30",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_31",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_20",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_21",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_22",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_23",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_24",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_25",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_26",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_27",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_28",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_29",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_30",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_31",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "VREFP",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "VREFN",
         iomuxc: None,
+        feature: None,
     },
 ];
 pub const PERIPHERALS: &[Peripheral] = &[
@@ -395,6 +461,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO0",
@@ -692,6 +759,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO1",
@@ -989,6 +1057,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM0",
@@ -997,6 +1066,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM1",
@@ -1005,6 +1075,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM2",
@@ -1013,6 +1084,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM3",
@@ -1021,6 +1093,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM4",
@@ -1029,6 +1102,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM5",
@@ -1037,6 +1111,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM6",
@@ -1045,6 +1120,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM7",
@@ -1053,6 +1129,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "USART0",
@@ -1091,6 +1168,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 5,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART1",
@@ -1129,6 +1207,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 7,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART2",
@@ -1167,6 +1246,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 11,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART3",
@@ -1205,6 +1285,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 9,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART4",
@@ -1243,6 +1324,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 13,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART5",
@@ -1281,6 +1363,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 15,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART6",
@@ -1319,6 +1402,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 17,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART7",
@@ -1357,9 +1441,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 19,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "SPI0",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1391,9 +1478,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM0"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI1",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1425,9 +1515,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM1"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI2",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1459,9 +1552,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM2"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI3",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1493,9 +1589,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM3"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI4",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1527,9 +1626,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM4"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI5",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1561,9 +1663,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM5"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI6",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1595,9 +1700,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM6"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI7",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1629,6 +1737,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM7"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SCT0",
@@ -1834,6 +1943,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[

--- a/nxp-pac/src/chips/lpc55s69_cm33_core1/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s69_cm33_core1/metadata.rs
@@ -9,266 +9,332 @@ pub const PINS: &[Pin] = &[
     Pin {
         name: "PIO0_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_20",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_21",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_22",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_23",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_24",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_25",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_26",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_27",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_28",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_29",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_30",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO0_31",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_0",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_1",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_2",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_3",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_4",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_5",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_6",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_7",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_8",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_9",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_10",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_11",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_12",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_13",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_14",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_15",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_16",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_17",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_18",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_19",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_20",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_21",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_22",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_23",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_24",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_25",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_26",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_27",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_28",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_29",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_30",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "PIO1_31",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "VREFP",
         iomuxc: None,
+        feature: None,
     },
     Pin {
         name: "VREFN",
         iomuxc: None,
+        feature: None,
     },
 ];
 pub const PERIPHERALS: &[Peripheral] = &[
@@ -395,6 +461,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO0",
@@ -692,6 +759,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO1",
@@ -989,6 +1057,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM0",
@@ -997,6 +1066,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM1",
@@ -1005,6 +1075,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM2",
@@ -1013,6 +1084,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM3",
@@ -1021,6 +1093,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM4",
@@ -1029,6 +1102,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM5",
@@ -1037,6 +1111,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM6",
@@ -1045,6 +1120,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXCOMM7",
@@ -1053,6 +1129,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "USART0",
@@ -1091,6 +1168,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 5,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART1",
@@ -1129,6 +1207,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 7,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART2",
@@ -1167,6 +1246,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 11,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART3",
@@ -1205,6 +1285,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 9,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART4",
@@ -1243,6 +1324,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 13,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART5",
@@ -1281,6 +1363,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 15,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART6",
@@ -1319,6 +1402,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 17,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "USART7",
@@ -1357,9 +1441,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 19,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "SPI0",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1391,9 +1478,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM0"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI1",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1425,9 +1515,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM1"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI2",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1459,9 +1552,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM2"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI3",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1493,9 +1589,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM3"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI4",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1527,9 +1626,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM4"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI5",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1561,9 +1663,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM5"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI6",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1595,9 +1700,12 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM6"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI7",
+        address: 0,
+        driver_name: "",
         signals: &[
             Signal {
                 name: "MISO",
@@ -1629,6 +1737,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: Some("FLEXCOMM7"),
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SCT0",
@@ -1834,6 +1943,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[

--- a/nxp-pac/src/chips/mcxa256/metadata.rs
+++ b/nxp-pac/src/chips/mcxa256/metadata.rs
@@ -806,6 +806,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 51,
         }],
+        gate: None,
     },
     Peripheral {
         name: "ADC1",
@@ -1008,6 +1009,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 52,
         }],
+        gate: None,
     },
     Peripheral {
         name: "ADC2",
@@ -1020,6 +1022,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 123,
         }],
+        gate: None,
     },
     Peripheral {
         name: "ADC3",
@@ -1032,6 +1035,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 124,
         }],
+        gate: None,
     },
     Peripheral {
         name: "AOI0",
@@ -1040,6 +1044,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "AOI1",
@@ -1048,6 +1053,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CAN0",
@@ -1113,6 +1119,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 2,
         }],
+        gate: None,
     },
     Peripheral {
         name: "CAN1",
@@ -1198,6 +1205,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 87,
         }],
+        gate: None,
     },
     Peripheral {
         name: "CDOG0",
@@ -1206,6 +1214,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CDOG1",
@@ -1214,6 +1223,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CLKOUT",
@@ -1247,6 +1257,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CMC",
@@ -1255,6 +1266,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CMP0",
@@ -1334,6 +1346,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CMP1",
@@ -1418,6 +1431,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CMP2",
@@ -1426,6 +1440,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CRC0",
@@ -1434,6 +1449,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CTIMER0",
@@ -1996,6 +2012,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 32,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "CTIMER1",
@@ -2483,6 +2500,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 34,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "CTIMER2",
@@ -2990,6 +3008,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 36,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "CTIMER3",
@@ -3492,6 +3511,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 38,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "CTIMER4",
@@ -3989,6 +4009,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 40,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "DAC0",
@@ -4009,6 +4030,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 56,
         }],
+        gate: None,
     },
     Peripheral {
         name: "DBGMAILBOX",
@@ -4054,6 +4076,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "DMA0",
@@ -4062,6 +4085,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "EIM0",
@@ -4070,6 +4094,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "ERM0",
@@ -4078,6 +4103,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "EXTAL48M",
@@ -4094,6 +4120,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXIO0",
@@ -4846,6 +4873,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 74,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "FMC0",
@@ -4854,6 +4882,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FMU0",
@@ -4862,6 +4891,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FREQME0",
@@ -4931,6 +4961,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEX_PWM0",
@@ -5563,6 +5594,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 48,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "FLEX_PWM1",
@@ -5787,6 +5819,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 86,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "GPIO0",
@@ -6016,6 +6049,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 60,
         }],
+        gate: None,
     },
     Peripheral {
         name: "GPIO1",
@@ -6236,6 +6270,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 61,
         }],
+        gate: None,
     },
     Peripheral {
         name: "GPIO2",
@@ -6492,6 +6527,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 62,
         }],
+        gate: None,
     },
     Peripheral {
         name: "GPIO3",
@@ -6793,6 +6829,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 63,
         }],
+        gate: None,
     },
     Peripheral {
         name: "GPIO4",
@@ -6878,6 +6915,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 64,
         }],
+        gate: None,
     },
     Peripheral {
         name: "I3C0",
@@ -6956,6 +6994,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 8,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "INPUTMUX0",
@@ -6964,6 +7003,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "ISPMODE",
@@ -6987,6 +7027,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPI2C0",
@@ -7066,6 +7107,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 12,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "LPI2C1",
@@ -7150,6 +7192,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 14,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "LPI2C2",
@@ -7243,6 +7286,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 4,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "LPI2C3",
@@ -7322,6 +7366,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 6,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "LPSPI0",
@@ -7454,6 +7499,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 16,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "LPSPI1",
@@ -7591,6 +7637,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 18,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "LPTMR0",
@@ -7622,6 +7669,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 49,
         }],
+        gate: None,
     },
     Peripheral {
         name: "LPUART0",
@@ -7726,6 +7774,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 22,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "LPUART1",
@@ -7855,6 +7904,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 24,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "LPUART2",
@@ -7989,6 +8039,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 26,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "LPUART3",
@@ -8093,6 +8144,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 28,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "LPUART4",
@@ -8207,6 +8259,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 30,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "LPUART5",
@@ -8331,6 +8384,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 103,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "MAU0",
@@ -8343,6 +8397,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 115,
         }],
+        gate: None,
     },
     Peripheral {
         name: "OPAMP0",
@@ -8379,6 +8434,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "OPAMP1",
@@ -8387,6 +8443,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "OPAMP2",
@@ -8395,6 +8452,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "OPAMP3",
@@ -8403,6 +8461,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "OSTIMER0",
@@ -8411,6 +8470,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "PKC0",
@@ -8419,6 +8479,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "PORT0",
@@ -8427,6 +8488,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "PORT1",
@@ -8435,6 +8497,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "PORT2",
@@ -8443,6 +8506,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "PORT3",
@@ -8451,6 +8515,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "PORT4",
@@ -8459,6 +8524,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "EQDC0",
@@ -8471,6 +8537,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 65,
         }],
+        gate: None,
     },
     Peripheral {
         name: "EQDC1",
@@ -8483,6 +8550,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 66,
         }],
+        gate: None,
     },
     Peripheral {
         name: "RESET",
@@ -8506,6 +8574,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "RTC0",
@@ -8514,6 +8583,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SCG0",
@@ -8522,6 +8592,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SGI0",
@@ -8541,6 +8612,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 120,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "SLCD0",
@@ -9336,6 +9408,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPC0",
@@ -9352,6 +9425,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SYSCON",
@@ -9360,6 +9434,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SMART_DMA0",
@@ -10001,6 +10076,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "TAMPER0",
@@ -10017,6 +10093,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "TAMPER1",
@@ -10033,6 +10110,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "TAMPER2",
@@ -10049,6 +10127,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "TAMPER3",
@@ -10065,6 +10144,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "TAMPER4",
@@ -10081,6 +10161,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "TAMPER5",
@@ -10097,6 +10178,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "TDET0",
@@ -10105,6 +10187,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "TRNG0",
@@ -10113,6 +10196,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "UDF0",
@@ -10121,6 +10205,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "USB0",
@@ -10137,6 +10222,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "UTICK0",
@@ -10210,6 +10296,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "VBAT0",
@@ -10218,6 +10305,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "VREFI",
@@ -10234,6 +10322,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "WAKETIMER0",
@@ -10242,6 +10331,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "WUU0",
@@ -10516,6 +10606,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 1,
         }],
+        gate: None,
     },
     Peripheral {
         name: "WWDT0",
@@ -10524,6 +10615,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "XTAL48M",
@@ -10540,6 +10632,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "EDMA_0_TCD",
@@ -10548,6 +10641,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "MRCC0",
@@ -10556,6 +10650,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[

--- a/nxp-pac/src/chips/mcxa256/metadata.rs
+++ b/nxp-pac/src/chips/mcxa256/metadata.rs
@@ -806,7 +806,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 51,
         }],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("AdcConfig"),
+        }),
     },
     Peripheral {
         name: "ADC1",
@@ -1009,7 +1013,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 52,
         }],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("AdcConfig"),
+        }),
     },
     Peripheral {
         name: "ADC2",
@@ -1449,7 +1457,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "CTIMER0",
@@ -2012,7 +2024,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 32,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("CTimerConfig"),
+        }),
     },
     Peripheral {
         name: "CTIMER1",
@@ -2500,7 +2516,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 34,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("CTimerConfig"),
+        }),
     },
     Peripheral {
         name: "CTIMER2",
@@ -3008,7 +3028,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 36,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("CTimerConfig"),
+        }),
     },
     Peripheral {
         name: "CTIMER3",
@@ -3511,7 +3535,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 38,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("CTimerConfig"),
+        }),
     },
     Peripheral {
         name: "CTIMER4",
@@ -4009,7 +4037,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 40,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("CTimerConfig"),
+        }),
     },
     Peripheral {
         name: "DAC0",
@@ -4085,7 +4117,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "EIM0",
@@ -6049,7 +6085,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 60,
         }],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc2",
+            reset: Some("mrcc_glb_rst2"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "GPIO1",
@@ -6270,7 +6310,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 61,
         }],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc2",
+            reset: Some("mrcc_glb_rst2"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "GPIO2",
@@ -6527,7 +6571,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 62,
         }],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc2",
+            reset: Some("mrcc_glb_rst2"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "GPIO3",
@@ -6829,7 +6877,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 63,
         }],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc2",
+            reset: Some("mrcc_glb_rst2"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "GPIO4",
@@ -6915,7 +6967,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 64,
         }],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc2",
+            reset: Some("mrcc_glb_rst2"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "I3C0",
@@ -6994,7 +7050,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 8,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("I3cConfig"),
+        }),
     },
     Peripheral {
         name: "INPUTMUX0",
@@ -7003,7 +7063,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "ISPMODE",
@@ -7107,7 +7171,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 12,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("Lpi2cConfig"),
+        }),
     },
     Peripheral {
         name: "LPI2C1",
@@ -7192,7 +7260,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 14,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("Lpi2cConfig"),
+        }),
     },
     Peripheral {
         name: "LPI2C2",
@@ -7286,7 +7358,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 4,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("Lpi2cConfig"),
+        }),
     },
     Peripheral {
         name: "LPI2C3",
@@ -7366,7 +7442,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 6,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("Lpi2cConfig"),
+        }),
     },
     Peripheral {
         name: "LPSPI0",
@@ -7499,7 +7579,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 16,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("LpspiConfig"),
+        }),
     },
     Peripheral {
         name: "LPSPI1",
@@ -7637,7 +7721,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 18,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("LpspiConfig"),
+        }),
     },
     Peripheral {
         name: "LPTMR0",
@@ -7774,7 +7862,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 22,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("LpuartConfig"),
+        }),
     },
     Peripheral {
         name: "LPUART1",
@@ -7904,7 +7996,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 24,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("LpuartConfig"),
+        }),
     },
     Peripheral {
         name: "LPUART2",
@@ -8039,7 +8135,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 26,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("LpuartConfig"),
+        }),
     },
     Peripheral {
         name: "LPUART3",
@@ -8144,7 +8244,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 28,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("LpuartConfig"),
+        }),
     },
     Peripheral {
         name: "LPUART4",
@@ -8259,7 +8363,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 30,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("LpuartConfig"),
+        }),
     },
     Peripheral {
         name: "LPUART5",
@@ -8384,7 +8492,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 103,
             },
         ],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("LpuartConfig"),
+        }),
     },
     Peripheral {
         name: "MAU0",
@@ -8470,7 +8582,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("OsTimerConfig"),
+        }),
     },
     Peripheral {
         name: "PKC0",
@@ -8488,7 +8604,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "PORT1",
@@ -8497,7 +8617,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "PORT2",
@@ -8506,7 +8630,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "PORT3",
@@ -8515,7 +8643,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "PORT4",
@@ -8524,7 +8656,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "EQDC0",
@@ -10196,7 +10332,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "UDF0",
@@ -10615,7 +10755,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
-        gate: None,
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: None,
+            config: Some("Clk1MConfig"),
+        }),
     },
     Peripheral {
         name: "XTAL48M",

--- a/nxp-pac/src/chips/mcxa577/metadata.rs
+++ b/nxp-pac/src/chips/mcxa577/metadata.rs
@@ -685,6 +685,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "_10BASE_T1S0",
@@ -742,6 +743,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "ADC0",
@@ -962,6 +964,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 51,
         }],
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("AdcConfig"),
+        }),
     },
     Peripheral {
         name: "ADC1",
@@ -1155,6 +1162,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 52,
         }],
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("AdcConfig"),
+        }),
     },
     Peripheral {
         name: "AOI0",
@@ -1163,6 +1175,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "AOI1",
@@ -1171,6 +1184,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CAN0",
@@ -1236,6 +1250,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 2,
         }],
+        gate: None,
     },
     Peripheral {
         name: "CAN1",
@@ -1321,6 +1336,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 87,
         }],
+        gate: None,
     },
     Peripheral {
         name: "CDOG0",
@@ -1329,6 +1345,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CDOG1",
@@ -1337,6 +1354,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CLKOUT",
@@ -1360,6 +1378,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CMC",
@@ -1368,6 +1387,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CMP0",
@@ -1465,6 +1485,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "CRC0",
@@ -1473,6 +1494,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "CTIMER0",
@@ -2067,6 +2093,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 32,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("CTimerConfig"),
+        }),
     },
     Peripheral {
         name: "CTIMER1",
@@ -2586,6 +2617,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 34,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("CTimerConfig"),
+        }),
     },
     Peripheral {
         name: "CTIMER2",
@@ -3125,6 +3161,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 36,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("CTimerConfig"),
+        }),
     },
     Peripheral {
         name: "CTIMER3",
@@ -3669,6 +3710,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 38,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("CTimerConfig"),
+        }),
     },
     Peripheral {
         name: "CTIMER4",
@@ -4198,6 +4244,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 40,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("CTimerConfig"),
+        }),
     },
     Peripheral {
         name: "DAC0",
@@ -4218,6 +4269,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 56,
         }],
+        gate: None,
     },
     Peripheral {
         name: "DAC1",
@@ -4238,6 +4290,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 57,
         }],
+        gate: None,
     },
     Peripheral {
         name: "DGDET0",
@@ -4246,6 +4299,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "DBGMAILBOX",
@@ -4291,6 +4345,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "DMA0",
@@ -4299,6 +4354,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "DMA1",
@@ -4307,6 +4367,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "EIM0",
@@ -4315,6 +4380,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "ENET0",
@@ -4477,6 +4543,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "ERM0",
@@ -4485,6 +4552,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "EWM0",
@@ -4546,6 +4614,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "EXTAL32K",
@@ -4562,6 +4631,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "EXTAL48M",
@@ -4578,6 +4648,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXIO0",
@@ -5350,6 +5421,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 74,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "FLEXSPI0",
@@ -5514,6 +5586,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 111,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "FMC0",
@@ -5522,6 +5595,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FMU0",
@@ -5530,6 +5604,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FREQME0",
@@ -5581,6 +5656,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GLIKEY0",
@@ -5589,6 +5665,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO0",
@@ -5854,6 +5931,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 60,
         }],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc3",
+            reset: Some("mrcc_glb_rst3"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "GPIO1",
@@ -6074,6 +6156,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 61,
         }],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc3",
+            reset: Some("mrcc_glb_rst3"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "GPIO2",
@@ -6366,6 +6453,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 62,
         }],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc3",
+            reset: Some("mrcc_glb_rst3"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "GPIO3",
@@ -6631,6 +6723,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 63,
         }],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc3",
+            reset: Some("mrcc_glb_rst3"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "GPIO4",
@@ -6770,6 +6867,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 64,
         }],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc3",
+            reset: Some("mrcc_glb_rst3"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "GPIO5",
@@ -6873,6 +6975,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 59,
         }],
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc3",
+            reset: None,
+            config: None,
+        }),
     },
     Peripheral {
         name: "I3C0",
@@ -6941,6 +7048,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 8,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc2",
+            reset: Some("mrcc_glb_rst2"),
+            config: Some("I3cConfig"),
+        }),
     },
     Peripheral {
         name: "I3C1",
@@ -7050,6 +7162,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 10,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc2",
+            reset: Some("mrcc_glb_rst2"),
+            config: Some("I3cConfig"),
+        }),
     },
     Peripheral {
         name: "I3C2",
@@ -7118,6 +7235,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 107,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc2",
+            reset: Some("mrcc_glb_rst2"),
+            config: Some("I3cConfig"),
+        }),
     },
     Peripheral {
         name: "I3C3",
@@ -7186,6 +7308,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 109,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc2",
+            reset: Some("mrcc_glb_rst2"),
+            config: Some("I3cConfig"),
+        }),
     },
     Peripheral {
         name: "INPUTMUX0",
@@ -7194,6 +7321,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "ISPMODE",
@@ -7210,6 +7342,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "ITRC0",
@@ -7218,6 +7351,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPI2C0",
@@ -7321,6 +7455,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 12,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("Lpi2cConfig"),
+        }),
     },
     Peripheral {
         name: "LPI2C1",
@@ -7405,6 +7544,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 14,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("Lpi2cConfig"),
+        }),
     },
     Peripheral {
         name: "LPI2C2",
@@ -7498,6 +7642,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 4,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("Lpi2cConfig"),
+        }),
     },
     Peripheral {
         name: "LPI2C3",
@@ -7628,6 +7777,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 6,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("Lpi2cConfig"),
+        }),
     },
     Peripheral {
         name: "LPI2C4",
@@ -7768,6 +7922,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 95,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("Lpi2cConfig"),
+        }),
     },
     Peripheral {
         name: "LPSPI0",
@@ -7900,6 +8059,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 16,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("LpspiConfig"),
+        }),
     },
     Peripheral {
         name: "LPSPI1",
@@ -8037,6 +8201,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 18,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("LpspiConfig"),
+        }),
     },
     Peripheral {
         name: "LPSPI2",
@@ -8169,6 +8338,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 20,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("LpspiConfig"),
+        }),
     },
     Peripheral {
         name: "LPSPI3",
@@ -8336,6 +8510,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 97,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("LpspiConfig"),
+        }),
     },
     Peripheral {
         name: "LPSPI4",
@@ -8468,6 +8647,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 99,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("LpspiConfig"),
+        }),
     },
     Peripheral {
         name: "LPSPI5",
@@ -8600,6 +8784,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 101,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: Some("LpspiConfig"),
+        }),
     },
     Peripheral {
         name: "LPTMR0",
@@ -8638,6 +8827,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 49,
         }],
+        gate: None,
     },
     Peripheral {
         name: "LPUART0",
@@ -8762,6 +8952,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 22,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("LpuartConfig"),
+        }),
     },
     Peripheral {
         name: "LPUART1",
@@ -8891,6 +9086,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 24,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("LpuartConfig"),
+        }),
     },
     Peripheral {
         name: "LPUART2",
@@ -9025,6 +9225,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 26,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("LpuartConfig"),
+        }),
     },
     Peripheral {
         name: "LPUART3",
@@ -9129,6 +9334,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 28,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("LpuartConfig"),
+        }),
     },
     Peripheral {
         name: "LPUART4",
@@ -9228,6 +9438,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 30,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("LpuartConfig"),
+        }),
     },
     Peripheral {
         name: "LPUART5",
@@ -9352,6 +9567,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 103,
             },
         ],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("LpuartConfig"),
+        }),
     },
     Peripheral {
         name: "MBC0",
@@ -9360,6 +9580,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "OSTIMER0",
@@ -9368,6 +9589,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc0",
+            reset: Some("mrcc_glb_rst0"),
+            config: Some("OsTimerConfig"),
+        }),
     },
     Peripheral {
         name: "PF",
@@ -9494,6 +9720,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "PKC0",
@@ -9502,6 +9729,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "PORT0",
@@ -9510,6 +9738,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "PORT1",
@@ -9518,6 +9751,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "PORT2",
@@ -9526,6 +9764,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "PORT3",
@@ -9534,6 +9777,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "PORT4",
@@ -9542,6 +9790,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: Some("mrcc_glb_rst1"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "PORT5",
@@ -9550,6 +9803,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_cc1",
+            reset: None,
+            config: None,
+        }),
     },
     Peripheral {
         name: "RESET",
@@ -9573,6 +9831,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "ROMCP",
@@ -9581,6 +9840,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "RTC0",
@@ -9597,6 +9857,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SCG0",
@@ -9605,6 +9866,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SGI0",
@@ -9624,6 +9886,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 120,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "SPC0",
@@ -9652,6 +9915,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SPI_Filter0",
@@ -9660,6 +9924,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SYSCON",
@@ -9668,6 +9933,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "Secure_AHB_Ctrl_Alias_0",
@@ -9676,6 +9942,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "Secure_AHB_Ctrl_Alias_1",
@@ -9684,6 +9951,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "Secure_AHB_Ctrl_Alias_2",
@@ -9692,6 +9960,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "Secure_AHB_Ctrl_Alias_3",
@@ -9700,6 +9969,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "SmartDMA0",
@@ -10341,6 +10611,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "TDET0",
@@ -10422,6 +10693,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "TRIG",
@@ -10801,6 +11073,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "TRNG0",
@@ -10809,6 +11082,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc4",
+            reset: Some("mrcc_glb_rst4"),
+            config: None,
+        }),
     },
     Peripheral {
         name: "TSI0",
@@ -11938,6 +12216,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "UDF0",
@@ -11946,6 +12225,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "USB1",
@@ -11998,6 +12278,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "USB1_HS_PHY",
@@ -12006,6 +12287,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "UTICK0",
@@ -12079,6 +12361,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "VBAT0",
@@ -12095,6 +12378,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "VREF0",
@@ -12103,6 +12387,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "WAKETIMER0",
@@ -12111,6 +12396,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "WUU0",
@@ -12367,6 +12653,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             mux: "DMA3",
             request: 1,
         }],
+        gate: None,
     },
     Peripheral {
         name: "WWDT0",
@@ -12375,6 +12662,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: None,
+            config: Some("Clk1MConfig"),
+        }),
     },
     Peripheral {
         name: "WWDT1",
@@ -12383,6 +12675,11 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: Some(Gate {
+            enable: "mrcc_glb_acc0",
+            reset: None,
+            config: Some("Clk1MConfig"),
+        }),
     },
     Peripheral {
         name: "XTAL32K",
@@ -12399,6 +12696,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "XTAL48M",
@@ -12415,6 +12713,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "EDMA_0_TCD",
@@ -12423,6 +12722,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "EDMA_1_TCD",
@@ -12431,6 +12731,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "eSPI0",
@@ -12579,6 +12880,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
                 request: 93,
             },
         ],
+        gate: None,
     },
     Peripheral {
         name: "seccon",
@@ -12587,6 +12889,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "MRCC0",
@@ -12595,6 +12898,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[

--- a/nxp-pac/src/chips/mimxrt1011/metadata.rs
+++ b/nxp-pac/src/chips/mimxrt1011/metadata.rs
@@ -12,6 +12,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806396u32),
             pad: 1075806572u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_01",
@@ -19,6 +20,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806392u32),
             pad: 1075806568u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_02",
@@ -26,6 +28,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806388u32),
             pad: 1075806564u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_03",
@@ -33,6 +36,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806384u32),
             pad: 1075806560u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_04",
@@ -40,6 +44,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806380u32),
             pad: 1075806556u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_05",
@@ -47,6 +52,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806376u32),
             pad: 1075806552u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_06",
@@ -54,6 +60,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806372u32),
             pad: 1075806548u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_07",
@@ -61,6 +68,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806368u32),
             pad: 1075806544u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_08",
@@ -68,6 +76,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806364u32),
             pad: 1075806540u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_09",
@@ -75,6 +84,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806360u32),
             pad: 1075806536u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_10",
@@ -82,6 +92,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806356u32),
             pad: 1075806532u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_11",
@@ -89,6 +100,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806352u32),
             pad: 1075806528u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_12",
@@ -96,6 +108,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806348u32),
             pad: 1075806524u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_13",
@@ -103,6 +116,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806344u32),
             pad: 1075806520u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_00",
@@ -110,6 +124,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806280u32),
             pad: 1075806456u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_01",
@@ -117,6 +132,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806276u32),
             pad: 1075806452u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_02",
@@ -124,6 +140,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806272u32),
             pad: 1075806448u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_03",
@@ -131,6 +148,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806268u32),
             pad: 1075806444u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_04",
@@ -138,6 +156,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806264u32),
             pad: 1075806440u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_05",
@@ -145,6 +164,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806260u32),
             pad: 1075806436u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_06",
@@ -152,6 +172,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806256u32),
             pad: 1075806432u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_07",
@@ -159,6 +180,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806252u32),
             pad: 1075806428u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_08",
@@ -166,6 +188,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806248u32),
             pad: 1075806424u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_09",
@@ -173,6 +196,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806244u32),
             pad: 1075806420u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_10",
@@ -180,6 +204,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806240u32),
             pad: 1075806416u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_11",
@@ -187,6 +212,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806236u32),
             pad: 1075806412u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_12",
@@ -194,6 +220,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806232u32),
             pad: 1075806408u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_13",
@@ -201,6 +228,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806228u32),
             pad: 1075806404u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_14",
@@ -208,6 +236,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806224u32),
             pad: 1075806400u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_00",
@@ -215,6 +244,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806340u32),
             pad: 1075806516u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_01",
@@ -222,6 +252,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806336u32),
             pad: 1075806512u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_02",
@@ -229,6 +260,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806332u32),
             pad: 1075806508u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_03",
@@ -236,6 +268,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806328u32),
             pad: 1075806504u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_04",
@@ -243,6 +276,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806324u32),
             pad: 1075806500u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_05",
@@ -250,6 +284,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806320u32),
             pad: 1075806496u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_06",
@@ -257,6 +292,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806316u32),
             pad: 1075806492u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_07",
@@ -264,6 +300,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806312u32),
             pad: 1075806488u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_08",
@@ -271,6 +308,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806308u32),
             pad: 1075806484u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_09",
@@ -278,6 +316,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806304u32),
             pad: 1075806480u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_10",
@@ -285,6 +324,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806300u32),
             pad: 1075806476u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_11",
@@ -292,6 +332,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806296u32),
             pad: 1075806472u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_12",
@@ -299,6 +340,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806292u32),
             pad: 1075806468u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_13",
@@ -306,6 +348,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806288u32),
             pad: 1075806464u32,
         }),
+        feature: None,
     },
     Pin {
         name: "PMIC_ON_REQ",
@@ -313,6 +356,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1074429952u32),
             pad: 1074429968u32,
         }),
+        feature: None,
     },
     Pin {
         name: "ONOFF",
@@ -320,6 +364,7 @@ pub const PINS: &[Pin] = &[
             mux: None,
             pad: 1074429964u32,
         }),
+        feature: None,
     },
     Pin {
         name: "TEST_MODE",
@@ -327,6 +372,7 @@ pub const PINS: &[Pin] = &[
             mux: None,
             pad: 1074429956u32,
         }),
+        feature: None,
     },
     Pin {
         name: "POR_B",
@@ -334,6 +380,7 @@ pub const PINS: &[Pin] = &[
             mux: None,
             pad: 1074429960u32,
         }),
+        feature: None,
     },
 ];
 pub const PERIPHERALS: &[Peripheral] = &[
@@ -489,6 +536,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO1",
@@ -759,6 +807,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO2",
@@ -894,6 +943,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO5",
@@ -910,6 +960,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         }],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART1",
@@ -969,6 +1020,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART2",
@@ -1028,6 +1080,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART3",
@@ -1097,6 +1150,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART4",
@@ -1156,6 +1210,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[

--- a/nxp-pac/src/chips/mimxrt1062/metadata.rs
+++ b/nxp-pac/src/chips/mimxrt1062/metadata.rs
@@ -12,6 +12,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806396u32),
             pad: 1075806892u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_01",
@@ -19,6 +20,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806400u32),
             pad: 1075806896u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_02",
@@ -26,6 +28,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806404u32),
             pad: 1075806900u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_03",
@@ -33,6 +36,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806408u32),
             pad: 1075806904u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_04",
@@ -40,6 +44,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806412u32),
             pad: 1075806908u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_05",
@@ -47,6 +52,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806416u32),
             pad: 1075806912u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_06",
@@ -54,6 +60,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806420u32),
             pad: 1075806916u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_07",
@@ -61,6 +68,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806424u32),
             pad: 1075806920u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_08",
@@ -68,6 +76,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806428u32),
             pad: 1075806924u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_09",
@@ -75,6 +84,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806432u32),
             pad: 1075806928u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_10",
@@ -82,6 +92,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806436u32),
             pad: 1075806932u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_11",
@@ -89,6 +100,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806440u32),
             pad: 1075806936u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_12",
@@ -96,6 +108,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806444u32),
             pad: 1075806940u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_13",
@@ -103,6 +116,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806448u32),
             pad: 1075806944u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_14",
@@ -110,6 +124,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806452u32),
             pad: 1075806948u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_15",
@@ -117,6 +132,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806456u32),
             pad: 1075806952u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_00",
@@ -124,6 +140,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806460u32),
             pad: 1075806956u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_01",
@@ -131,6 +148,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806464u32),
             pad: 1075806960u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_02",
@@ -138,6 +156,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806468u32),
             pad: 1075806964u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_03",
@@ -145,6 +164,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806472u32),
             pad: 1075806968u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_04",
@@ -152,6 +172,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806476u32),
             pad: 1075806972u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_05",
@@ -159,6 +180,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806480u32),
             pad: 1075806976u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_06",
@@ -166,6 +188,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806484u32),
             pad: 1075806980u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_07",
@@ -173,6 +196,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806488u32),
             pad: 1075806984u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_08",
@@ -180,6 +204,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806492u32),
             pad: 1075806988u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_09",
@@ -187,6 +212,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806496u32),
             pad: 1075806992u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_10",
@@ -194,6 +220,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806500u32),
             pad: 1075806996u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_11",
@@ -201,6 +228,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806504u32),
             pad: 1075807000u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_12",
@@ -208,6 +236,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806508u32),
             pad: 1075807004u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_13",
@@ -215,6 +244,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806512u32),
             pad: 1075807008u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_14",
@@ -222,6 +252,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806516u32),
             pad: 1075807012u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_15",
@@ -229,6 +260,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806520u32),
             pad: 1075807016u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_00",
@@ -236,6 +268,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806524u32),
             pad: 1075806524u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_01",
@@ -243,6 +276,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806528u32),
             pad: 1075806528u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_02",
@@ -250,6 +284,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806532u32),
             pad: 1075806532u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_03",
@@ -257,6 +292,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806536u32),
             pad: 1075806536u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_04",
@@ -264,6 +300,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806540u32),
             pad: 1075806540u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_05",
@@ -271,6 +308,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806544u32),
             pad: 1075806544u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_06",
@@ -278,6 +316,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806548u32),
             pad: 1075806548u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_07",
@@ -285,6 +324,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806552u32),
             pad: 1075806552u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_08",
@@ -292,6 +332,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806556u32),
             pad: 1075806556u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_09",
@@ -299,6 +340,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806560u32),
             pad: 1075806560u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_10",
@@ -306,6 +348,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806564u32),
             pad: 1075806564u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_11",
@@ -313,6 +356,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806568u32),
             pad: 1075806568u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_12",
@@ -320,6 +364,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806572u32),
             pad: 1075806572u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_13",
@@ -327,6 +372,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806576u32),
             pad: 1075806576u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_14",
@@ -334,6 +380,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806580u32),
             pad: 1075806580u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_15",
@@ -341,6 +388,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806584u32),
             pad: 1075806584u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_00",
@@ -348,6 +396,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806588u32),
             pad: 1075806588u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_01",
@@ -355,6 +404,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806592u32),
             pad: 1075806592u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_02",
@@ -362,6 +412,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806596u32),
             pad: 1075806596u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_03",
@@ -369,6 +420,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806600u32),
             pad: 1075806600u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_04",
@@ -376,6 +428,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806604u32),
             pad: 1075806604u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_05",
@@ -383,6 +436,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806608u32),
             pad: 1075806608u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_06",
@@ -390,6 +444,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806612u32),
             pad: 1075806612u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_07",
@@ -397,6 +452,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806616u32),
             pad: 1075806616u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_08",
@@ -404,6 +460,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806620u32),
             pad: 1075806620u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_09",
@@ -411,6 +468,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806624u32),
             pad: 1075806624u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_10",
@@ -418,6 +476,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806628u32),
             pad: 1075806628u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_11",
@@ -425,6 +484,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806632u32),
             pad: 1075806632u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_12",
@@ -432,6 +492,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806636u32),
             pad: 1075806636u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_13",
@@ -439,6 +500,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806640u32),
             pad: 1075806640u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_14",
@@ -446,6 +508,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806644u32),
             pad: 1075806644u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_15",
@@ -453,6 +516,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806648u32),
             pad: 1075806648u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_00",
@@ -460,6 +524,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806228u32),
             pad: 1075806724u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_01",
@@ -467,6 +532,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806232u32),
             pad: 1075806728u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_02",
@@ -474,6 +540,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806236u32),
             pad: 1075806732u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_03",
@@ -481,6 +548,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806240u32),
             pad: 1075806736u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_04",
@@ -488,6 +556,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806244u32),
             pad: 1075806740u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_05",
@@ -495,6 +564,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806248u32),
             pad: 1075806744u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_06",
@@ -502,6 +572,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806252u32),
             pad: 1075806748u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_07",
@@ -509,6 +580,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806256u32),
             pad: 1075806752u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_08",
@@ -516,6 +588,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806260u32),
             pad: 1075806756u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_09",
@@ -523,6 +596,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806264u32),
             pad: 1075806760u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_10",
@@ -530,6 +604,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806268u32),
             pad: 1075806764u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_11",
@@ -537,6 +612,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806272u32),
             pad: 1075806768u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_12",
@@ -544,6 +620,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806276u32),
             pad: 1075806772u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_13",
@@ -551,6 +628,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806280u32),
             pad: 1075806776u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_14",
@@ -558,6 +636,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806284u32),
             pad: 1075806780u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_15",
@@ -565,6 +644,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806288u32),
             pad: 1075806784u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_16",
@@ -572,6 +652,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806292u32),
             pad: 1075806788u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_17",
@@ -579,6 +660,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806296u32),
             pad: 1075806792u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_18",
@@ -586,6 +668,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806300u32),
             pad: 1075806796u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_19",
@@ -593,6 +676,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806304u32),
             pad: 1075806800u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_20",
@@ -600,6 +684,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806308u32),
             pad: 1075806804u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_21",
@@ -607,6 +692,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806312u32),
             pad: 1075806808u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_22",
@@ -614,6 +700,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806316u32),
             pad: 1075806812u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_23",
@@ -621,6 +708,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806320u32),
             pad: 1075806816u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_24",
@@ -628,6 +716,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806324u32),
             pad: 1075806820u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_25",
@@ -635,6 +724,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806328u32),
             pad: 1075806824u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_26",
@@ -642,6 +732,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806332u32),
             pad: 1075806828u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_27",
@@ -649,6 +740,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806336u32),
             pad: 1075806832u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_28",
@@ -656,6 +748,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806340u32),
             pad: 1075806836u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_29",
@@ -663,6 +756,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806344u32),
             pad: 1075806840u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_30",
@@ -670,6 +764,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806348u32),
             pad: 1075806844u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_31",
@@ -677,6 +772,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806352u32),
             pad: 1075806848u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_32",
@@ -684,6 +780,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806356u32),
             pad: 1075806852u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_33",
@@ -691,6 +788,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806360u32),
             pad: 1075806856u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_34",
@@ -698,6 +796,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806364u32),
             pad: 1075806860u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_35",
@@ -705,6 +804,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806368u32),
             pad: 1075806864u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_36",
@@ -712,6 +812,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806372u32),
             pad: 1075806868u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_37",
@@ -719,6 +820,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806376u32),
             pad: 1075806872u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_38",
@@ -726,6 +828,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806380u32),
             pad: 1075806876u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_39",
@@ -733,6 +836,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806384u32),
             pad: 1075806880u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_40",
@@ -740,6 +844,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806388u32),
             pad: 1075806884u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_41",
@@ -747,6 +852,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806392u32),
             pad: 1075806888u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B0_00",
@@ -754,6 +860,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806652u32),
             pad: 1075807148u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B0_01",
@@ -761,6 +868,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806656u32),
             pad: 1075807152u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B0_02",
@@ -768,6 +876,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806660u32),
             pad: 1075807156u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B0_03",
@@ -775,6 +884,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806664u32),
             pad: 1075807160u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B0_04",
@@ -782,6 +892,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806668u32),
             pad: 1075807164u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B0_05",
@@ -789,6 +900,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806672u32),
             pad: 1075807168u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_00",
@@ -796,6 +908,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806676u32),
             pad: 1075807172u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_01",
@@ -803,6 +916,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806680u32),
             pad: 1075807176u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_02",
@@ -810,6 +924,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806684u32),
             pad: 1075807180u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_03",
@@ -817,6 +932,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806688u32),
             pad: 1075807184u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_04",
@@ -824,6 +940,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806692u32),
             pad: 1075807188u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_05",
@@ -831,6 +948,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806696u32),
             pad: 1075807192u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_06",
@@ -838,6 +956,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806700u32),
             pad: 1075807196u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_07",
@@ -845,6 +964,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806704u32),
             pad: 1075807200u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_08",
@@ -852,6 +972,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806708u32),
             pad: 1075807204u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_09",
@@ -859,6 +980,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806712u32),
             pad: 1075807208u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_10",
@@ -866,6 +988,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806716u32),
             pad: 1075807212u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_11",
@@ -873,6 +996,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806720u32),
             pad: 1075807216u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_00",
@@ -880,6 +1004,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807836u32),
             pad: 1075807924u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_01",
@@ -887,6 +1012,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807840u32),
             pad: 1075807928u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_02",
@@ -894,6 +1020,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807844u32),
             pad: 1075807932u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_03",
@@ -901,6 +1028,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807848u32),
             pad: 1075807936u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_04",
@@ -908,6 +1036,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807852u32),
             pad: 1075807940u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_05",
@@ -915,6 +1044,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807856u32),
             pad: 1075807944u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_06",
@@ -922,6 +1052,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807860u32),
             pad: 1075807948u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_07",
@@ -929,6 +1060,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807864u32),
             pad: 1075807952u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_08",
@@ -936,6 +1068,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807868u32),
             pad: 1075807956u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_09",
@@ -943,6 +1076,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807872u32),
             pad: 1075807960u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_10",
@@ -950,6 +1084,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807876u32),
             pad: 1075807964u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_11",
@@ -957,6 +1092,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807880u32),
             pad: 1075807968u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_12",
@@ -964,6 +1100,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807884u32),
             pad: 1075807972u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_13",
@@ -971,6 +1108,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807888u32),
             pad: 1075807976u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_00",
@@ -978,6 +1116,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807892u32),
             pad: 1075807980u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_01",
@@ -985,6 +1124,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807896u32),
             pad: 1075807984u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_02",
@@ -992,6 +1132,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807900u32),
             pad: 1075807988u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_03",
@@ -999,6 +1140,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807904u32),
             pad: 1075807992u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_04",
@@ -1006,6 +1148,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807908u32),
             pad: 1075807996u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_05",
@@ -1013,6 +1156,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807912u32),
             pad: 1075808000u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_06",
@@ -1020,6 +1164,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807916u32),
             pad: 1075808004u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_07",
@@ -1027,6 +1172,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807920u32),
             pad: 1075808008u32,
         }),
+        feature: None,
     },
     Pin {
         name: "WAKEUP",
@@ -1034,6 +1180,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1074429952u32),
             pad: 1074429976u32,
         }),
+        feature: None,
     },
     Pin {
         name: "PMIC_ON_REQ",
@@ -1041,6 +1188,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1074429956u32),
             pad: 1074429980u32,
         }),
+        feature: None,
     },
     Pin {
         name: "PMIC_STBY_REQ",
@@ -1048,6 +1196,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1074429960u32),
             pad: 1074429984u32,
         }),
+        feature: None,
     },
     Pin {
         name: "ONOFF",
@@ -1055,6 +1204,7 @@ pub const PINS: &[Pin] = &[
             mux: None,
             pad: 1074429972u32,
         }),
+        feature: None,
     },
     Pin {
         name: "POR_B",
@@ -1062,6 +1212,7 @@ pub const PINS: &[Pin] = &[
             mux: None,
             pad: 1074429968u32,
         }),
+        feature: None,
     },
     Pin {
         name: "TEST_MODE",
@@ -1069,6 +1220,7 @@ pub const PINS: &[Pin] = &[
             mux: None,
             pad: 1074429964u32,
         }),
+        feature: None,
     },
 ];
 pub const PERIPHERALS: &[Peripheral] = &[
@@ -1320,6 +1472,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXSPI2",
@@ -1592,6 +1745,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO1",
@@ -1889,6 +2043,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO2",
@@ -2186,6 +2341,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO3",
@@ -2447,6 +2603,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO4",
@@ -2744,6 +2901,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO5",
@@ -2780,6 +2938,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO10",
@@ -2987,6 +3146,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART1",
@@ -3032,6 +3192,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART2",
@@ -3091,6 +3252,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART3",
@@ -3174,6 +3336,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART4",
@@ -3243,6 +3406,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART5",
@@ -3302,6 +3466,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART6",
@@ -3361,6 +3526,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART7",
@@ -3420,6 +3586,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART8",
@@ -3489,6 +3656,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[

--- a/nxp-pac/src/chips/mimxrt1064/metadata.rs
+++ b/nxp-pac/src/chips/mimxrt1064/metadata.rs
@@ -12,6 +12,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806396u32),
             pad: 1075806892u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_01",
@@ -19,6 +20,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806400u32),
             pad: 1075806896u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_02",
@@ -26,6 +28,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806404u32),
             pad: 1075806900u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_03",
@@ -33,6 +36,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806408u32),
             pad: 1075806904u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_04",
@@ -40,6 +44,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806412u32),
             pad: 1075806908u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_05",
@@ -47,6 +52,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806416u32),
             pad: 1075806912u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_06",
@@ -54,6 +60,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806420u32),
             pad: 1075806916u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_07",
@@ -61,6 +68,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806424u32),
             pad: 1075806920u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_08",
@@ -68,6 +76,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806428u32),
             pad: 1075806924u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_09",
@@ -75,6 +84,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806432u32),
             pad: 1075806928u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_10",
@@ -82,6 +92,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806436u32),
             pad: 1075806932u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_11",
@@ -89,6 +100,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806440u32),
             pad: 1075806936u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_12",
@@ -96,6 +108,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806444u32),
             pad: 1075806940u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_13",
@@ -103,6 +116,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806448u32),
             pad: 1075806944u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_14",
@@ -110,6 +124,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806452u32),
             pad: 1075806948u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B0_15",
@@ -117,6 +132,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806456u32),
             pad: 1075806952u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_00",
@@ -124,6 +140,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806460u32),
             pad: 1075806956u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_01",
@@ -131,6 +148,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806464u32),
             pad: 1075806960u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_02",
@@ -138,6 +156,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806468u32),
             pad: 1075806964u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_03",
@@ -145,6 +164,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806472u32),
             pad: 1075806968u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_04",
@@ -152,6 +172,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806476u32),
             pad: 1075806972u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_05",
@@ -159,6 +180,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806480u32),
             pad: 1075806976u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_06",
@@ -166,6 +188,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806484u32),
             pad: 1075806980u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_07",
@@ -173,6 +196,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806488u32),
             pad: 1075806984u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_08",
@@ -180,6 +204,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806492u32),
             pad: 1075806988u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_09",
@@ -187,6 +212,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806496u32),
             pad: 1075806992u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_10",
@@ -194,6 +220,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806500u32),
             pad: 1075806996u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_11",
@@ -201,6 +228,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806504u32),
             pad: 1075807000u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_12",
@@ -208,6 +236,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806508u32),
             pad: 1075807004u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_13",
@@ -215,6 +244,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806512u32),
             pad: 1075807008u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_14",
@@ -222,6 +252,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806516u32),
             pad: 1075807012u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_AD_B1_15",
@@ -229,6 +260,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806520u32),
             pad: 1075807016u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_00",
@@ -236,6 +268,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806524u32),
             pad: 1075806524u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_01",
@@ -243,6 +276,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806528u32),
             pad: 1075806528u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_02",
@@ -250,6 +284,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806532u32),
             pad: 1075806532u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_03",
@@ -257,6 +292,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806536u32),
             pad: 1075806536u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_04",
@@ -264,6 +300,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806540u32),
             pad: 1075806540u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_05",
@@ -271,6 +308,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806544u32),
             pad: 1075806544u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_06",
@@ -278,6 +316,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806548u32),
             pad: 1075806548u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_07",
@@ -285,6 +324,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806552u32),
             pad: 1075806552u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_08",
@@ -292,6 +332,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806556u32),
             pad: 1075806556u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_09",
@@ -299,6 +340,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806560u32),
             pad: 1075806560u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_10",
@@ -306,6 +348,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806564u32),
             pad: 1075806564u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_11",
@@ -313,6 +356,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806568u32),
             pad: 1075806568u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_12",
@@ -320,6 +364,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806572u32),
             pad: 1075806572u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_13",
@@ -327,6 +372,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806576u32),
             pad: 1075806576u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_14",
@@ -334,6 +380,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806580u32),
             pad: 1075806580u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B0_15",
@@ -341,6 +388,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806584u32),
             pad: 1075806584u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_00",
@@ -348,6 +396,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806588u32),
             pad: 1075806588u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_01",
@@ -355,6 +404,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806592u32),
             pad: 1075806592u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_02",
@@ -362,6 +412,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806596u32),
             pad: 1075806596u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_03",
@@ -369,6 +420,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806600u32),
             pad: 1075806600u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_04",
@@ -376,6 +428,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806604u32),
             pad: 1075806604u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_05",
@@ -383,6 +436,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806608u32),
             pad: 1075806608u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_06",
@@ -390,6 +444,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806612u32),
             pad: 1075806612u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_07",
@@ -397,6 +452,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806616u32),
             pad: 1075806616u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_08",
@@ -404,6 +460,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806620u32),
             pad: 1075806620u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_09",
@@ -411,6 +468,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806624u32),
             pad: 1075806624u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_10",
@@ -418,6 +476,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806628u32),
             pad: 1075806628u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_11",
@@ -425,6 +484,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806632u32),
             pad: 1075806632u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_12",
@@ -432,6 +492,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806636u32),
             pad: 1075806636u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_13",
@@ -439,6 +500,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806640u32),
             pad: 1075806640u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_14",
@@ -446,6 +508,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806644u32),
             pad: 1075806644u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_B1_15",
@@ -453,6 +516,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806648u32),
             pad: 1075806648u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_00",
@@ -460,6 +524,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806228u32),
             pad: 1075806724u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_01",
@@ -467,6 +532,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806232u32),
             pad: 1075806728u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_02",
@@ -474,6 +540,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806236u32),
             pad: 1075806732u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_03",
@@ -481,6 +548,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806240u32),
             pad: 1075806736u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_04",
@@ -488,6 +556,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806244u32),
             pad: 1075806740u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_05",
@@ -495,6 +564,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806248u32),
             pad: 1075806744u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_06",
@@ -502,6 +572,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806252u32),
             pad: 1075806748u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_07",
@@ -509,6 +580,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806256u32),
             pad: 1075806752u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_08",
@@ -516,6 +588,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806260u32),
             pad: 1075806756u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_09",
@@ -523,6 +596,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806264u32),
             pad: 1075806760u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_10",
@@ -530,6 +604,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806268u32),
             pad: 1075806764u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_11",
@@ -537,6 +612,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806272u32),
             pad: 1075806768u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_12",
@@ -544,6 +620,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806276u32),
             pad: 1075806772u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_13",
@@ -551,6 +628,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806280u32),
             pad: 1075806776u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_14",
@@ -558,6 +636,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806284u32),
             pad: 1075806780u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_15",
@@ -565,6 +644,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806288u32),
             pad: 1075806784u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_16",
@@ -572,6 +652,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806292u32),
             pad: 1075806788u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_17",
@@ -579,6 +660,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806296u32),
             pad: 1075806792u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_18",
@@ -586,6 +668,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806300u32),
             pad: 1075806796u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_19",
@@ -593,6 +676,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806304u32),
             pad: 1075806800u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_20",
@@ -600,6 +684,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806308u32),
             pad: 1075806804u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_21",
@@ -607,6 +692,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806312u32),
             pad: 1075806808u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_22",
@@ -614,6 +700,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806316u32),
             pad: 1075806812u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_23",
@@ -621,6 +708,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806320u32),
             pad: 1075806816u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_24",
@@ -628,6 +716,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806324u32),
             pad: 1075806820u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_25",
@@ -635,6 +724,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806328u32),
             pad: 1075806824u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_26",
@@ -642,6 +732,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806332u32),
             pad: 1075806828u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_27",
@@ -649,6 +740,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806336u32),
             pad: 1075806832u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_28",
@@ -656,6 +748,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806340u32),
             pad: 1075806836u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_29",
@@ -663,6 +756,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806344u32),
             pad: 1075806840u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_30",
@@ -670,6 +764,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806348u32),
             pad: 1075806844u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_31",
@@ -677,6 +772,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806352u32),
             pad: 1075806848u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_32",
@@ -684,6 +780,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806356u32),
             pad: 1075806852u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_33",
@@ -691,6 +788,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806360u32),
             pad: 1075806856u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_34",
@@ -698,6 +796,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806364u32),
             pad: 1075806860u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_35",
@@ -705,6 +804,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806368u32),
             pad: 1075806864u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_36",
@@ -712,6 +812,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806372u32),
             pad: 1075806868u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_37",
@@ -719,6 +820,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806376u32),
             pad: 1075806872u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_38",
@@ -726,6 +828,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806380u32),
             pad: 1075806876u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_39",
@@ -733,6 +836,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806384u32),
             pad: 1075806880u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_40",
@@ -740,6 +844,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806388u32),
             pad: 1075806884u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_EMC_41",
@@ -747,6 +852,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806392u32),
             pad: 1075806888u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B0_00",
@@ -754,6 +860,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806652u32),
             pad: 1075807148u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B0_01",
@@ -761,6 +868,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806656u32),
             pad: 1075807152u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B0_02",
@@ -768,6 +876,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806660u32),
             pad: 1075807156u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B0_03",
@@ -775,6 +884,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806664u32),
             pad: 1075807160u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B0_04",
@@ -782,6 +892,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806668u32),
             pad: 1075807164u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B0_05",
@@ -789,6 +900,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806672u32),
             pad: 1075807168u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_00",
@@ -796,6 +908,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806676u32),
             pad: 1075807172u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_01",
@@ -803,6 +916,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806680u32),
             pad: 1075807176u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_02",
@@ -810,6 +924,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806684u32),
             pad: 1075807180u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_03",
@@ -817,6 +932,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806688u32),
             pad: 1075807184u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_04",
@@ -824,6 +940,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806692u32),
             pad: 1075807188u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_05",
@@ -831,6 +948,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806696u32),
             pad: 1075807192u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_06",
@@ -838,6 +956,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806700u32),
             pad: 1075807196u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_07",
@@ -845,6 +964,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806704u32),
             pad: 1075807200u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_08",
@@ -852,6 +972,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806708u32),
             pad: 1075807204u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_09",
@@ -859,6 +980,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806712u32),
             pad: 1075807208u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_10",
@@ -866,6 +988,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806716u32),
             pad: 1075807212u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SD_B1_11",
@@ -873,6 +996,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075806720u32),
             pad: 1075807216u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_00",
@@ -880,6 +1004,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807836u32),
             pad: 1075807924u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_01",
@@ -887,6 +1012,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807840u32),
             pad: 1075807928u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_02",
@@ -894,6 +1020,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807844u32),
             pad: 1075807932u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_03",
@@ -901,6 +1028,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807848u32),
             pad: 1075807936u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_04",
@@ -908,6 +1036,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807852u32),
             pad: 1075807940u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_05",
@@ -915,6 +1044,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807856u32),
             pad: 1075807944u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_06",
@@ -922,6 +1052,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807860u32),
             pad: 1075807948u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_07",
@@ -929,6 +1060,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807864u32),
             pad: 1075807952u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_08",
@@ -936,6 +1068,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807868u32),
             pad: 1075807956u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_09",
@@ -943,6 +1076,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807872u32),
             pad: 1075807960u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_10",
@@ -950,6 +1084,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807876u32),
             pad: 1075807964u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_11",
@@ -957,6 +1092,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807880u32),
             pad: 1075807968u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_12",
@@ -964,6 +1100,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807884u32),
             pad: 1075807972u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B0_13",
@@ -971,6 +1108,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807888u32),
             pad: 1075807976u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_00",
@@ -978,6 +1116,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807892u32),
             pad: 1075807980u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_01",
@@ -985,6 +1124,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807896u32),
             pad: 1075807984u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_02",
@@ -992,6 +1132,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807900u32),
             pad: 1075807988u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_03",
@@ -999,6 +1140,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807904u32),
             pad: 1075807992u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_04",
@@ -1006,6 +1148,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807908u32),
             pad: 1075807996u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_05",
@@ -1013,6 +1156,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807912u32),
             pad: 1075808000u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_06",
@@ -1020,6 +1164,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807916u32),
             pad: 1075808004u32,
         }),
+        feature: None,
     },
     Pin {
         name: "GPIO_SPI_B1_07",
@@ -1027,6 +1172,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1075807920u32),
             pad: 1075808008u32,
         }),
+        feature: None,
     },
     Pin {
         name: "WAKEUP",
@@ -1034,6 +1180,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1074429952u32),
             pad: 1074429976u32,
         }),
+        feature: None,
     },
     Pin {
         name: "PMIC_ON_REQ",
@@ -1041,6 +1188,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1074429956u32),
             pad: 1074429980u32,
         }),
+        feature: None,
     },
     Pin {
         name: "PMIC_STBY_REQ",
@@ -1048,6 +1196,7 @@ pub const PINS: &[Pin] = &[
             mux: Some(1074429960u32),
             pad: 1074429984u32,
         }),
+        feature: None,
     },
     Pin {
         name: "ONOFF",
@@ -1055,6 +1204,7 @@ pub const PINS: &[Pin] = &[
             mux: None,
             pad: 1074429972u32,
         }),
+        feature: None,
     },
     Pin {
         name: "POR_B",
@@ -1062,6 +1212,7 @@ pub const PINS: &[Pin] = &[
             mux: None,
             pad: 1074429968u32,
         }),
+        feature: None,
     },
     Pin {
         name: "TEST_MODE",
@@ -1069,6 +1220,7 @@ pub const PINS: &[Pin] = &[
             mux: None,
             pad: 1074429964u32,
         }),
+        feature: None,
     },
 ];
 pub const PERIPHERALS: &[Peripheral] = &[
@@ -1320,6 +1472,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "FLEXSPI2",
@@ -1592,6 +1745,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO1",
@@ -1889,6 +2043,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO2",
@@ -2186,6 +2341,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO3",
@@ -2447,6 +2603,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO4",
@@ -2744,6 +2901,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO5",
@@ -2780,6 +2938,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "GPIO10",
@@ -2987,6 +3146,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART1",
@@ -3032,6 +3192,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART2",
@@ -3091,6 +3252,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART3",
@@ -3174,6 +3336,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART4",
@@ -3243,6 +3406,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART5",
@@ -3302,6 +3466,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART6",
@@ -3361,6 +3526,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART7",
@@ -3420,6 +3586,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
     Peripheral {
         name: "LPUART8",
@@ -3489,6 +3656,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
         ],
         flexcomm: None,
         dma_muxing: &[],
+        gate: None,
     },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[

--- a/nxp-pac/src/metadata.rs
+++ b/nxp-pac/src/metadata.rs
@@ -50,6 +50,7 @@ pub struct Peripheral {
     pub signals: &'static [Signal],
     pub flexcomm: Option<&'static str>,
     pub dma_muxing: &'static [DmaMux],
+    pub gate: Option<Gate>,
 }
 
 #[derive(Debug)]
@@ -71,6 +72,12 @@ pub struct DmaMux {
     pub signal: &'static str,
     pub mux: &'static str,
     pub request: u8,
+}
+
+pub struct Gate {
+    pub enable: &'static str,
+    pub reset: &'static str,
+    pub bit: &'static str,
 }
 
 pub use _generated::*;

--- a/nxp-pac/src/metadata.rs
+++ b/nxp-pac/src/metadata.rs
@@ -74,10 +74,11 @@ pub struct DmaMux {
     pub request: u8,
 }
 
+#[derive(Debug)]
 pub struct Gate {
     pub enable: &'static str,
-    pub reset: &'static str,
-    pub bit: &'static str,
+    pub reset: Option<&'static str>,
+    pub config: Option<&'static str>,
 }
 
 pub use _generated::*;


### PR DESCRIPTION
Should be general enough for all chips.

It's optional to add to the metadata.
Metadata has been filled for mxca targets.

Also fixes a bug from a refactor where the metadata wasn't generated anymore for targets without metapac.