### PR TITLE
Sanitize LPC55 labels in transforms

### DIFF
--- a/data/transforms/lpc55s16.yaml
+++ b/data/transforms/lpc55s16.yaml
@@ -122,6 +122,12 @@ transforms:
     from: iocon::vals::Pio\d+Egp
     to: iocon::vals::PioEgp
 
+  - !MergeFieldsets
+    from: iocon::regs::Pio\d+
+    to: iocon::regs::Pio
+    main: iocon::regs::Pio013
+    check: NoCheck
+
   - !MakeRegisterArray
     blocks: iocon::Iocon
     from: pio0_\d+
@@ -131,12 +137,6 @@ transforms:
     from: pio1_\d+
     to: pio1
 
-  - !MergeFieldsets
-    from: iocon::regs::Pio\d+
-    to: iocon::regs::Pio
-    main: iocon::regs::Pio013
-    check: NoCheck
-
   - !MergeEnums
     from: syscon::vals::Fc\dRst
     to: syscon::vals::FcRst
@@ -144,37 +144,37 @@ transforms:
     from: syscon::vals::Fcclksel\dSel
     to: syscon::vals::FcclkselSel
 
+  - !MergeFieldsets
+    from: syscon::regs::Fcclksel\d
+    to: syscon::regs::Fcclksel
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: fcclksel\d
     to: fcclksel
-  - !MergeFieldsets
-    from: syscon::regs::Fcclksel\d
-    to: syscon::regs::Fcclksel
 
+  - !MergeFieldsets
+    from: syscon::regs::Flexfrg\dctrl
+    to: syscon::regs::Flexfrgctrl
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: flexfrg\dctrl
     to: flexfrgctrl
-  - !MergeFieldsets
-    from: syscon::regs::Flexfrg\dctrl
-    to: syscon::regs::Flexfrgctrl
 
+  - !MergeFieldsets
+    from: syscon::regs::Fcclkselx\d
+    to: syscon::regs::Fcclkselx
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: fcclkselx\d
     to: fcckkselx
-  - !MergeFieldsets
-    from: syscon::regs::Fcclkselx\d
-    to: syscon::regs::Fcclkselx
 
+  - !MergeFieldsets
+    from: syscon::regs::Flexfrgxctrl\d
+    to: syscon::regs::Flexfrgxctrl
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: flexfrgxctrl\d
     to: flexfrgxctrl
-  - !MergeFieldsets
-    from: syscon::regs::Flexfrgxctrl\d
-    to: syscon::regs::Flexfrgxctrl
 
   - !MakeFieldArray
     fieldsets: syscon::regs::Presetctrl1
@@ -195,6 +195,27 @@ transforms:
     to: set_fc
 
   # SCTimer
+  - !MergeEnums
+    from: sct0::vals::O\d+res
+    to: sct0::vals::Ores
+  - !MergeEnums
+    from: sct0::vals::Setclr\d+
+    to: sct0::vals::Setclr
+  - !MergeEnums
+    from: sct0::vals::Bidir[L,H]
+    to: sct0::vals::Bidir
+  - !MergeFieldsets
+    from: sct0::regs::Cap\d+
+    to: sct0::regs::Cap
+  - !MergeFieldsets
+    from: sct0::regs::Capctrl\d+
+    to: sct0::regs::Capctrl
+  - !MergeFieldsets
+    from: sct0::regs::Matchrel\d+
+    to: sct0::regs::Matchrel
+  - !MergeFieldsets
+    from: sct0::regs::Match\d+
+    to: sct0::regs::Match
   - !MakeRegisterArray
     blocks: sct0::Sct0
     from: match\d+
@@ -227,27 +248,6 @@ transforms:
     fieldsets: sct0::regs::Input
     from: sin\d+
     to: sin
