### PR TITLE
Clean chip and core target dir before generating

### DIFF
--- a/generator/src/metapac.rs
+++ b/generator/src/metapac.rs
@@ -115,9 +115,10 @@ fn generate_meta_peripherals_mod(current: &Path, mut drivers: Vec<String>) -> an
 /// Generates all core-specific code for a metapac PAC, including any peripherals that have been mapped.
 pub fn generate_core(current: &Path, core: &str, mut metadata: Metadata) -> anyhow::Result<()> {
     let core_dir = current.join("nxp-pac/src/chips").join(core.to_lowercase());
-    if !core_dir.exists() {
-        fs::create_dir_all(&core_dir).context("creating chip dir")?;
+    if core_dir.exists() {
+        fs::remove_dir_all(&core_dir).context("removing old chip dir")?;
     }
+    fs::create_dir_all(&core_dir).context("creating chip dir")?;
 
     // Remove all peripherals that are defined, but don't have a metaperipheral mapped.
     let yaml_peri_dir = current.join("data/metadata/peripherals");

--- a/generator/src/metapac.rs
+++ b/generator/src/metapac.rs
@@ -158,9 +158,10 @@ pub fn generate_core(current: &Path, core: &str, mut metadata: Metadata) -> anyh
     });
 
     export_device_x(&core_dir, &metadata).context("exporting device.x")?;
-    export_mod_rs(&core_dir, &metadata).context("exporting mod.rs")?;
     export_vectors_rs(&core_dir, &metadata).context("exporting _vectors.rs")?;
     export_common_rs(&core_dir).context("exporting common.rs")?;
+    // mod.rs contains vectors.rs and common.rs, so write it last to avoid issues with rustfmt
+    export_mod_rs(&core_dir, &metadata).context("exporting mod.rs")?;
 
     Ok(())
 }

--- a/generator/src/pac.rs
+++ b/generator/src/pac.rs
@@ -58,6 +58,9 @@ pub fn generate_core(
 
     let device_x = temp.path().join("device.x");
     let output_dir = chip_dir.join(core.to_lowercase());
+    if output_dir.exists() {
+        fs::remove_dir_all(&output_dir).context("removing old PAC core dir")?;
+    }
     fs::create_dir_all(&output_dir)?;
     fs::copy(&device_x, output_dir.join("device.x"))?;
 


### PR DESCRIPTION
The current generator impl doesn't clean the target directory when generating.
This means that if you rename a peripheral, the old files will still remain (unless you manually delete them).
Doing this also uncovered that you couldn't actually start from scratch with a few of the PACs because it tried to call rustfmt on mod.rs when the files it referred to didn't exist yet.

This addresses the "how do I remove old files" aspects of #96