### PR TITLE
Add locked to all CI cargo builds to ensure PRs update Cargo.lock

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,10 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.1
       - name: Check
         run: |
-          cargo check -p generator
+          cargo check -p generator --locked
       - name: Clippy
         run: |
-          cargo clippy -p generator -- -D warnings
+          cargo clippy -p generator --locked -- -D warnings
 
   # Check if we can still generate code for all PACs (do not commit changes)
   run-generate:
@@ -50,7 +50,7 @@ jobs:
           cargo install form
       - name: Run generate on all chips
         run: |
-          cargo run -p generator -- generate
+          cargo run -p generator --locked -- generate
 
   check:
     runs-on: ubuntu-latest
@@ -75,4 +75,4 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.1
       - name: Check
         run: |
-          cargo check -p nxp-pac --features ${{ matrix.chip }}
+          cargo check -p nxp-pac --locked --features ${{ matrix.chip }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "chiptool"
 version = "0.1.0"
+source = "git+https://github.com/embassy-rs/chiptool.git?rev=e5ab29fff80a7cbe271631dbf7e4233c52dd8e32#e5ab29fff80a7cbe271631dbf7e4233c52dd8e32"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
There's a lock file in this repo, but it's stale.
Do CI builds using --locked, which will complain if Cargo.lock is out of date so that contributors do not forget to update the lock file.