-  - !MergeEnums
-    from: sct0::vals::O\d+res
-    to: sct0::vals::Ores
-  - !MergeEnums
-    from: sct0::vals::Setclr\d+
-    to: sct0::vals::Setclr
-  - !MergeFieldsets
-    from: sct0::regs::Cap\d+
-    to: sct0::regs::Cap
-  - !MergeFieldsets
-    from: sct0::regs::Capctrl\d+
-    to: sct0::regs::Capctrl
-  - !MergeFieldsets
-    from: sct0::regs::Matchrel\d+
-    to: sct0::regs::Matchrel
-  - !MergeFieldsets
-    from: sct0::regs::Match\d+
-    to: sct0::regs::Match
-  - !MergeEnums
-    from: sct0::vals::Bidir[L,H]
-    to: sct0::vals::Bidir
 
   # Turn `clr` and `set` in `` into bit arrays.
   - !DeleteFields

--- a/data/transforms/lpc55s16.yaml
+++ b/data/transforms/lpc55s16.yaml
@@ -1,6 +1,7 @@
 includes:
   - useless.yaml
   - cm33.yaml
+  - sanitize.yaml
 transforms:
   - !DeleteEnumVariants
     enum: inputmux::Dma0ItrigInmuxInp

--- a/data/transforms/lpc55s16.yaml
+++ b/data/transforms/lpc55s16.yaml
@@ -4,25 +4,25 @@ includes:
   - sanitize.yaml
 transforms:
   - !DeleteEnumVariants
-    enum: inputmux::Dma0ItrigInmuxInp
+    enum: inputmux::vals::Dma0ItrigInmuxInp
     from: VAL22(.*)
   - !DeleteEnumVariants
-    enum: inputmux::InpN
+    enum: inputmux::vals::InpN
     from: VAL24(.*)
   - !DeleteEnumVariants
-    enum: inputmux::Timer0captselCaptsel
+    enum: inputmux::vals::Timer0captselCaptsel
     from: VAL25(.*)
   - !DeleteEnumVariants
-    enum: inputmux::Timer1captselCaptsel
+    enum: inputmux::vals::Timer1captselCaptsel
     from: VAL25(.*)
   - !DeleteEnumVariants
-    enum: inputmux::Timer2captselCaptsel
+    enum: inputmux::vals::Timer2captselCaptsel
     from: VAL25(.*)
   - !DeleteEnumVariants
-    enum: inputmux::Timer3captselCaptsel
+    enum: inputmux::vals::Timer3captselCaptsel
     from: VAL25(.*)
   - !DeleteEnumVariants
-    enum: inputmux::Timer4captselCaptsel
+    enum: inputmux::vals::Timer4captselCaptsel
     from: VAL25(.*)
 
   # - !DeleteEnumVariants
@@ -30,11 +30,11 @@ transforms:
   #   from: ENUM_0X[5-7]
 
   - !DeleteEnums
-    from: syscon::AdcclkselSel
+    from: syscon::vals::AdcclkselSel
 
   - !Add
     ir:
-      enum/syscon::AdcclkselSel:
+      enum/syscon::vals::AdcclkselSel:
         description: ADC clock source select
         bit_size: 3
         variants:
@@ -54,7 +54,7 @@ transforms:
   # yuppiii it does what i wanted it to do :D
   - !Add
     ir:
-      enum/puf::Key:
+      enum/puf::vals::Key:
         description: Key destination for PUF key.
         bit_size: 8
         variants:
@@ -90,37 +90,37 @@ transforms:
     from: presetctrlx\d
 
   - !Delete
-    from: syscon::Ahbclkctrlx\d
+    from: syscon::regs::Ahbclkctrlx\d
   - !Delete
-    from: syscon::Presetctrlx\d
+    from: syscon::regs::Presetctrlx\d
 
   - !MergeEnums
-    from: iocon::Pio\d+Digimode
-    to: iocon::PioDigimode
+    from: iocon::vals::Pio\d+Digimode
+    to: iocon::vals::PioDigimode
   - !MergeEnums
