### PR TITLE
Small flexspi cleanup

### DIFF
--- a/data/metadata/peripherals/README.md
+++ b/data/metadata/peripherals/README.md
@@ -17,7 +17,7 @@ Anything in this folder is not used directly, but can be used by you as a start 
 This is per device:
 
 - A YAML per peripheral, with transforms applied and namespaces stripped. These files are suitable to base your metapac peripheral definition files on.
-- Everything in the `raw/original` folder, which are the same files but without the namespaces stripped. These files are the direct output of the transforms, and thus useful when developing the transforms.
+- Everything in the `raw/post-transforms` folder, which are the same files but without the namespaces stripped. These files are the direct output of the transforms, and thus useful when developing the transforms.
 - `_addresses.json`: A list of all peripherals and their addresses, taken from the SVD. Handy for adding it to the metadata.
 - `_interrupts.json`: A list of all interrupts and their numbers, taken from the SVD. Handy for adding it to the metadata.
 

--- a/data/metadata/peripherals/mcxa/FLEXSPI.yaml
+++ b/data/metadata/peripherals/mcxa/FLEXSPI.yaml
@@ -72,22 +72,13 @@ block/Flexspi:
       stride: 4
     byte_offset: 64
     access: Read
-  - name: flsha1cr0
+  - name: flshcr0
     description: Flash Control 0.
+    array:
+      len: 4
+      stride: 4
     byte_offset: 96
-    fieldset: Flsha1cr0
-  - name: flsha2cr0
-    description: Flash Control 0.
-    byte_offset: 100
-    fieldset: Flsha2cr0
-  - name: flshb1cr0
-    description: Flash Control 0.
-    byte_offset: 104
-    fieldset: Flshb1cr0
-  - name: flshb2cr0
-    description: Flash Control 0.
-    byte_offset: 108
-    fieldset: Flshb2cr0
+    fieldset: Flshcr0
   - name: flshcr1
     description: Flash Control 1.
     array:
@@ -788,40 +779,7 @@ fieldset/Dlpr:
     description: Data Learning Pattern.
     bit_offset: 0
     bit_size: 32
-fieldset/Flsha1cr0:
-  description: Flash Control 0.
-  fields:
-  - name: flshsz
-    description: Flash Size in KB.
-    bit_offset: 0
-    bit_size: 23
-  - name: addrshift
-    description: AHB Address Shift Function control.
-    bit_offset: 29
-    bit_size: 1
-fieldset/Flsha2cr0:
-  description: Flash Control 0.
-  fields:
-  - name: flshsz
-    description: Flash Size in KB.
-    bit_offset: 0
-    bit_size: 23
-  - name: addrshift
-    description: AHB Address Shift Function control.
-    bit_offset: 29
-    bit_size: 1
-fieldset/Flshb1cr0:
-  description: Flash Control 0.
-  fields:
-  - name: flshsz
-    description: Flash Size in KB.
-    bit_offset: 0
-    bit_size: 23
-  - name: addrshift
-    description: AHB Address Shift Function control.
-    bit_offset: 29
-    bit_size: 1
-fieldset/Flshb2cr0:
+fieldset/Flshcr0:
   description: Flash Control 0.
   fields:
   - name: flshsz

--- a/data/transforms/mcxa/flexspi.yaml
+++ b/data/transforms/mcxa/flexspi.yaml
@@ -1,0 +1,8 @@
+transforms:
+  - !MergeFieldsets
+    from: flexspi0::Flsh(a|b)(\d+)cr0
+    to: flexspi::Flshcr0
+  - !MakeRegisterArray
+    blocks: flexspi0::Flexspi0
+    from: flsh(a|b)(\d+)cr0
+    to: flshcr0

--- a/data/transforms/mcxa577.yaml
+++ b/data/transforms/mcxa577.yaml
@@ -36,6 +36,7 @@ includes:
   - mcxa/spc.yaml
   - mcxa/trng.yaml
   - mcxa/wwdt.yaml
+  - mcxa/flexspi.yaml
 
   - remove-suffix.yaml
 transforms:

--- a/generator/src/metadata.rs
+++ b/generator/src/metadata.rs
@@ -387,16 +387,21 @@ pub fn extract_peripherals(
         }
     }
 
-    let original_dir = &output_dir.join("original");
+    let post_transforms_dir = &output_dir.join("post-transforms");
 