-    from: iocon::Pio\d+Func
-    to: iocon::PioFunc
+    from: iocon::vals::Pio\d+Func
+    to: iocon::vals::PioFunc
   - !MergeEnums
-    from: iocon::Pio\d+Mode
-    to: iocon::PioMode
+    from: iocon::vals::Pio\d+Mode
+    to: iocon::vals::PioMode
   - !MergeEnums
-    from: iocon::Pio\d+Od
-    to: iocon::PioOd
+    from: iocon::vals::Pio\d+Od
+    to: iocon::vals::PioOd
   - !MergeEnums
-    from: iocon::Pio\d+Slew
-    to: iocon::PioSlew
+    from: iocon::vals::Pio\d+Slew
+    to: iocon::vals::PioSlew
   - !MergeEnums
-    from: iocon::Pio\d+Ssel
-    to: iocon::PioSsel
+    from: iocon::vals::Pio\d+Ssel
+    to: iocon::vals::PioSsel
   - !MergeEnums
-    from: iocon::Pio\d+I2cfilter
-    to: iocon::PioI2cfilter
+    from: iocon::vals::Pio\d+I2cfilter
+    to: iocon::vals::PioI2cfilter
   - !MergeEnums
-    from: iocon::Pio\d+Filteroff
-    to: iocon::PioFilteroff
+    from: iocon::vals::Pio\d+Filteroff
+    to: iocon::vals::PioFilteroff
   - !MergeEnums
-    from: iocon::Pio\d+Egp
-    to: iocon::PioEgp
+    from: iocon::vals::Pio\d+Egp
+    to: iocon::vals::PioEgp
 
   - !MakeRegisterArray
     blocks: iocon::Iocon
@@ -132,65 +132,65 @@ transforms:
     to: pio1
 
   - !MergeFieldsets
-    from: iocon::Pio\d+
-    to: iocon::Pio
-    main: iocon::Pio013
+    from: iocon::regs::Pio\d+
+    to: iocon::regs::Pio
+    main: iocon::regs::Pio013
     check: NoCheck
 
   - !MergeEnums
-    from: syscon::Fc\dRst
-    to: syscon::FcRst
+    from: syscon::vals::Fc\dRst
+    to: syscon::vals::FcRst
   - !MergeEnums
-    from: syscon::Fcclksel\dSel
-    to: syscon::FcclkselSel
+    from: syscon::vals::Fcclksel\dSel
+    to: syscon::vals::FcclkselSel
 
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: fcclksel\d
     to: fcclksel
   - !MergeFieldsets
-    from: syscon::Fcclksel\d
-    to: syscon::Fcclksel
+    from: syscon::regs::Fcclksel\d
+    to: syscon::regs::Fcclksel
 
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: flexfrg\dctrl
     to: flexfrgctrl
   - !MergeFieldsets
-    from: syscon::Flexfrg\dctrl
-    to: syscon::Flexfrgctrl
+    from: syscon::regs::Flexfrg\dctrl
+    to: syscon::regs::Flexfrgctrl
 
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: fcclkselx\d
     to: fcckkselx
   - !MergeFieldsets
-    from: syscon::Fcclkselx\d
-    to: syscon::Fcclkselx
+    from: syscon::regs::Fcclkselx\d
+    to: syscon::regs::Fcclkselx
 
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: flexfrgxctrl\d
     to: flexfrgxctrl
   - !MergeFieldsets
-    from: syscon::Flexfrgxctrl\d
-    to: syscon::Flexfrgxctrl
+    from: syscon::regs::Flexfrgxctrl\d
+    to: syscon::regs::Flexfrgxctrl
 
   - !MakeFieldArray
-    fieldsets: syscon::Presetctrl1
+    fieldsets: syscon::regs::Presetctrl1
     from: fc\d_rst
     to: fc_rst
   - !MakeFieldArray
-    fieldsets: syscon::Presetctrl1
+    fieldsets: syscon::regs::Presetctrl1
     from: set_fc\d_rst
     to: set_fc_rst
 
   - !MakeFieldArray