-    if !fs::exists(original_dir).context("checking output original subdirectory existance")? {
-        fs::create_dir(original_dir).with_context(|| {
-            format!("creating original subdirectory {}", original_dir.display())
+    if !fs::exists(post_transforms_dir)
+        .context("checking output post-transforms subdirectory existance")?
+    {
+        fs::create_dir(post_transforms_dir).with_context(|| {
+            format!(
+                "creating post-transforms subdirectory {}",
+                post_transforms_dir.display()
+            )
         })?;
     }
 
     chiptool::commands::extract_all::extract_all(ExtractAll {
-        output: original_dir.canonicalize()?,
+        output: post_transforms_dir.canonicalize()?,
         extract_shared: ExtractShared {
             svd: svd.canonicalize()?,
             transform,
@@ -407,7 +412,7 @@ pub fn extract_peripherals(
     .with_context(|| format!("Error generating peripheral yamls for {core}"))?;
 
     let path_regex = regex::Regex::new("^(.+)__.+$")?;
-    for entry in fs::read_dir(original_dir).context("reading original subdir")? {
+    for entry in fs::read_dir(post_transforms_dir).context("reading post-transforms subdir")? {
         let entry = entry?;
 
         let filename: String = entry.file_name().to_string_lossy().into_owned();

--- a/nxp-pac/src/meta_peripherals/mcxa/FLEXSPI.rs
+++ b/nxp-pac/src/meta_peripherals/mcxa/FLEXSPI.rs
@@ -127,23 +127,14 @@ impl Flexspi {
     }
     #[doc = "Flash Control 0."]
     #[inline(always)]
-    pub const fn flsha1cr0(self) -> crate::pac::common::Reg<Flsha1cr0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x60usize) as _) }
-    }
-    #[doc = "Flash Control 0."]
-    #[inline(always)]
-    pub const fn flsha2cr0(self) -> crate::pac::common::Reg<Flsha2cr0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x64usize) as _) }
-    }
-    #[doc = "Flash Control 0."]
-    #[inline(always)]
-    pub const fn flshb1cr0(self) -> crate::pac::common::Reg<Flshb1cr0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x68usize) as _) }
-    }
-    #[doc = "Flash Control 0."]
-    #[inline(always)]
-    pub const fn flshb2cr0(self) -> crate::pac::common::Reg<Flshb2cr0, crate::pac::common::RW> {
-        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x6cusize) as _) }
+    pub const fn flshcr0(
+        self,
+        n: usize,
+    ) -> crate::pac::common::Reg<Flshcr0, crate::pac::common::RW> {
+        assert!(n < 4usize);
+        unsafe {
+            crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x60usize + n * 4usize) as _)
+        }
     }
     #[doc = "Flash Control 1."]
     #[inline(always)]