-    fieldsets: syscon::Ahbclkctrl1
+    fieldsets: syscon::regs::Ahbclkctrl1
     from: fc\d
     to: fc
   - !MakeFieldArray
-    fieldsets: syscon::Ahbclkctrl1
+    fieldsets: syscon::regs::Ahbclkctrl1
     from: set_fc\d
     to: set_fc
 
@@ -212,50 +212,50 @@ transforms:
     from: capctrl\d+
     to: capctrl
   - !MakeFieldArray
-    fieldsets: sct0::Res
+    fieldsets: sct0::regs::Res
     from: o\d+res
     to: ores
   - !MakeFieldArray
-    fieldsets: sct0::Outputdirctrl
+    fieldsets: sct0::regs::Outputdirctrl
     from: setclr\d+
     to: setclr
   - !MakeFieldArray
-    fieldsets: sct0::Input
+    fieldsets: sct0::regs::Input
     from: ain\d+
     to: ain
   - !MakeFieldArray
-    fieldsets: sct0::Input
+    fieldsets: sct0::regs::Input
     from: sin\d+
     to: sin
   - !MergeEnums
-    from: sct0::O\d+res
-    to: sct0::Ores
+    from: sct0::vals::O\d+res
+    to: sct0::vals::Ores
   - !MergeEnums
-    from: sct0::Setclr\d+
-    to: sct0::Setclr
+    from: sct0::vals::Setclr\d+
+    to: sct0::vals::Setclr
   - !MergeFieldsets
-    from: sct0::Cap\d+
-    to: sct0::Cap
+    from: sct0::regs::Cap\d+
+    to: sct0::regs::Cap
   - !MergeFieldsets
-    from: sct0::Capctrl\d+
-    to: sct0::Capctrl
+    from: sct0::regs::Capctrl\d+
+    to: sct0::regs::Capctrl
   - !MergeFieldsets
-    from: sct0::Matchrel\d+
-    to: sct0::Matchrel
+    from: sct0::regs::Matchrel\d+
+    to: sct0::regs::Matchrel
   - !MergeFieldsets
-    from: sct0::Match\d+
-    to: sct0::Match
+    from: sct0::regs::Match\d+
+    to: sct0::regs::Match
   - !MergeEnums
-    from: sct0::Bidir[L,H]
-    to: sct0::Bidir
+    from: sct0::vals::Bidir[L,H]
+    to: sct0::vals::Bidir
 
   # Turn `clr` and `set` in `` into bit arrays.
   - !DeleteFields
-    fieldset: sct0::Out(Clr|Set)
+    fieldset: sct0::regs::Out(Clr|Set)
     from: .*
 
   - !AddFields
-    fieldset: sct0::OutClr
+    fieldset: sct0::regs::OutClr
     fields:
       - name: clr
         bit_offset: 0
@@ -264,7 +264,7 @@ transforms:
           len: 16
           stride: 1
   - !AddFields
-    fieldset: sct0::OutSet
+    fieldset: sct0::regs::OutSet
     fields:
       - name: set
         bit_offset: 0

--- a/data/transforms/lpc55s69_cm33.yaml
+++ b/data/transforms/lpc55s69_cm33.yaml
@@ -124,14 +124,6 @@ transforms:
     from: iocon::vals::Pio\d+Egp
     to: iocon::vals::PioEgp
 
-  - !MakeRegisterArray
-    blocks: iocon::Iocon
-    from: pio0_\d+
-    to: pio0
-  - !MakeRegisterArray
-    blocks: iocon::Iocon
-    from: pio1_\d+
-    to: pio1
 
   - !MergeFieldsets
     from: iocon::regs::Pio\d+
@@ -148,6 +140,15 @@ transforms:
         bit_size: 1
         enum: iocon::vals::PioAsw
 
+  - !MakeRegisterArray
+    blocks: iocon::Iocon
+    from: pio0_\d+
+    to: pio0
+  - !MakeRegisterArray
+    blocks: iocon::Iocon
+    from: pio1_\d+
+    to: pio1
+
   - !MergeEnums
     from: syscon::vals::Fc\dRst
     to: syscon::vals::FcRst
@@ -155,37 +156,37 @@ transforms:
     from: syscon::vals::Fcclksel\dSel
     to: syscon::vals::FcclkselSel
 
+  - !MergeFieldsets
+    from: syscon::regs::Fcclksel\d
+    to: syscon::regs::Fcclksel
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: fcclksel\d
     to: fcclksel
-  - !MergeFieldsets
-    from: syscon::regs::Fcclksel\d
-    to: syscon::regs::Fcclksel
 
+  - !MergeFieldsets
+    from: syscon::regs::Flexfrg\dctrl
+    to: syscon::regs::Flexfrgctrl
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: flexfrg\dctrl
     to: flexfrgctrl
-  - !MergeFieldsets
-    from: syscon::regs::Flexfrg\dctrl
-    to: syscon::regs::Flexfrgctrl
 
+  - !MergeFieldsets
+    from: syscon::regs::Fcclkselx\d
+    to: syscon::regs::Fcclkselx
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: fcclkselx\d
     to: fcckkselx
-  - !MergeFieldsets
-    from: syscon::regs::Fcclkselx\d
-    to: syscon::regs::Fcclkselx
 
+  - !MergeFieldsets
+    from: syscon::regs::Flexfrgxctrl\d
+    to: syscon::regs::Flexfrgxctrl
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: flexfrgxctrl\d
     to: flexfrgxctrl
-  - !MergeFieldsets
-    from: syscon::regs::Flexfrgxctrl\d
-    to: syscon::regs::Flexfrgxctrl
 
   - !MakeFieldArray
     fieldsets: syscon::regs::Presetctrl1
@@ -206,6 +207,27 @@ transforms:
     to: set_fc
 
   # SCTimer
+  - !MergeEnums
+    from: sct0::vals::O\d+res
+    to: sct0::vals::Ores
+  - !MergeEnums
+    from: sct0::vals::Setclr\d+
+    to: sct0::vals::Setclr
+  - !MergeEnums
+    from: sct0::vals::Bidir[L,H]
+    to: sct0::vals::Bidir
+  - !MergeFieldsets
+    from: sct0::regs::Cap\d+
+    to: sct0::regs::Cap
+  - !MergeFieldsets
+    from: sct0::regs::Capctrl\d+
+    to: sct0::regs::Capctrl
+  - !MergeFieldsets
+    from: sct0::regs::Matchrel\d+
+    to: sct0::regs::Matchrel
+  - !MergeFieldsets
+    from: sct0::regs::Match\d+
+    to: sct0::regs::Match
   - !MakeRegisterArray
     blocks: sct0::Sct0
     from: match\d+
@@ -238,27 +260,6 @@ transforms:
     fieldsets: sct0::regs::Input
     from: sin\d+
     to: sin
-  - !MergeEnums
-    from: sct0::vals::O\d+res
-    to: sct0::vals::Ores
-  - !MergeEnums
-    from: sct0::vals::Setclr\d+
-    to: sct0::vals::Setclr
-  - !MergeFieldsets
-    from: sct0::regs::Cap\d+
-    to: sct0::regs::Cap
-  - !MergeFieldsets
-    from: sct0::regs::Capctrl\d+
-    to: sct0::regs::Capctrl
-  - !MergeFieldsets
-    from: sct0::regs::Matchrel\d+
-    to: sct0::regs::Matchrel
-  - !MergeFieldsets
-    from: sct0::regs::Match\d+
-    to: sct0::regs::Match
-  - !MergeEnums
-    from: sct0::vals::Bidir[L,H]
-    to: sct0::vals::Bidir
 
   # Turn `clr` and `set` in `` into bit arrays.
   - !DeleteFields