@@ -2141,8 +2132,8 @@ impl defmt::Format for Dlpr {
 #[doc = "Flash Control 0."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct Flsha1cr0(pub u32);
-impl Flsha1cr0 {
+pub struct Flshcr0(pub u32);
+impl Flshcr0 {
     #[doc = "Flash Size in KB."]
     #[must_use]
     #[inline(always)]
@@ -2168,191 +2159,26 @@ impl Flsha1cr0 {
         self.0 = (self.0 & !(0x01 << 29usize)) | (((val as u32) & 0x01) << 29usize);
     }
 }
-impl Default for Flsha1cr0 {
+impl Default for Flshcr0 {
     #[inline(always)]
-    fn default() -> Flsha1cr0 {
-        Flsha1cr0(0)
+    fn default() -> Flshcr0 {
+        Flshcr0(0)
     }
 }
-impl core::fmt::Debug for Flsha1cr0 {
+impl core::fmt::Debug for Flshcr0 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("Flsha1cr0")
+        f.debug_struct("Flshcr0")
             .field("flshsz", &self.flshsz())
             .field("addrshift", &self.addrshift())
             .finish()
     }
 }
 #[cfg(feature = "defmt")]
-impl defmt::Format for Flsha1cr0 {
+impl defmt::Format for Flshcr0 {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "Flsha1cr0 {{ flshsz: {=u32:?}, addrshift: {=bool:?} }}",
-            self.flshsz(),
-            self.addrshift()
-        )
-    }
-}
-#[doc = "Flash Control 0."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct Flsha2cr0(pub u32);
-impl Flsha2cr0 {
-    #[doc = "Flash Size in KB."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn flshsz(&self) -> u32 {
-        let val = (self.0 >> 0usize) & 0x007f_ffff;
-        val as u32
-    }
-    #[doc = "Flash Size in KB."]
-    #[inline(always)]
-    pub const fn set_flshsz(&mut self, val: u32) {
-        self.0 = (self.0 & !(0x007f_ffff << 0usize)) | (((val as u32) & 0x007f_ffff) << 0usize);
-    }
-    #[doc = "AHB Address Shift Function control."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn addrshift(&self) -> bool {
-        let val = (self.0 >> 29usize) & 0x01;
-        val != 0
-    }
-    #[doc = "AHB Address Shift Function control."]
-    #[inline(always)]
-    pub const fn set_addrshift(&mut self, val: bool) {
-        self.0 = (self.0 & !(0x01 << 29usize)) | (((val as u32) & 0x01) << 29usize);
-    }
-}
-impl Default for Flsha2cr0 {
-    #[inline(always)]
-    fn default() -> Flsha2cr0 {
-        Flsha2cr0(0)
-    }
-}
-impl core::fmt::Debug for Flsha2cr0 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("Flsha2cr0")
-            .field("flshsz", &self.flshsz())
-            .field("addrshift", &self.addrshift())
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for Flsha2cr0 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "Flsha2cr0 {{ flshsz: {=u32:?}, addrshift: {=bool:?} }}",
-            self.flshsz(),
-            self.addrshift()
-        )
-    }
-}
-#[doc = "Flash Control 0."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct Flshb1cr0(pub u32);
-impl Flshb1cr0 {
-    #[doc = "Flash Size in KB."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn flshsz(&self) -> u32 {
-        let val = (self.0 >> 0usize) & 0x007f_ffff;
-        val as u32
-    }
-    #[doc = "Flash Size in KB."]
-    #[inline(always)]
-    pub const fn set_flshsz(&mut self, val: u32) {
-        self.0 = (self.0 & !(0x007f_ffff << 0usize)) | (((val as u32) & 0x007f_ffff) << 0usize);
-    }
-    #[doc = "AHB Address Shift Function control."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn addrshift(&self) -> bool {
-        let val = (self.0 >> 29usize) & 0x01;
-        val != 0
-    }
-    #[doc = "AHB Address Shift Function control."]
-    #[inline(always)]
-    pub const fn set_addrshift(&mut self, val: bool) {
-        self.0 = (self.0 & !(0x01 << 29usize)) | (((val as u32) & 0x01) << 29usize);
-    }
-}
-impl Default for Flshb1cr0 {
-    #[inline(always)]
-    fn default() -> Flshb1cr0 {
-        Flshb1cr0(0)
-    }
-}
-impl core::fmt::Debug for Flshb1cr0 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("Flshb1cr0")
-            .field("flshsz", &self.flshsz())
-            .field("addrshift", &self.addrshift())
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for Flshb1cr0 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "Flshb1cr0 {{ flshsz: {=u32:?}, addrshift: {=bool:?} }}",
-            self.flshsz(),
-            self.addrshift()
-        )
-    }
-}
-#[doc = "Flash Control 0."]
-#[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct Flshb2cr0(pub u32);
-impl Flshb2cr0 {
-    #[doc = "Flash Size in KB."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn flshsz(&self) -> u32 {
-        let val = (self.0 >> 0usize) & 0x007f_ffff;
-        val as u32
-    }
-    #[doc = "Flash Size in KB."]
-    #[inline(always)]
-    pub const fn set_flshsz(&mut self, val: u32) {
-        self.0 = (self.0 & !(0x007f_ffff << 0usize)) | (((val as u32) & 0x007f_ffff) << 0usize);
-    }
-    #[doc = "AHB Address Shift Function control."]
-    #[must_use]
-    #[inline(always)]
-    pub const fn addrshift(&self) -> bool {
-        let val = (self.0 >> 29usize) & 0x01;
-        val != 0
-    }
-    #[doc = "AHB Address Shift Function control."]
-    #[inline(always)]
-    pub const fn set_addrshift(&mut self, val: bool) {
-        self.0 = (self.0 & !(0x01 << 29usize)) | (((val as u32) & 0x01) << 29usize);
-    }
-}
-impl Default for Flshb2cr0 {
-    #[inline(always)]
-    fn default() -> Flshb2cr0 {
-        Flshb2cr0(0)
-    }
-}
-impl core::fmt::Debug for Flshb2cr0 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("Flshb2cr0")
-            .field("flshsz", &self.flshsz())
-            .field("addrshift", &self.addrshift())
-            .finish()
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for Flshb2cr0 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "Flshb2cr0 {{ flshsz: {=u32:?}, addrshift: {=bool:?} }}",
+            "Flshcr0 {{ flshsz: {=u32:?}, addrshift: {=bool:?} }}",
             self.flshsz(),
             self.addrshift()
         )


### PR DESCRIPTION
The CR1 & CR2 registers are arrays, but CR0 not for some reason.
This PR fixes that.

It also renames the original folder as that led to some confusion