--- a/data/transforms/lpc55s69_cm33.yaml
+++ b/data/transforms/lpc55s69_cm33.yaml
@@ -3,25 +3,25 @@ includes:
   - sanitize.yaml
 transforms:
   - !DeleteEnumVariants
-    enum: inputmux::Dma0ItrigInmuxInp
+    enum: inputmux::vals::Dma0ItrigInmuxInp
     from: VAL22(.*)
   - !DeleteEnumVariants
-    enum: inputmux::InpN
+    enum: inputmux::vals::InpN
     from: VAL24(.*)
   - !DeleteEnumVariants
-    enum: inputmux::Timer0captselCaptsel
+    enum: inputmux::vals::Timer0captselCaptsel
     from: VAL25(.*)
   - !DeleteEnumVariants
-    enum: inputmux::Timer1captselCaptsel
+    enum: inputmux::vals::Timer1captselCaptsel
     from: VAL25(.*)
   - !DeleteEnumVariants
-    enum: inputmux::Timer2captselCaptsel
+    enum: inputmux::vals::Timer2captselCaptsel
     from: VAL25(.*)
   - !DeleteEnumVariants
-    enum: inputmux::Timer3captselCaptsel
+    enum: inputmux::vals::Timer3captselCaptsel
     from: VAL25(.*)
   - !DeleteEnumVariants
-    enum: inputmux::Timer4captselCaptsel
+    enum: inputmux::vals::Timer4captselCaptsel
     from: VAL25(.*)
 
   # - !DeleteEnumVariants
@@ -29,11 +29,11 @@ transforms:
   #   from: ENUM_0X[5-7]
 
   - !DeleteEnums
-    from: syscon::AdcclkselSel
+    from: syscon::vals::AdcclkselSel
 
   - !Add
     ir:
-      enum/syscon::AdcclkselSel:
+      enum/syscon::vals::AdcclkselSel:
         description: ADC clock source select
         bit_size: 3
         variants:
@@ -53,7 +53,7 @@ transforms:
   # yuppiii it does what i wanted it to do :D
   - !Add
     ir:
-      enum/puf::Key:
+      enum/puf::vals::Key:
         description: Key destination for PUF key.
         bit_size: 8
         variants:
@@ -89,40 +89,40 @@ transforms:
     from: presetctrlx\d
 
   - !Delete
-    from: syscon::Ahbclkctrlx\d
+    from: syscon::regs::Ahbclkctrlx\d
   - !Delete
-    from: syscon::Presetctrlx\d
+    from: syscon::regs::Presetctrlx\d
 
   - !MergeEnums
-    from: iocon::Pio\d+Asw
-    to: iocon::PioAsw
+    from: iocon::vals::Pio\d+Asw
+    to: iocon::vals::PioAsw
   - !MergeEnums
-    from: iocon::Pio\d+Digimode
-    to: iocon::PioDigimode
+    from: iocon::vals::Pio\d+Digimode
+    to: iocon::vals::PioDigimode
   - !MergeEnums
-    from: iocon::Pio\d+Func
-    to: iocon::PioFunc
+    from: iocon::vals::Pio\d+Func
+    to: iocon::vals::PioFunc
   - !MergeEnums
-    from: iocon::Pio\d+Mode
-    to: iocon::PioMode
+    from: iocon::vals::Pio\d+Mode
+    to: iocon::vals::PioMode
   - !MergeEnums
-    from: iocon::Pio\d+Od
-    to: iocon::PioOd
+    from: iocon::vals::Pio\d+Od
+    to: iocon::vals::PioOd
   - !MergeEnums
-    from: iocon::Pio\d+Slew
-    to: iocon::PioSlew
+    from: iocon::vals::Pio\d+Slew
+    to: iocon::vals::PioSlew
   - !MergeEnums
-    from: iocon::Pio\d+Ssel
-    to: iocon::PioSsel
+    from: iocon::vals::Pio\d+Ssel
+    to: iocon::vals::PioSsel
   - !MergeEnums
-    from: iocon::Pio\d+I2cfilter
-    to: iocon::PioI2cfilter
+    from: iocon::vals::Pio\d+I2cfilter
+    to: iocon::vals::PioI2cfilter
   - !MergeEnums
-    from: iocon::Pio\d+Filteroff
-    to: iocon::PioFilteroff
+    from: iocon::vals::Pio\d+Filteroff
+    to: iocon::vals::PioFilteroff
   - !MergeEnums
-    from: iocon::Pio\d+Egp
-    to: iocon::PioEgp
+    from: iocon::vals::Pio\d+Egp
+    to: iocon::vals::PioEgp
 
   - !MakeRegisterArray
     blocks: iocon::Iocon
@@ -134,74 +134,74 @@ transforms:
     to: pio1
 
   - !MergeFieldsets
-    from: iocon::Pio\d+
-    to: iocon::Pio
-    main: iocon::Pio013
+    from: iocon::regs::Pio\d+
+    to: iocon::regs::Pio
+    main: iocon::regs::Pio013
     check: NoCheck
 
   - !AddFields
-    fieldset: iocon::Pio
+    fieldset: iocon::regs::Pio
     fields:
       - name: asw
         description: "Analog switch input control."
         bit_offset: 10
         bit_size: 1
-        enum: iocon::PioAsw
+        enum: iocon::vals::PioAsw
 
   - !MergeEnums
-    from: syscon::Fc\dRst
-    to: syscon::FcRst
+    from: syscon::vals::Fc\dRst
+    to: syscon::vals::FcRst
   - !MergeEnums
-    from: syscon::Fcclksel\dSel
-    to: syscon::FcclkselSel
+    from: syscon::vals::Fcclksel\dSel
+    to: syscon::vals::FcclkselSel
 
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: fcclksel\d
     to: fcclksel
   - !MergeFieldsets
-    from: syscon::Fcclksel\d
-    to: syscon::Fcclksel
+    from: syscon::regs::Fcclksel\d
+    to: syscon::regs::Fcclksel
 
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: flexfrg\dctrl
     to: flexfrgctrl
   - !MergeFieldsets
-    from: syscon::Flexfrg\dctrl
-    to: syscon::Flexfrgctrl
+    from: syscon::regs::Flexfrg\dctrl
+    to: syscon::regs::Flexfrgctrl
 
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: fcclkselx\d
     to: fcckkselx
   - !MergeFieldsets
-    from: syscon::Fcclkselx\d
-    to: syscon::Fcclkselx
+    from: syscon::regs::Fcclkselx\d
+    to: syscon::regs::Fcclkselx
 
   - !MakeRegisterArray
     blocks: syscon::Syscon
     from: flexfrgxctrl\d
     to: flexfrgxctrl
   - !MergeFieldsets
-    from: syscon::Flexfrgxctrl\d
-    to: syscon::Flexfrgxctrl
+    from: syscon::regs::Flexfrgxctrl\d
+    to: syscon::regs::Flexfrgxctrl
 
   - !MakeFieldArray
-    fieldsets: syscon::Presetctrl1
+    fieldsets: syscon::regs::Presetctrl1
     from: fc\d_rst
     to: fc_rst
   - !MakeFieldArray
-    fieldsets: syscon::Presetctrl1
+    fieldsets: syscon::regs::Presetctrl1
     from: set_fc\d_rst
     to: set_fc_rst
 
   - !MakeFieldArray
-    fieldsets: syscon::Ahbclkctrl1
+    fieldsets: syscon::regs::Ahbclkctrl1
     from: fc\d
     to: fc
   - !MakeFieldArray
-    fieldsets: syscon::Ahbclkctrl1
+    fieldsets: syscon::regs::Ahbclkctrl1
     from: set_fc\d
     to: set_fc
 
@@ -223,50 +223,50 @@ transforms:
     from: capctrl\d+
     to: capctrl
   - !MakeFieldArray
-    fieldsets: sct0::Res
+    fieldsets: sct0::regs::Res
     from: o\d+res
     to: ores
   - !MakeFieldArray
-    fieldsets: sct0::Outputdirctrl
+    fieldsets: sct0::regs::Outputdirctrl
     from: setclr\d+
     to: setclr
   - !MakeFieldArray
-    fieldsets: sct0::Input
+    fieldsets: sct0::regs::Input
     from: ain\d+
     to: ain
   - !MakeFieldArray
-    fieldsets: sct0::Input
+    fieldsets: sct0::regs::Input
     from: sin\d+
     to: sin
   - !MergeEnums
-    from: sct0::O\d+res
-    to: sct0::Ores
+    from: sct0::vals::O\d+res
+    to: sct0::vals::Ores
   - !MergeEnums
-    from: sct0::Setclr\d+
-    to: sct0::Setclr
+    from: sct0::vals::Setclr\d+
+    to: sct0::vals::Setclr
   - !MergeFieldsets
-    from: sct0::Cap\d+
-    to: sct0::Cap
+    from: sct0::regs::Cap\d+
+    to: sct0::regs::Cap
   - !MergeFieldsets
-    from: sct0::Capctrl\d+
-    to: sct0::Capctrl
+    from: sct0::regs::Capctrl\d+
+    to: sct0::regs::Capctrl
   - !MergeFieldsets
-    from: sct0::Matchrel\d+
-    to: sct0::Matchrel
+    from: sct0::regs::Matchrel\d+
+    to: sct0::regs::Matchrel
   - !MergeFieldsets
-    from: sct0::Match\d+
-    to: sct0::Match
+    from: sct0::regs::Match\d+
+    to: sct0::regs::Match
   - !MergeEnums
-    from: sct0::Bidir[L,H]
-    to: sct0::Bidir
+    from: sct0::vals::Bidir[L,H]
+    to: sct0::vals::Bidir
 
   # Turn `clr` and `set` in `` into bit arrays.
   - !DeleteFields
-    fieldset: sct0::Out(Clr|Set)
+    fieldset: sct0::regs::Out(Clr|Set)
     from: .*
 
   - !AddFields
-    fieldset: sct0::OutClr
+    fieldset: sct0::regs::OutClr
     fields:
       - name: clr
         bit_offset: 0
@@ -275,7 +275,7 @@ transforms:
           len: 16
           stride: 1
   - !AddFields
-    fieldset: sct0::OutSet
+    fieldset: sct0::regs::OutSet
     fields:
       - name: set
         bit_offset: 0

--- a/data/transforms/lpc55s69_cm33.yaml
+++ b/data/transforms/lpc55s69_cm33.yaml
@@ -1,5 +1,6 @@
 includes:
   - cm33.yaml
+  - sanitize.yaml
 transforms:
   - !DeleteEnumVariants
     enum: inputmux::Dma0ItrigInmuxInp


### PR DESCRIPTION
As noted in #100, chiptool doesn't automatically sanitize labels and LPC55 wasn't calling sanitize.
Update all the transforms to work with with the newer chiptool. Some needed to be reordered to deal with these changes.

Note that there's still a ton of churn in the output with this approach compared to the previous PAC (which I think is due to changes in how chiptool does sanitize).

Example of the sort of diff I'm seeing in the output:

```
+++ b/nxp-pac/src/chips/lpc55s16/adc0/vals.rs
@@ -3,9 +3,9 @@
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AdcActive {
     #[doc = "The ADC is IDLE. There are no pending triggers to service and no active commands are being processed."]
-    ADC_ACTIVE_0 = 0x0,
+    AdcActive0 = 0x0,
     #[doc = "The ADC is processing a conversion, running through the power up delay, or servicing a trigger."]
-    ADC_ACTIVE_1 = 0x01,
+    AdcActive1 = 0x01,
 }
```
