### PR TITLE
Add MCXA577 USBHS PAC registers

### DIFF
--- a/data/metadata/MCXA5xx.json
+++ b/data/metadata/MCXA5xx.json
@@ -10552,6 +10552,8 @@
     },
     {
       "name": "USB1",
+      "address": "0x4002E000",
+      "block": "mcxa/USBHS",
       "signals": [
         {
           "name": "OTGn_ID",
@@ -10596,7 +10598,15 @@
       ]
     },
     {
+      "name": "USBNC",
+      "address": "0x4002E200",
+      "block": "mcxa/USBNC",
+      "signals": []
+    },
+    {
       "name": "USB1_HS_PHY",
+      "address": "0x4002F000",
+      "block": "mcxa/USBPHY",
       "signals": []
     },
     {

--- a/data/metadata/peripherals/mcxa/USBHS.yaml
+++ b/data/metadata/peripherals/mcxa/USBHS.yaml
@@ -1,0 +1,3361 @@
+block/Usbhs:
+  description: USBC.
+  items:
+  - name: ID
+    description: Identification.
+    byte_offset: 0
+    access: Read
+    fieldset: ID
+  - name: HWGENERAL
+    description: Hardware General.
+    byte_offset: 4
+    access: Read
+    fieldset: HWGENERAL
+  - name: HWHOST
+    description: Host Hardware Parameters.
+    byte_offset: 8
+    access: Read
+    fieldset: HWHOST
+  - name: HWDEVICE
+    description: Device Hardware Parameters.
+    byte_offset: 12
+    access: Read
+    fieldset: HWDEVICE
+  - name: HWTXBUF
+    description: TX Buffer Hardware Parameters.
+    byte_offset: 16
+    access: Read
+    fieldset: HWTXBUF
+  - name: HWRXBUF
+    description: RX Buffer Hardware Parameters.
+    byte_offset: 20
+    access: Read
+    fieldset: HWRXBUF
+  - name: GPTIMER0LD
+    description: General Purpose Timer 0 Load.
+    byte_offset: 128
+    fieldset: GPTIMER0LD
+  - name: GPTIMER0CTRL
+    description: General Purpose Timer 0 Controller.
+    byte_offset: 132
+    fieldset: GPTIMER0CTRL
+  - name: GPTIMER1LD
+    description: General Purpose Timer 1 Load.
+    byte_offset: 136
+    fieldset: GPTIMER1LD
+  - name: GPTIMER1CTRL
+    description: General Purpose Timer 1 Controller.
+    byte_offset: 140
+    fieldset: GPTIMER1CTRL
+  - name: SBUSCFG
+    description: System Bus Configuration.
+    byte_offset: 144
+    fieldset: SBUSCFG
+  - name: CAPLENGTH
+    description: Capability Registers Length.
+    byte_offset: 256
+    access: Read
+    bit_size: 8
+    fieldset: CAPLENGTH
+  - name: HCIVERSION
+    description: Host Controller Interface Version.
+    byte_offset: 258
+    access: Read
+    bit_size: 16
+    fieldset: HCIVERSION
+  - name: HCSPARAMS
+    description: Host Controller Structural Parameters.
+    byte_offset: 260
+    access: Read
+    fieldset: HCSPARAMS
+  - name: HCCPARAMS
+    description: Host Controller Capability Parameters.
+    byte_offset: 264
+    access: Read
+    fieldset: HCCPARAMS
+  - name: DCIVERSION
+    description: Device Controller Interface Version.
+    byte_offset: 288
+    access: Read
+    bit_size: 16
+    fieldset: DCIVERSION
+  - name: DCCPARAMS
+    description: Device Controller Capability Parameters.
+    byte_offset: 292
+    access: Read
+    fieldset: DCCPARAMS
+  - name: USBCMD
+    description: USB Command.
+    byte_offset: 320
+    fieldset: USBCMD
+  - name: USBSTS
+    description: USB Status.
+    byte_offset: 324
+    fieldset: USBSTS
+  - name: USBINTR
+    description: Interrupt Enable.
+    byte_offset: 328
+    fieldset: USBINTR
+  - name: FRINDEX
+    description: USB Frame Index.
+    byte_offset: 332
+    fieldset: FRINDEX
+  - name: DEVICEADDR
+    description: Device Address.
+    byte_offset: 340
+    fieldset: DEVICEADDR
+  - name: PERIODICLISTBASE
+    description: Frame List Base Address.
+    byte_offset: 340
+    fieldset: PERIODICLISTBASE
+  - name: ASYNCLISTADDR
+    description: Next Asynchronous Address.
+    byte_offset: 344
+    fieldset: ASYNCLISTADDR
+  - name: ENDPTLISTADDR
+    description: Endpoint List Address.
+    byte_offset: 344
+    fieldset: ENDPTLISTADDR
+  - name: BURSTSIZE
+    description: Programmable Burst Size.
+    byte_offset: 352
+    fieldset: BURSTSIZE
+  - name: TXFILLTUNING
+    description: TX FIFO Fill Tuning.
+    byte_offset: 356
+    fieldset: TXFILLTUNING
+  - name: ENDPTNAK
+    description: Endpoint NAK.
+    byte_offset: 376
+    fieldset: ENDPTNAK
+  - name: ENDPTNAKEN
+    description: Endpoint NAK Enable.
+    byte_offset: 380
+    fieldset: ENDPTNAKEN
+  - name: CONFIGFLAG
+    description: Configure Flag.
+    byte_offset: 384
+    access: Read
+    fieldset: CONFIGFLAG
+  - name: PORTSC1
+    description: Port Status and Control.
+    byte_offset: 388
+    fieldset: PORTSC1
+  - name: OTGSC
+    description: On-The-Go Status and Control.
+    byte_offset: 420
+    fieldset: OTGSC
+  - name: USBMODE
+    description: USB Device Mode.
+    byte_offset: 424
+    fieldset: USBMODE
+  - name: ENDPTSETUPSTAT
+    description: Endpoint Setup Status.
+    byte_offset: 428
+    fieldset: ENDPTSETUPSTAT
+  - name: ENDPTPRIME
+    description: Endpoint Prime.
+    byte_offset: 432
+    fieldset: ENDPTPRIME
+  - name: ENDPTFLUSH
+    description: Endpoint Flush.
+    byte_offset: 436
+    fieldset: ENDPTFLUSH
+  - name: ENDPTSTAT
+    description: Endpoint Status.
+    byte_offset: 440
+    access: Read
+    fieldset: ENDPTSTAT
+  - name: ENDPTCOMPLETE
+    description: Endpoint Complete.
+    byte_offset: 444
+    fieldset: ENDPTCOMPLETE
+  - name: ENDPTCTRL0
+    description: Endpoint Control 0.
+    byte_offset: 448
+    fieldset: ENDPTCTRL0
+  - name: ENDPTCTRL1
+    description: Endpoint Control 1.
+    byte_offset: 452
+    fieldset: ENDPTCTRL1
+  - name: ENDPTCTRL2
+    description: Endpoint Control 2.
+    byte_offset: 456
+    fieldset: ENDPTCTRL2
+  - name: ENDPTCTRL3
+    description: Endpoint Control 3.
+    byte_offset: 460
+    fieldset: ENDPTCTRL3
+  - name: ENDPTCTRL4
+    description: Endpoint Control 4.
+    byte_offset: 464
+    fieldset: ENDPTCTRL4
+  - name: ENDPTCTRL5
+    description: Endpoint Control 5.
+    byte_offset: 468
+    fieldset: ENDPTCTRL5
+  - name: ENDPTCTRL6
+    description: Endpoint Control 6.
+    byte_offset: 472
+    fieldset: ENDPTCTRL6
+  - name: ENDPTCTRL7
+    description: Endpoint Control 7.
+    byte_offset: 476
+    fieldset: ENDPTCTRL7
+fieldset/ASYNCLISTADDR:
+  description: Next Asynchronous Address.
+  fields:
+  - name: ASYBASE
+    description: Link Pointer Low (LPL).
+    bit_offset: 5
+    bit_size: 27
+fieldset/BURSTSIZE:
+  description: Programmable Burst Size.
+  fields:
+  - name: RXPBURST
+    description: Programmable RX Burst Size.
+    bit_offset: 0
+    bit_size: 8
+  - name: TXPBURST
+    description: Programmable TX Burst Size.
+    bit_offset: 8
+    bit_size: 8
+fieldset/CAPLENGTH:
+  description: Capability Registers Length.
+  bit_size: 8
+  fields:
+  - name: CAPLENGTH
+    description: Capability Length.
+    bit_offset: 0
+    bit_size: 8
+fieldset/CONFIGFLAG:
+  description: Configure Flag.
+  fields:
+  - name: CF
+    description: Configure Flag.
+    bit_offset: 0
+    bit_size: 1
+    enum: CF
+fieldset/DCCPARAMS:
+  description: Device Controller Capability Parameters.
+  fields:
+  - name: DEN
+    description: Device Endpoint Number.
+    bit_offset: 0
+    bit_size: 5
+    enum: DEN
+  - name: DC
+    description: Device Capable.
+    bit_offset: 7
+    bit_size: 1
+    enum: DCCPARAMS_DC
+  - name: HC
+    description: Host Capable.
+    bit_offset: 8
+    bit_size: 1
+    enum: DCCPARAMS_HC
+fieldset/DCIVERSION:
+  description: Device Controller Interface Version.
+  bit_size: 16
+  fields:
+  - name: DCIVERSION
+    description: Device Controller Interface Version Number.
+    bit_offset: 0
+    bit_size: 16
+fieldset/DEVICEADDR:
+  description: Device Address.
+  fields:
+  - name: USBADRA
+    description: Device Address Advance.
+    bit_offset: 24
+    bit_size: 1
+  - name: USBADR
+    description: Device Address.
+    bit_offset: 25
+    bit_size: 7
+fieldset/ENDPTCOMPLETE:
+  description: Endpoint Complete.
+  fields:
+  - name: ERCE
+    description: Endpoint Receive Complete Event.
+    bit_offset: 0
+    bit_size: 8
+    enum: ERCE
+  - name: ETCE
+    description: Endpoint Transmit Complete Event.
+    bit_offset: 16
+    bit_size: 8
+    enum: ETCE
+fieldset/ENDPTCTRL0:
+  description: Endpoint Control 0.
+  fields:
+  - name: RXS
+    description: RX Endpoint Stall.
+    bit_offset: 0
+    bit_size: 1
+    enum: ENDPTCTRL0_RXS
+  - name: RXT
+    description: RX Endpoint Type.
+    bit_offset: 2
+    bit_size: 2
+  - name: RXE
+    description: RX Endpoint Enable.
+    bit_offset: 7
+    bit_size: 1
+    enum: ENDPTCTRL0_RXE
+  - name: TXS
+    description: TX Endpoint Stall.
+    bit_offset: 16
+    bit_size: 1
+    enum: ENDPTCTRL0_TXS
+  - name: TXT
+    description: TX Endpoint Type.
+    bit_offset: 18
+    bit_size: 2
+  - name: TXE
+    description: TX Endpoint Enable.
+    bit_offset: 23
+    bit_size: 1
+    enum: ENDPTCTRL0_TXE
+fieldset/ENDPTCTRL1:
+  description: Endpoint Control 1.
+  fields:
+  - name: RXS
+    description: RX Endpoint Stall.
+    bit_offset: 0
+    bit_size: 1
+    enum: ENDPTCTRL1_RXS
+  - name: RXD
+    description: RX Endpoint Data Sink.
+    bit_offset: 1
+    bit_size: 1
+  - name: RXT
+    description: RX Endpoint Type.
+    bit_offset: 2
+    bit_size: 2
+    enum: ENDPTCTRL1_RXT
+  - name: RXI
+    description: RX Data Toggle Inhibit.
+    bit_offset: 5
+    bit_size: 1
+    enum: ENDPTCTRL1_RXI
+  - name: RXR
+    description: RX Data Toggle Reset.
+    bit_offset: 6
+    bit_size: 1
+    enum: ENDPTCTRL1_RXR
+  - name: RXE
+    description: RX Endpoint Enable.
+    bit_offset: 7
+    bit_size: 1
+    enum: ENDPTCTRL1_RXE
+  - name: TXS
+    description: TX Endpoint Stall.
+    bit_offset: 16
+    bit_size: 1
+    enum: ENDPTCTRL1_TXS
+  - name: TXD
+    description: TX Endpoint Data Source.
+    bit_offset: 17
+    bit_size: 1
+  - name: TXT
+    description: TX Endpoint Type.
+    bit_offset: 18
+    bit_size: 2
+    enum: ENDPTCTRL1_TXT
+  - name: TXI
+    description: TX Data Toggle Inhibit.
+    bit_offset: 21
+    bit_size: 1
+    enum: ENDPTCTRL1_TXI
+  - name: TXR
+    description: TX Data Toggle Reset.
+    bit_offset: 22
+    bit_size: 1
+    enum: ENDPTCTRL1_TXR
+  - name: TXE
+    description: TX Endpoint Enable.
+    bit_offset: 23
+    bit_size: 1
+    enum: ENDPTCTRL1_TXE
+fieldset/ENDPTCTRL2:
+  description: Endpoint Control 2.
+  fields:
+  - name: RXS
+    description: RX Endpoint Stall.
+    bit_offset: 0
+    bit_size: 1
+    enum: ENDPTCTRL2_RXS
+  - name: RXD
+    description: RX Endpoint Data Sink.
+    bit_offset: 1
+    bit_size: 1
+  - name: RXT
+    description: RX Endpoint Type.
+    bit_offset: 2
+    bit_size: 2
+    enum: ENDPTCTRL2_RXT
+  - name: RXI
+    description: RX Data Toggle Inhibit.
+    bit_offset: 5
+    bit_size: 1
+    enum: ENDPTCTRL2_RXI
+  - name: RXR
+    description: RX Data Toggle Reset.
+    bit_offset: 6
+    bit_size: 1
+    enum: ENDPTCTRL2_RXR
+  - name: RXE
+    description: RX Endpoint Enable.
+    bit_offset: 7
+    bit_size: 1
+    enum: ENDPTCTRL2_RXE
+  - name: TXS
+    description: TX Endpoint Stall.
+    bit_offset: 16
+    bit_size: 1
+    enum: ENDPTCTRL2_TXS
+  - name: TXD
+    description: TX Endpoint Data Source.
+    bit_offset: 17
+    bit_size: 1
+  - name: TXT
+    description: TX Endpoint Type.
+    bit_offset: 18
+    bit_size: 2
+    enum: ENDPTCTRL2_TXT
+  - name: TXI
+    description: TX Data Toggle Inhibit.
+    bit_offset: 21
+    bit_size: 1
+    enum: ENDPTCTRL2_TXI
+  - name: TXR
+    description: TX Data Toggle Reset.
+    bit_offset: 22
+    bit_size: 1
+    enum: ENDPTCTRL2_TXR
+  - name: TXE
+    description: TX Endpoint Enable.
+    bit_offset: 23
+    bit_size: 1
+    enum: ENDPTCTRL2_TXE
+fieldset/ENDPTCTRL3:
+  description: Endpoint Control 3.
+  fields:
+  - name: RXS
+    description: RX Endpoint Stall.
+    bit_offset: 0
+    bit_size: 1
+    enum: ENDPTCTRL3_RXS
+  - name: RXD
+    description: RX Endpoint Data Sink.
+    bit_offset: 1
+    bit_size: 1
+  - name: RXT
+    description: RX Endpoint Type.
+    bit_offset: 2
+    bit_size: 2
+    enum: ENDPTCTRL3_RXT
+  - name: RXI
+    description: RX Data Toggle Inhibit.
+    bit_offset: 5
+    bit_size: 1
+    enum: ENDPTCTRL3_RXI
+  - name: RXR
+    description: RX Data Toggle Reset.
+    bit_offset: 6
+    bit_size: 1
+    enum: ENDPTCTRL3_RXR
+  - name: RXE
+    description: RX Endpoint Enable.
+    bit_offset: 7
+    bit_size: 1
+    enum: ENDPTCTRL3_RXE
+  - name: TXS
+    description: TX Endpoint Stall.
+    bit_offset: 16
+    bit_size: 1
+    enum: ENDPTCTRL3_TXS
+  - name: TXD
+    description: TX Endpoint Data Source.
+    bit_offset: 17
+    bit_size: 1
+  - name: TXT
+    description: TX Endpoint Type.
+    bit_offset: 18
+    bit_size: 2
+    enum: ENDPTCTRL3_TXT
+  - name: TXI
+    description: TX Data Toggle Inhibit.
+    bit_offset: 21
+    bit_size: 1
+    enum: ENDPTCTRL3_TXI
+  - name: TXR
+    description: TX Data Toggle Reset.
+    bit_offset: 22
+    bit_size: 1
+    enum: ENDPTCTRL3_TXR
+  - name: TXE
+    description: TX Endpoint Enable.
+    bit_offset: 23
+    bit_size: 1
+    enum: ENDPTCTRL3_TXE
+fieldset/ENDPTCTRL4:
+  description: Endpoint Control 4.
+  fields:
+  - name: RXS
+    description: RX Endpoint Stall.
+    bit_offset: 0
+    bit_size: 1
+    enum: ENDPTCTRL4_RXS
+  - name: RXD
+    description: RX Endpoint Data Sink.
+    bit_offset: 1
+    bit_size: 1
+  - name: RXT
+    description: RX Endpoint Type.
+    bit_offset: 2
+    bit_size: 2
+    enum: ENDPTCTRL4_RXT
+  - name: RXI
+    description: RX Data Toggle Inhibit.
+    bit_offset: 5
+    bit_size: 1
+    enum: ENDPTCTRL4_RXI
+  - name: RXR
+    description: RX Data Toggle Reset.
+    bit_offset: 6
+    bit_size: 1
+    enum: ENDPTCTRL4_RXR
+  - name: RXE
+    description: RX Endpoint Enable.
+    bit_offset: 7
+    bit_size: 1
+    enum: ENDPTCTRL4_RXE
+  - name: TXS
+    description: TX Endpoint Stall.
+    bit_offset: 16
+    bit_size: 1
+    enum: ENDPTCTRL4_TXS
+  - name: TXD
+    description: TX Endpoint Data Source.
+    bit_offset: 17
+    bit_size: 1
+  - name: TXT
+    description: TX Endpoint Type.
+    bit_offset: 18
+    bit_size: 2
+    enum: ENDPTCTRL4_TXT
+  - name: TXI
+    description: TX Data Toggle Inhibit.
+    bit_offset: 21
+    bit_size: 1
+    enum: ENDPTCTRL4_TXI
+  - name: TXR
+    description: TX Data Toggle Reset.
+    bit_offset: 22
+    bit_size: 1
+    enum: ENDPTCTRL4_TXR
+  - name: TXE
+    description: TX Endpoint Enable.
+    bit_offset: 23
+    bit_size: 1
+    enum: ENDPTCTRL4_TXE
+fieldset/ENDPTCTRL5:
+  description: Endpoint Control 5.
+  fields:
+  - name: RXS
+    description: RX Endpoint Stall.
+    bit_offset: 0
+    bit_size: 1
+    enum: ENDPTCTRL5_RXS
+  - name: RXD
+    description: RX Endpoint Data Sink.
+    bit_offset: 1
+    bit_size: 1
+  - name: RXT
+    description: RX Endpoint Type.
+    bit_offset: 2
+    bit_size: 2
+    enum: ENDPTCTRL5_RXT
+  - name: RXI
+    description: RX Data Toggle Inhibit.
+    bit_offset: 5
+    bit_size: 1
+    enum: ENDPTCTRL5_RXI
+  - name: RXR
+    description: RX Data Toggle Reset.
+    bit_offset: 6
+    bit_size: 1
+    enum: ENDPTCTRL5_RXR
+  - name: RXE
+    description: RX Endpoint Enable.
+    bit_offset: 7
+    bit_size: 1
+    enum: ENDPTCTRL5_RXE
+  - name: TXS
+    description: TX Endpoint Stall.
+    bit_offset: 16
+    bit_size: 1
+    enum: ENDPTCTRL5_TXS
+  - name: TXD
+    description: TX Endpoint Data Source.
+    bit_offset: 17
+    bit_size: 1
+  - name: TXT
+    description: TX Endpoint Type.
+    bit_offset: 18
+    bit_size: 2
+    enum: ENDPTCTRL5_TXT
+  - name: TXI
+    description: TX Data Toggle Inhibit.
+    bit_offset: 21
+    bit_size: 1
+    enum: ENDPTCTRL5_TXI
+  - name: TXR
+    description: TX Data Toggle Reset.
+    bit_offset: 22
+    bit_size: 1
+    enum: ENDPTCTRL5_TXR
+  - name: TXE
+    description: TX Endpoint Enable.
+    bit_offset: 23
+    bit_size: 1
+    enum: ENDPTCTRL5_TXE
+fieldset/ENDPTCTRL6:
+  description: Endpoint Control 6.
+  fields:
+  - name: RXS
+    description: RX Endpoint Stall.
+    bit_offset: 0
+    bit_size: 1
+    enum: ENDPTCTRL6_RXS
+  - name: RXD
+    description: RX Endpoint Data Sink.
+    bit_offset: 1
+    bit_size: 1
+  - name: RXT
+    description: RX Endpoint Type.
+    bit_offset: 2
+    bit_size: 2
+    enum: ENDPTCTRL6_RXT
+  - name: RXI
+    description: RX Data Toggle Inhibit.
+    bit_offset: 5
+    bit_size: 1
+    enum: ENDPTCTRL6_RXI
+  - name: RXR
+    description: RX Data Toggle Reset.
+    bit_offset: 6
+    bit_size: 1
+    enum: ENDPTCTRL6_RXR
+  - name: RXE
+    description: RX Endpoint Enable.
+    bit_offset: 7
+    bit_size: 1
+    enum: ENDPTCTRL6_RXE
+  - name: TXS
+    description: TX Endpoint Stall.
+    bit_offset: 16
+    bit_size: 1
+    enum: ENDPTCTRL6_TXS
+  - name: TXD
+    description: TX Endpoint Data Source.
+    bit_offset: 17
+    bit_size: 1
+  - name: TXT
+    description: TX Endpoint Type.
+    bit_offset: 18
+    bit_size: 2
+    enum: ENDPTCTRL6_TXT
+  - name: TXI
+    description: TX Data Toggle Inhibit.
+    bit_offset: 21
+    bit_size: 1
+    enum: ENDPTCTRL6_TXI
+  - name: TXR
+    description: TX Data Toggle Reset.
+    bit_offset: 22
+    bit_size: 1
+    enum: ENDPTCTRL6_TXR
+  - name: TXE
+    description: TX Endpoint Enable.
+    bit_offset: 23
+    bit_size: 1
+    enum: ENDPTCTRL6_TXE
+fieldset/ENDPTCTRL7:
+  description: Endpoint Control 7.
+  fields:
+  - name: RXS
+    description: RX Endpoint Stall.
+    bit_offset: 0
+    bit_size: 1
+    enum: ENDPTCTRL7_RXS
+  - name: RXD
+    description: RX Endpoint Data Sink.
+    bit_offset: 1
+    bit_size: 1
+  - name: RXT
+    description: RX Endpoint Type.
+    bit_offset: 2
+    bit_size: 2
+    enum: ENDPTCTRL7_RXT
+  - name: RXI
+    description: RX Data Toggle Inhibit.
+    bit_offset: 5
+    bit_size: 1
+    enum: ENDPTCTRL7_RXI
+  - name: RXR
+    description: RX Data Toggle Reset.
+    bit_offset: 6
+    bit_size: 1
+    enum: ENDPTCTRL7_RXR
+  - name: RXE
+    description: RX Endpoint Enable.
+    bit_offset: 7
+    bit_size: 1
+    enum: ENDPTCTRL7_RXE
+  - name: TXS
+    description: TX Endpoint Stall.
+    bit_offset: 16
+    bit_size: 1
+    enum: ENDPTCTRL7_TXS
+  - name: TXD
+    description: TX Endpoint Data Source.
+    bit_offset: 17
+    bit_size: 1
+  - name: TXT
+    description: TX Endpoint Type.
+    bit_offset: 18
+    bit_size: 2
+    enum: ENDPTCTRL7_TXT
+  - name: TXI
+    description: TX Data Toggle Inhibit.
+    bit_offset: 21
+    bit_size: 1
+    enum: ENDPTCTRL7_TXI
+  - name: TXR
+    description: TX Data Toggle Reset.
+    bit_offset: 22
+    bit_size: 1
+    enum: ENDPTCTRL7_TXR
+  - name: TXE
+    description: TX Endpoint Enable.
+    bit_offset: 23
+    bit_size: 1
+    enum: ENDPTCTRL7_TXE
+fieldset/ENDPTFLUSH:
+  description: Endpoint Flush.
+  fields:
+  - name: FERB
+    description: Flush Endpoint Receive Buffer.
+    bit_offset: 0
+    bit_size: 8
+  - name: FETB
+    description: Flush Endpoint Transmit Buffer.
+    bit_offset: 16
+    bit_size: 8
+fieldset/ENDPTLISTADDR:
+  description: Endpoint List Address.
+  fields:
+  - name: EPBASE
+    description: Endpoint List Pointer (Low).
+    bit_offset: 11
+    bit_size: 21
+fieldset/ENDPTNAK:
+  description: Endpoint NAK.
+  fields:
+  - name: EPRN
+    description: RX Endpoint NAK Flag.
+    bit_offset: 0
+    bit_size: 8
+    enum: EPRN
+  - name: EPTN
+    description: TX Endpoint NAK Flag.
+    bit_offset: 16
+    bit_size: 8
+    enum: EPTN
+fieldset/ENDPTNAKEN:
+  description: Endpoint NAK Enable.
+  fields:
+  - name: EPRNE
+    description: RX Endpoint NAK Enable.
+    bit_offset: 0
+    bit_size: 8
+  - name: EPTNE
+    description: TX Endpoint NAK Enable.
+    bit_offset: 16
+    bit_size: 8
+fieldset/ENDPTPRIME:
+  description: Endpoint Prime.
+  fields:
+  - name: PERB
+    description: Prime Endpoint Receive Buffer.
+    bit_offset: 0
+    bit_size: 8
+  - name: PETB
+    description: Prime Endpoint Transmit Buffer.
+    bit_offset: 16
+    bit_size: 8
+fieldset/ENDPTSETUPSTAT:
+  description: Endpoint Setup Status.
+  fields:
+  - name: ENDPTSETUPSTAT
+    description: Endpoint Setup Status Flag.
+    bit_offset: 0
+    bit_size: 16
+    enum: ENDPTSETUPSTAT_FLAG
+fieldset/ENDPTSTAT:
+  description: Endpoint Status.
+  fields:
+  - name: ERBR
+    description: Endpoint Receive Buffer Ready.
+    bit_offset: 0
+    bit_size: 8
+  - name: ETBR
+    description: Endpoint Transmit Buffer Ready.
+    bit_offset: 16
+    bit_size: 8
+fieldset/FRINDEX:
+  description: USB Frame Index.
+  fields:
+  - name: FRINDEX
+    description: Frame Index.
+    bit_offset: 0
+    bit_size: 14
+    enum: FRINDEX_VALUE
+fieldset/GPTIMER0CTRL:
+  description: General Purpose Timer 0 Controller.
+  fields:
+  - name: GPTCNT
+    description: General Purpose Timer Counter.
+    bit_offset: 0
+    bit_size: 24
+  - name: GPTMODE
+    description: General Purpose Timer Mode.
+    bit_offset: 24
+    bit_size: 1
+    enum: GPTIMER0CTRL_GPTMODE
+  - name: GPTRST
+    description: General Purpose Timer Reset.
+    bit_offset: 30
+    bit_size: 1
+    enum: GPTIMER0CTRL_GPTRST
+  - name: GPTRUN
+    description: General Purpose Timer Run.
+    bit_offset: 31
+    bit_size: 1
+    enum: GPTIMER0CTRL_GPTRUN
+fieldset/GPTIMER0LD:
+  description: General Purpose Timer 0 Load.
+  fields:
+  - name: GPTLD
+    description: General Purpose Timer Load Value.
+    bit_offset: 0
+    bit_size: 24
+fieldset/GPTIMER1CTRL:
+  description: General Purpose Timer 1 Controller.
+  fields:
+  - name: GPTCNT
+    description: General Purpose Timer Counter.
+    bit_offset: 0
+    bit_size: 24
+  - name: GPTMODE
+    description: General Purpose Timer Mode.
+    bit_offset: 24
+    bit_size: 1
+    enum: GPTIMER1CTRL_GPTMODE
+  - name: GPTRST
+    description: General Purpose Timer Reset.
+    bit_offset: 30
+    bit_size: 1
+    enum: GPTIMER1CTRL_GPTRST
+  - name: GPTRUN
+    description: General Purpose Timer Run.
+    bit_offset: 31
+    bit_size: 1
+    enum: GPTIMER1CTRL_GPTRUN
+fieldset/GPTIMER1LD:
+  description: General Purpose Timer 1 Load.
+  fields:
+  - name: GPTLD
+    description: General Purpose Timer Load Value.
+    bit_offset: 0
+    bit_size: 24
+fieldset/HCCPARAMS:
+  description: Host Controller Capability Parameters.
+  fields:
+  - name: ADC
+    description: Addressing Capability.
+    bit_offset: 0
+    bit_size: 1
+  - name: PFL
+    description: Programmable Frame List Flag.
+    bit_offset: 1
+    bit_size: 1
+  - name: ASP
+    description: Asynchronous Schedule Park Capability.
+    bit_offset: 2
+    bit_size: 1
+  - name: IST
+    description: Isochronous Scheduling Threshold.
+    bit_offset: 4
+    bit_size: 4
+  - name: EECP
+    description: EHCI Extended Capabilities Pointer.
+    bit_offset: 8
+    bit_size: 8
+fieldset/HCIVERSION:
+  description: Host Controller Interface Version.
+  bit_size: 16
+  fields:
+  - name: HCIVERSION
+    description: Host Controller Interface Version Number.
+    bit_offset: 0
+    bit_size: 16
+fieldset/HCSPARAMS:
+  description: Host Controller Structural Parameters.
+  fields:
+  - name: N_PORTS
+    description: Number of Ports.
+    bit_offset: 0
+    bit_size: 4
+  - name: PPC
+    description: Port Power Control.
+    bit_offset: 4
+    bit_size: 1
+    enum: PPC
+  - name: N_PCC
+    description: Number of Ports per Companion Controller.
+    bit_offset: 8
+    bit_size: 4
+  - name: N_CC
+    description: Number of Companion Controller (N_CC).
+    bit_offset: 12
+    bit_size: 4
+    enum: N_CC
+  - name: PI
+    description: Port Indicators (P_INDICATOR).
+    bit_offset: 16
+    bit_size: 1
+  - name: N_PTT
+    description: Number of Ports per Transaction Translator (N_PTT).
+    bit_offset: 20
+    bit_size: 4
+  - name: N_TT
+    description: Number of Transaction Translators (N_TT).
+    bit_offset: 24
+    bit_size: 4
+fieldset/HWDEVICE:
+  description: Device Hardware Parameters.
+  fields:
+  - name: DC
+    description: Device Capable.
+    bit_offset: 0
+    bit_size: 1
+    enum: HWDEVICE_DC
+  - name: DEVEP
+    description: Device Endpoint Number.
+    bit_offset: 1
+    bit_size: 5
+fieldset/HWGENERAL:
+  description: Hardware General.
+  fields:
+  - name: PHYW
+    description: PHY Width.
+    bit_offset: 4
+    bit_size: 2
+    enum: PHYW
+  - name: PHYM
+    description: Transceiver Type.
+    bit_offset: 6
+    bit_size: 4
+    enum: PHYM
+  - name: SM
+    description: Serial Interface Mode Capability.
+    bit_offset: 10
+    bit_size: 2
+    enum: SM
+  - name: LPM
+    description: Link Power Management Capability.
+    bit_offset: 12
+    bit_size: 1
+    enum: LPM
+fieldset/HWHOST:
+  description: Host Hardware Parameters.
+  fields:
+  - name: HC
+    description: Host Capable.
+    bit_offset: 0
+    bit_size: 1
+    enum: HWHOST_HC
+  - name: NPORT
+    description: Number of Ports.
+    bit_offset: 1
+    bit_size: 3
+fieldset/HWRXBUF:
+  description: RX Buffer Hardware Parameters.
+  fields:
+  - name: RXBURST
+    description: RX Burst.
+    bit_offset: 0
+    bit_size: 8
+  - name: RXADD
+    description: RX Add.
+    bit_offset: 8
+    bit_size: 8
+fieldset/HWTXBUF:
+  description: TX Buffer Hardware Parameters.
+  fields:
+  - name: TXBURST
+    description: TX Burst.
+    bit_offset: 0
+    bit_size: 8
+  - name: TXCHANADD
+    description: TX Channel Add.
+    bit_offset: 16
+    bit_size: 8
+fieldset/ID:
+  description: Identification.
+  fields:
+  - name: ID
+    description: Configuration Number.
+    bit_offset: 0
+    bit_size: 6
+  - name: NID
+    description: Complement Version.
+    bit_offset: 8
+    bit_size: 6
+  - name: REVISION
+    description: Revision Number.
+    bit_offset: 16
+    bit_size: 8
+fieldset/OTGSC:
+  description: On-The-Go Status and Control.
+  fields:
+  - name: VD
+    description: VBUS Discharge.
+    bit_offset: 0
+    bit_size: 1
+  - name: VC
+    description: VBUS Charge.
+    bit_offset: 1
+    bit_size: 1
+  - name: HAAR
+    description: Hardware Assist Auto Reset.
+    bit_offset: 2
+    bit_size: 1
+    enum: HAAR
+  - name: OT
+    description: OTG Termination.
+    bit_offset: 3
+    bit_size: 1
+  - name: DP
+    description: Data Pulsing.
+    bit_offset: 4
+    bit_size: 1
+  - name: IDPU
+    description: ID Pullup.
+    bit_offset: 5
+    bit_size: 1
+  - name: HADP
+    description: Hardware Assist Data Pulse.
+    bit_offset: 6
+    bit_size: 1
+    enum: HADP
+  - name: HABA
+    description: Hardware Assist B-Disconnect to A-connect.
+    bit_offset: 7
+    bit_size: 1
+    enum: HABA
+  - name: ID
+    description: USB ID.
+    bit_offset: 8
+    bit_size: 1
+    enum: OTG_ID
+  - name: AVV
+    description: A VBUS Valid.
+    bit_offset: 9
+    bit_size: 1
+  - name: ASV
+    description: A Session Valid.
+    bit_offset: 10
+    bit_size: 1
+  - name: BSV
+    description: B Session Valid.
+    bit_offset: 11
+    bit_size: 1
+  - name: BSE
+    description: B Session End.
+    bit_offset: 12
+    bit_size: 1
+  - name: TOG_1MS
+    description: 1 Millisecond Timer Toggle.
+    bit_offset: 13
+    bit_size: 1
+  - name: DPS
+    description: Data Bus Pulsing Status.
+    bit_offset: 14
+    bit_size: 1
+  - name: IDIS
+    description: USB ID Interrupt Status.
+    bit_offset: 16
+    bit_size: 1
+  - name: AVVIS
+    description: A VBUS Valid Interrupt Status.
+    bit_offset: 17
+    bit_size: 1
+  - name: ASVIS
+    description: A Session Valid Interrupt Status.
+    bit_offset: 18
+    bit_size: 1
+  - name: BSVIS
+    description: B Session Valid Interrupt Status.
+    bit_offset: 19
+    bit_size: 1
+  - name: BSEIS
+    description: B Session End Interrupt Status.
+    bit_offset: 20
+    bit_size: 1
+  - name: STATUS_1MS
+    description: 1 Millisecond Timer Interrupt Status.
+    bit_offset: 21
+    bit_size: 1
+  - name: DPIS
+    description: Data Pulse Interrupt Status.
+    bit_offset: 22
+    bit_size: 1
+  - name: IDIE
+    description: USB ID Interrupt Enable.
+    bit_offset: 24
+    bit_size: 1
+  - name: AVVIE
+    description: A VBUS Valid Interrupt Enable.
+    bit_offset: 25
+    bit_size: 1
+  - name: ASVIE
+    description: A Session Valid Interrupt Enable.
+    bit_offset: 26
+    bit_size: 1
+  - name: BSVIE
+    description: B Session Valid Interrupt Enable.
+    bit_offset: 27
+    bit_size: 1
+  - name: BSEIE
+    description: B Session End Interrupt Enable.
+    bit_offset: 28
+    bit_size: 1
+  - name: EN_1MS
+    description: 1 Millisecond Timer Interrupt Enable.
+    bit_offset: 29
+    bit_size: 1
+  - name: DPIE
+    description: Data Pulse Interrupt Enable.
+    bit_offset: 30
+    bit_size: 1
+fieldset/PERIODICLISTBASE:
+  description: Frame List Base Address.
+  fields:
+  - name: BASEADR
+    description: Base Address (Low).
+    bit_offset: 12
+    bit_size: 20
+fieldset/PORTSC1:
+  description: Port Status and Control.
+  fields:
+  - name: CCS
+    description: Current Connect Status.
+    bit_offset: 0
+    bit_size: 1
+    enum: CCS
+  - name: CSC
+    description: Connect Status Change Flag.
+    bit_offset: 1
+    bit_size: 1
+    enum: CSC
+  - name: PE
+    description: Port Enable and Disable.
+    bit_offset: 2
+    bit_size: 1
+    enum: PE
+  - name: PEC
+    description: Port Enable and Disable Change Flag.
+    bit_offset: 3
+    bit_size: 1
+    enum: PEC
+  - name: OCA
+    description: Overcurrent Active.
+    bit_offset: 4
+    bit_size: 1
+    enum: OCA
+  - name: OCC
+    description: Overcurrent Change Flag.
+    bit_offset: 5
+    bit_size: 1
+    enum: OCC
+  - name: FPR
+    description: Force Port Resume.
+    bit_offset: 6
+    bit_size: 1
+    enum: FPR
+  - name: SUSP
+    description: Suspend.
+    bit_offset: 7
+    bit_size: 1
+    enum: SUSP
+  - name: PR
+    description: Port Reset.
+    bit_offset: 8
+    bit_size: 1
+    enum: PR
+  - name: HSP
+    description: High-Speed Port.
+    bit_offset: 9
+    bit_size: 1
+    enum: HSP
+  - name: LS
+    description: Line Status.
+    bit_offset: 10
+    bit_size: 2
+    enum: LS
+  - name: PP
+    description: Port Power (PP).
+    bit_offset: 12
+    bit_size: 1
+    enum: PP
+  - name: PO
+    description: Port Owner.
+    bit_offset: 13
+    bit_size: 1
+  - name: PIC
+    description: Port Indicator Control.
+    bit_offset: 14
+    bit_size: 2
+    enum: PIC
+  - name: PTC
+    description: Port Test Control.
+    bit_offset: 16
+    bit_size: 4
+    enum: PTC
+  - name: WKCN
+    description: Wake on Connect Enable (WKCNNT_E).
+    bit_offset: 20
+    bit_size: 1
+    enum: WKCN
+  - name: WKDC
+    description: Wake on Disconnect Enable (WKDSCNNT_E).
+    bit_offset: 21
+    bit_size: 1
+    enum: WKDC
+  - name: WKOC
+    description: Wake on Overcurrent Enable (WKOC).
+    bit_offset: 22
+    bit_size: 1
+  - name: PHCD
+    description: PHY Low-Power Suspend - Clock Disable (PLPSCD).
+    bit_offset: 23
+    bit_size: 1
+    enum: PHCD
+  - name: PFSC
+    description: Port Force Full Speed Connect.
+    bit_offset: 24
+    bit_size: 1
+    enum: PFSC
+  - name: PTS_2
+    description: Parallel Transceiver Select 2.
+    bit_offset: 25
+    bit_size: 1
+  - name: PSPD
+    description: Port Speed.
+    bit_offset: 26
+    bit_size: 2
+    enum: PSPD
+  - name: PTW
+    description: Parallel Transceiver Width.
+    bit_offset: 28
+    bit_size: 1
+    enum: PTW
+  - name: STS
+    description: Serial Transceiver Select.
+    bit_offset: 29
+    bit_size: 1
+    enum: STS
+  - name: PTS_1
+    description: Parallel Transceiver Select 1.
+    bit_offset: 30
+    bit_size: 2
+fieldset/SBUSCFG:
+  description: System Bus Configuration.
+  fields:
+  - name: AHBBRST
+    description: AHB Manager Interface Burst Configuration.
+    bit_offset: 0
+    bit_size: 3
+    enum: AHBBRST
+fieldset/TXFILLTUNING:
+  description: TX FIFO Fill Tuning.
+  fields:
+  - name: TXSCHOH
+    description: Scheduler Overhead.
+    bit_offset: 0
+    bit_size: 7
+  - name: TXSCHHEALTH
+    description: Scheduler Health Counter.
+    bit_offset: 8
+    bit_size: 5
+  - name: TXFIFOTHRES
+    description: FIFO Burst Threshold.
+    bit_offset: 16
+    bit_size: 6
+fieldset/USBCMD:
+  description: USB Command.
+  fields:
+  - name: RS
+    description: Run/Stop.
+    bit_offset: 0
+    bit_size: 1
+    enum: RS
+  - name: RST
+    description: Controller Reset.
+    bit_offset: 1
+    bit_size: 1
+  - name: FS_1
+    description: Frame List Size 1.
+    bit_offset: 2
+    bit_size: 2
+  - name: PSE
+    description: Periodic Schedule Enable.
+    bit_offset: 4
+    bit_size: 1
+    enum: PSE
+  - name: ASE
+    description: Asynchronous Schedule Enable.
+    bit_offset: 5
+    bit_size: 1
+    enum: ASE
+  - name: IAA
+    description: Interrupt on Async Advance Doorbell.
+    bit_offset: 6
+    bit_size: 1
+  - name: ASP
+    description: Asynchronous Schedule Park Mode Count.
+    bit_offset: 8
+    bit_size: 2
+  - name: ASPE
+    description: Asynchronous Schedule Park Mode Enable.
+    bit_offset: 11
+    bit_size: 1
+    enum: ASPE
+  - name: SUTW
+    description: Setup Trip Wire (Device mode only).
+    bit_offset: 13
+    bit_size: 1
+  - name: ATDTW
+    description: Add dTD Trip Wire (Device mode only).
+    bit_offset: 14
+    bit_size: 1
+  - name: FS_2
+    description: Frame List Size 2 (Host mode only).
+    bit_offset: 15
+    bit_size: 1
+  - name: ITC
+    description: Interrupt Threshold Control.
+    bit_offset: 16
+    bit_size: 8
+    enum: ITC
+fieldset/USBINTR:
+  description: Interrupt Enable.
+  fields:
+  - name: UE
+    description: USB Interrupt Enable.
+    bit_offset: 0
+    bit_size: 1
+    enum: UE
+  - name: UEE
+    description: USB Error Interrupt Enable.
+    bit_offset: 1
+    bit_size: 1
+    enum: UEE
+  - name: PCE
+    description: Port Change Detect Interrupt Enable.
+    bit_offset: 2
+    bit_size: 1
+    enum: PCE
+  - name: FRE
+    description: Frame List Rollover Interrupt Enable.
+    bit_offset: 3
+    bit_size: 1
+    enum: FRE
+  - name: SEE
+    description: System Error Interrupt Enable.
+    bit_offset: 4
+    bit_size: 1
+    enum: SEE
+  - name: AAE
+    description: Asynchronous Advance Interrupt Enable.
+    bit_offset: 5
+    bit_size: 1
+    enum: AAE
+  - name: URE
+    description: USB Reset Interrupt Enable.
+    bit_offset: 6
+    bit_size: 1
+    enum: URE
+  - name: SRE
+    description: SOF Received Interrupt Enable.
+    bit_offset: 7
+    bit_size: 1
+    enum: SRE
+  - name: SLE
+    description: Sleep Interrupt Enable.
+    bit_offset: 8
+    bit_size: 1
+    enum: SLE
+  - name: NAKE
+    description: NAK Interrupt Enable.
+    bit_offset: 16
+    bit_size: 1
+    enum: NAKE
+  - name: UAIE
+    description: USB Host Asynchronous Interrupt Enable.
+    bit_offset: 18
+    bit_size: 1
+    enum: UAIE
+  - name: UPIE
+    description: USB Host Periodic Interrupt Enable.
+    bit_offset: 19
+    bit_size: 1
+    enum: UPIE
+  - name: TIE0
+    description: General Purpose Timer 0 Interrupt Enable.
+    bit_offset: 24
+    bit_size: 1
+    enum: TIE0
+  - name: TIE1
+    description: General Purpose Timer 1 Interrupt Enable.
+    bit_offset: 25
+    bit_size: 1
+    enum: TIE1
+  - name: LPM_L1_EXITIE
+    description: L1 Exit Interrupt Enable.
+    bit_offset: 28
+    bit_size: 1
+    enum: LPM_L1_EXITIE
+  - name: LPM_L1_ENTRYIE
+    description: L1 Entry Interrupt Enable.
+    bit_offset: 29
+    bit_size: 1
+    enum: LPM_L1_ENTRYIE
+  - name: LPM_DEV_RCVDIE
+    description: Device Received Extension Token Interrupt Enable.
+    bit_offset: 30
+    bit_size: 1
+    enum: LPM_DEV_RCVDIE
+  - name: LPM_HST_COMPIE
+    description: Host Completed LPM Transaction Interrupt Enable.
+    bit_offset: 31
+    bit_size: 1
+    enum: LPM_HST_COMPIE
+fieldset/USBMODE:
+  description: USB Device Mode.
+  fields:
+  - name: CM
+    description: Controller Mode.
+    bit_offset: 0
+    bit_size: 2
+    enum: CM
+  - name: ES
+    description: Endian Select.
+    bit_offset: 2
+    bit_size: 1
+    enum: ES
+  - name: SLOM
+    description: Setup Lockout Mode.
+    bit_offset: 3
+    bit_size: 1
+    enum: SLOM
+  - name: SDIS
+    description: Stream Disable Mode.
+    bit_offset: 4
+    bit_size: 1
+    enum: SDIS
+fieldset/USBSTS:
+  description: USB Status.
+  fields:
+  - name: UI
+    description: USB Interrupt (USBINT) Flag.
+    bit_offset: 0
+    bit_size: 1
+    enum: UI
+  - name: UEI
+    description: USB Error Interrupt (USBERRINT) Flag.
+    bit_offset: 1
+    bit_size: 1
+    enum: UEI
+  - name: PCI
+    description: Port Change Detect Flag.
+    bit_offset: 2
+    bit_size: 1
+    enum: PCI
+  - name: FRI
+    description: Frame List Rollover Flag.
+    bit_offset: 3
+    bit_size: 1
+    enum: FRI
+  - name: SEI
+    description: System Error Flag.
+    bit_offset: 4
+    bit_size: 1
+    enum: SEI
+  - name: AAI
+    description: Interrupt on Asynchronous Advance Flag.
+    bit_offset: 5
+    bit_size: 1
+    enum: AAI
+  - name: URI
+    description: USB Reset Received.
+    bit_offset: 6
+    bit_size: 1
+    enum: URI
+  - name: SRI
+    description: SOF Received Flag.
+    bit_offset: 7
+    bit_size: 1
+    enum: SRI
+  - name: SLI
+    description: Device Controller Suspend Flag.
+    bit_offset: 8
+    bit_size: 1
+    enum: SLI
+  - name: ULPII
+    description: ULPI Interrupt Flag.
+    bit_offset: 10
+    bit_size: 1
+    enum: ULPII
+  - name: HCH
+    description: HC Halted.
+    bit_offset: 12
+    bit_size: 1
+  - name: RCL
+    description: Reclamation.
+    bit_offset: 13
+    bit_size: 1
+    enum: RCL
+  - name: PS
+    description: Periodic Schedule Status.
+    bit_offset: 14
+    bit_size: 1
+    enum: PS
+  - name: AS
+    description: Asynchronous Schedule Status.
+    bit_offset: 15
+    bit_size: 1
+    enum: AS
+  - name: NAKI
+    description: NAK Interrupt.
+    bit_offset: 16
+    bit_size: 1
+  - name: UAI
+    description: USB Host Asynchronous Interrupt Flag.
+    bit_offset: 18
+    bit_size: 1
+    enum: UAI
+  - name: UPI
+    description: USB Host Periodic Interrupt Flag.
+    bit_offset: 19
+    bit_size: 1
+    enum: UPI
+  - name: TI0
+    description: General Purpose Timer Interrupt 0 (GPTINT0) Flag.
+    bit_offset: 24
+    bit_size: 1
+    enum: TI0
+  - name: TI1
+    description: General Purpose Timer Interrupt 1 (GPTINT1) Flag.
+    bit_offset: 25
+    bit_size: 1
+    enum: TI1
+  - name: LPM_L1_EXITI
+    description: L1 Exit Interrupt Flag.
+    bit_offset: 28
+    bit_size: 1
+    enum: LPM_L1_EXITI
+  - name: LPM_L1_ENTRYI
+    description: L1 Entry Interrupt Flag.
+    bit_offset: 29
+    bit_size: 1
+    enum: LPM_L1_ENTRYI
+  - name: LPM_DEV_RCVDI
+    description: Device Received Extension Token Interrupt Flag.
+    bit_offset: 30
+    bit_size: 1
+    enum: LPM_DEV_RCVDI
+  - name: LPM_HST_COMPI
+    description: Host Completes the LPM Transaction Interrupt Flag.
+    bit_offset: 31
+    bit_size: 1
+    enum: LPM_HST_COMPI
+enum/AAE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/AAI:
+  bit_size: 1
+  variants:
+  - name: INT_NO
+    description: Interrupt did not occur.
+    value: 0
+  - name: INT_YES
+    description: Interrupt occurred.
+    value: 1
+enum/AHBBRST:
+  bit_size: 3
+  variants:
+  - name: INCR_BURST
+    description: Incremental burst of unspecified length only.
+    value: 0
+  - name: INCR4_BURST
+    description: INCR4 burst, then single transfer.
+    value: 1
+  - name: INCR8_BURST
+    description: INCR8 burst, INCR4 burst, then single transfer.
+    value: 2
+  - name: INCR16_BURST
+    description: INCR16 burst, INCR8 burst, INCR4 burst, then single transfer.
+    value: 3
+  - name: INCR4_UNSPEC
+    description: INCR4 burst, then incremental burst of unspecified length.
+    value: 5
+  - name: INCR8_4_UNSPEC
+    description: INCR8 burst, INCR4 burst, then incremental burst of unspecified length.
+    value: 6
+  - name: INCR16_8_4_UNSPEC
+    description: INCR16 burst, INCR8 burst, INCR4 burst, then incremental burst of unspecified length.
+    value: 7
+enum/AS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disabled.
+    value: 0
+  - name: ENABLE
+    description: Enabled.
+    value: 1
+enum/ASE:
+  bit_size: 1
+  variants:
+  - name: DONT_PROCESS_ASYNC
+    description: Do not process the asynchronous schedule.
+    value: 0
+  - name: ACCESS_ASYNC
+    description: Access the asynchronous schedule.
+    value: 1
+enum/ASPE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/CCS:
+  bit_size: 1
+  variants:
+  - name: DEVICE_UNAVAILABLE
+    description: No device present or attached.
+    value: 0
+  - name: DEVICE_AVAILABLE
+    description: Device present and attached.
+    value: 1
+enum/CF:
+  bit_size: 1
+  variants:
+  - name: PORT_ROUTING_CLASSIC_HOST
+    description: Port routing to classic host controller.
+    value: 0
+  - name: PORT_ROUTING_HOST
+    description: Port routing to this host controller.
+    value: 1
+enum/CM:
+  bit_size: 2
+  variants:
+  - name: IDL
+    description: Idle (default for host and device combination).
+    value: 0
+  - name: DEVICE_CONTR
+    description: Device controller (default for device-only controller).
+    value: 2
+  - name: HOST_CONTR
+    description: Host controller (default for host-only controller).
+    value: 3
+enum/CSC:
+  bit_size: 1
+  variants:
+  - name: NO_CHANGE
+    description: No change occurred.
+    value: 0
+  - name: CHANGE
+    description: Change occurred.
+    value: 1
+enum/DCCPARAMS_DC:
+  bit_size: 1
+  variants:
+  - name: NOT_DC
+    description: Not device capable.
+    value: 0
+  - name: DC
+    description: Device capable.
+    value: 1
+enum/DCCPARAMS_HC:
+  bit_size: 1
+  variants:
+  - name: NOT_HC
+    description: Not host capable.
+    value: 0
+  - name: HC
+    description: Host capable.
+    value: 1
+enum/DEN:
+  bit_size: 5
+  variants:
+  - name: NOT_DEN
+    description: Not device capable.
+    value: 0
+  - name: DEN
+    description: Device capable.
+    value: 1
+enum/ENDPTCTRL0_RXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL0_RXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL0_TXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL0_TXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL1_RXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL1_RXI:
+  bit_size: 1
+  variants:
+  - name: ENABLE
+    description: Allow.
+    value: 0
+  - name: INHIBIT
+    description: Inhibit.
+    value: 1
+enum/ENDPTCTRL1_RXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL1_RXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL1_RXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTCTRL1_TXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL1_TXI:
+  bit_size: 1
+  variants:
+  - name: ENABLE
+    description: Allow.
+    value: 0
+  - name: INHIBIT
+    description: Inhibit.
+    value: 1
+enum/ENDPTCTRL1_TXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL1_TXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL1_TXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTCTRL2_RXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL2_RXI:
+  bit_size: 1
+  variants:
+  - name: ENABLE
+    description: Allow.
+    value: 0
+  - name: INHIBIT
+    description: Inhibit.
+    value: 1
+enum/ENDPTCTRL2_RXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL2_RXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL2_RXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTCTRL2_TXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL2_TXI:
+  bit_size: 1
+  variants:
+  - name: ENABLE
+    description: Allow.
+    value: 0
+  - name: INHIBIT
+    description: Inhibit.
+    value: 1
+enum/ENDPTCTRL2_TXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL2_TXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL2_TXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTCTRL3_RXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL3_RXI:
+  bit_size: 1
+  variants:
+  - name: ENABLE
+    description: Allow.
+    value: 0
+  - name: INHIBIT
+    description: Inhibit.
+    value: 1
+enum/ENDPTCTRL3_RXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL3_RXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL3_RXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTCTRL3_TXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL3_TXI:
+  bit_size: 1
+  variants:
+  - name: ENABLE
+    description: Allow.
+    value: 0
+  - name: INHIBIT
+    description: Inhibit.
+    value: 1
+enum/ENDPTCTRL3_TXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL3_TXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL3_TXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTCTRL4_RXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL4_RXI:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL4_RXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL4_RXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL4_RXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTCTRL4_TXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL4_TXI:
+  bit_size: 1
+  variants:
+  - name: ENABLE
+    description: Allow.
+    value: 0
+  - name: INHIBIT
+    description: Inhibit.
+    value: 1
+enum/ENDPTCTRL4_TXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL4_TXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL4_TXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTCTRL5_RXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL5_RXI:
+  bit_size: 1
+  variants:
+  - name: ENABLE
+    description: Allow.
+    value: 0
+  - name: INHIBIT
+    description: Inhibit.
+    value: 1
+enum/ENDPTCTRL5_RXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL5_RXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL5_RXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTCTRL5_TXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL5_TXI:
+  bit_size: 1
+  variants:
+  - name: ENABLE
+    description: Allow.
+    value: 0
+  - name: INHIBIT
+    description: Inhibit.
+    value: 1
+enum/ENDPTCTRL5_TXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL5_TXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL5_TXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTCTRL6_RXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL6_RXI:
+  bit_size: 1
+  variants:
+  - name: ENABLE
+    description: Allow.
+    value: 0
+  - name: INHIBIT
+    description: Inhibit.
+    value: 1
+enum/ENDPTCTRL6_RXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL6_RXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL6_RXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTCTRL6_TXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL6_TXI:
+  bit_size: 1
+  variants:
+  - name: ENABLE
+    description: Allow.
+    value: 0
+  - name: INHIBIT
+    description: Inhibit.
+    value: 1
+enum/ENDPTCTRL6_TXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL6_TXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL6_TXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTCTRL7_RXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL7_RXI:
+  bit_size: 1
+  variants:
+  - name: ENABLE
+    description: Allow.
+    value: 0
+  - name: INHIBIT
+    description: Inhibit.
+    value: 1
+enum/ENDPTCTRL7_RXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL7_RXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL7_RXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTCTRL7_TXE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDPTCTRL7_TXI:
+  bit_size: 1
+  variants:
+  - name: ENABLE
+    description: Allow.
+    value: 0
+  - name: INHIBIT
+    description: Inhibit.
+    value: 1
+enum/ENDPTCTRL7_TXR:
+  bit_size: 1
+  variants:
+  - name: NO_RESET
+    description: Does not reset.
+    value: 0
+  - name: RESET
+    description: Resets.
+    value: 1
+enum/ENDPTCTRL7_TXS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Endpoint OK.
+    value: 0
+  - name: ENABLE
+    description: Endpoint stalled.
+    value: 1
+enum/ENDPTCTRL7_TXT:
+  bit_size: 2
+  variants:
+  - name: CTL
+    description: Control.
+    value: 0
+  - name: ISO
+    description: Isochronous.
+    value: 1
+  - name: BLK
+    description: Bulk.
+    value: 2
+  - name: IRQ
+    description: Interrupt.
+    value: 3
+enum/ENDPTSETUPSTAT_FLAG:
+  bit_size: 16
+  variants:
+  - name: NOTREC
+    description: Not received.
+    value: 0
+  - name: RECVD
+    description: Received.
+    value: 1
+enum/EPRN:
+  bit_size: 8
+  variants:
+  - name: NONACK
+    description: No NACK.
+    value: 0
+  - name: NACK
+    description: NACK.
+    value: 1
+enum/EPTN:
+  bit_size: 8
+  variants:
+  - name: NONACK
+    description: No NACK.
+    value: 0
+  - name: NACK
+    description: NACK.
+    value: 1
+enum/ERCE:
+  bit_size: 8
+  variants:
+  - name: TRANSNOTCOMP
+    description: Transmit incomplete.
+    value: 0
+  - name: TRANSCOMP
+    description: Transmit complete.
+    value: 1
+enum/ES:
+  bit_size: 1
+  variants:
+  - name: LITTLE_ENDIAN
+    description: Little endian (default).
+    value: 0
+  - name: BIG_ENDIAN
+    description: Big endian.
+    value: 1
+enum/ETCE:
+  bit_size: 8
+  variants:
+  - name: TRANSNOTCOMP
+    description: Transmit incomplete.
+    value: 0
+  - name: TRANSCOMP
+    description: Transmit complete.
+    value: 1
+enum/FPR:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: No resume (K-state) detected or driven on port.
+    value: 0
+  - name: ENABLE
+    description: Resume detected or driven on port.
+    value: 1
+enum/FRE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/FRI:
+  bit_size: 1
+  variants:
+  - name: ROLL_NO
+    description: Frame list index did not roll over.
+    value: 0
+  - name: ROLL_YES
+    description: Frame list index rolled over.
+    value: 1
+enum/FRINDEX_VALUE:
+  bit_size: 14
+  variants:
+  - name: FRINDEX_1024
+    description: (1024) 12.
+    value: 0
+  - name: FRINDEX_512
+    description: (512) 11.
+    value: 1
+  - name: FRINDEX_256
+    description: (256) 10.
+    value: 2
+  - name: FRINDEX_128
+    description: (128) 9.
+    value: 3
+  - name: FRINDEX_64
+    description: (64) 8.
+    value: 4
+  - name: FRINDEX_32
+    description: (32) 7.
+    value: 5
+  - name: FRINDEX_16
+    description: (16) 6.
+    value: 6
+  - name: FRINDEX_8
+    description: (8) 5.
+    value: 7
+enum/GPTIMER0CTRL_GPTMODE:
+  bit_size: 1
+  variants:
+  - name: ONE_SHOT
+    description: One Shot mode.
+    value: 0
+  - name: REPEAT
+    description: Repeat mode.
+    value: 1
+enum/GPTIMER0CTRL_GPTRST:
+  bit_size: 1
+  variants:
+  - name: NO_ACTION
+    description: No action.
+    value: 0
+  - name: LOAD_CNTR
+    description: Load counter value.
+    value: 1
+enum/GPTIMER0CTRL_GPTRUN:
+  bit_size: 1
+  variants:
+  - name: STOP_CNTR
+    description: Stopped counting.
+    value: 0
+  - name: RUN
+    description: Running.
+    value: 1
+enum/GPTIMER1CTRL_GPTMODE:
+  bit_size: 1
+  variants:
+  - name: ONE_SHOT
+    description: One Shot mode.
+    value: 0
+  - name: REPEAT
+    description: Repeat mode.
+    value: 1
+enum/GPTIMER1CTRL_GPTRST:
+  bit_size: 1
+  variants:
+  - name: NO_ACTION
+    description: No action.
+    value: 0
+  - name: LOAD_CNTR
+    description: Load counter value.
+    value: 1
+enum/GPTIMER1CTRL_GPTRUN:
+  bit_size: 1
+  variants:
+  - name: STOP_CNTR
+    description: Stopped counting.
+    value: 0
+  - name: RUN
+    description: Running.
+    value: 1
+enum/HAAR:
+  bit_size: 1
+  variants:
+  - name: HAAR_0
+    description: Disable.
+    value: 0
+  - name: HAAR_1
+    description: Enable.
+    value: 1
+enum/HABA:
+  bit_size: 1
+  variants:
+  - name: HABA_0
+    description: Disable.
+    value: 0
+  - name: HABA_1
+    description: Enable.
+    value: 1
+enum/HADP:
+  bit_size: 1
+  variants:
+  - name: HADP_0
+    description: Disable.
+    value: 0
+  - name: HADP_1
+    description: Enable.
+    value: 1
+enum/HSP:
+  bit_size: 1
+  variants:
+  - name: NOTHS
+    description: Not in HS mode.
+    value: 0
+  - name: HS
+    description: In HS mode.
+    value: 1
+enum/HWDEVICE_DC:
+  bit_size: 1
+  variants:
+  - name: DEVICE_OP_DIS
+    description: Not supported.
+    value: 0
+  - name: DEVICE_OP_EN
+    description: Supported.
+    value: 1
+enum/HWHOST_HC:
+  bit_size: 1
+  variants:
+  - name: HOST_OP_DIS
+    description: Not supported.
+    value: 0
+  - name: HOST_OP_EN
+    description: Supported.
+    value: 1
+enum/OTG_ID:
+  bit_size: 1
+  variants:
+  - name: DEV_A
+    description: A device.
+    value: 0
+  - name: DEV_B
+    description: B device.
+    value: 1
+enum/ITC:
+  bit_size: 8
+  variants:
+  - name: IMMEDIATE
+    description: Immediate (no threshold).
+    value: 0
+  - name: MICROFRAME_1
+    description: 1 microframe.
+    value: 1
+  - name: MICROFRAME_2
+    description: 2 microframes.
+    value: 2
+  - name: MICROFRAME_4
+    description: 4 microframes.
+    value: 4
+  - name: MICROFRAME_8
+    description: 8 microframes.
+    value: 8
+  - name: MICROFRAME_16
+    description: 16 microframes.
+    value: 16
+  - name: MICROFRAME_32
+    description: 32 microframes.
+    value: 32
+  - name: MICROFRAME_64
+    description: 64 microframes.
+    value: 64
+enum/LPM:
+  bit_size: 1
+  variants:
+  - name: LPM_NO
+    description: Not supported.
+    value: 0
+  - name: LPM_EN
+    description: Supported.
+    value: 1
+enum/LPM_DEV_RCVDI:
+  bit_size: 1
+  variants:
+  - name: INT_NO
+    description: Interrupt did not occur.
+    value: 0
+  - name: INT_YES
+    description: Interrupt occurred.
+    value: 1
+enum/LPM_DEV_RCVDIE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/LPM_HST_COMPI:
+  bit_size: 1
+  variants:
+  - name: INT_NO
+    description: Interrupt did not occur.
+    value: 0
+  - name: INT_YES
+    description: Interrupt occurred.
+    value: 1
+enum/LPM_HST_COMPIE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/LPM_L1_ENTRYI:
+  bit_size: 1
+  variants:
+  - name: INT_NO
+    description: Interrupt did not occur.
+    value: 0
+  - name: INT_YES
+    description: Interrupt occurred.
+    value: 1
+enum/LPM_L1_ENTRYIE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/LPM_L1_EXITI:
+  bit_size: 1
+  variants:
+  - name: INT_NO
+    description: Interrupt did not occur.
+    value: 0
+  - name: INT_YES
+    description: Interrupt occurred.
+    value: 1
+enum/LPM_L1_EXITIE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/LS:
+  bit_size: 2
+  variants:
+  - name: SE0
+    description: SE0.
+    value: 0
+  - name: K_STATE
+    description: K-state.
+    value: 1
+  - name: J_STATE
+    description: J-state.
+    value: 2
+  - name: UNDEFINED
+    description: Undefined.
+    value: 3
+enum/NAKE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/N_CC:
+  bit_size: 4
+  variants:
+  - name: NO_COMP_CONTROLLER
+    description: No internal companion controller exists.
+    value: 0
+  - name: COMP_CONTROLLER
+    description: Internal companion controllers exist.
+    value: 1
+enum/OCA:
+  bit_size: 1
+  variants:
+  - name: NO_OVERCURRENT
+    description: No overcurrent condition exists.
+    value: 0
+  - name: OVERCURRENT
+    description: Overcurrent condition exists.
+    value: 1
+enum/OCC:
+  bit_size: 1
+  variants:
+  - name: NO_CHANGE
+    description: No change occurred.
+    value: 0
+  - name: CHANGE
+    description: Change occurred.
+    value: 1
+enum/PCE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/PCI:
+  bit_size: 1
+  variants:
+  - name: DETECT_NO
+    description: Port change not detected.
+    value: 0
+  - name: DETECT_YES
+    description: Port change detected.
+    value: 1
+enum/PE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/PEC:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: No change occurred.
+    value: 0
+  - name: ENABLE
+    description: Change occurred.
+    value: 1
+enum/PFSC:
+  bit_size: 1
+  variants:
+  - name: NORMAL
+    description: Normal operation.
+    value: 0
+  - name: FULL_SPEED
+    description: Forced to full speed.
+    value: 1
+enum/PHCD:
+  bit_size: 1
+  variants:
+  - name: PHY_CLK_EN
+    description: Enable.
+    value: 0
+  - name: PHY_CLK_DIS
+    description: Disable.
+    value: 1
+enum/PHYM:
+  bit_size: 4
+  variants:
+  - name: UTMI
+    description: UTMI/UMTI+.
+    value: 0
+  - name: ULPI_DDR
+    description: ULPI DDR.
+    value: 1
+  - name: ULPI
+    description: ULPI.
+    value: 2
+  - name: SERIAL
+    description: Serial only.
+    value: 3
+  - name: SW_RST_UTMI
+    description: 'Software programmable: reset to UTMI/UTMI+.'
+    value: 4
+  - name: SW_RST_ULPI_DDR
+    description: 'Software programmable: reset to ULPI DDR.'
+    value: 5
+  - name: SW_RST_ULPI
+    description: 'Software programmable: reset to ULPI.'
+    value: 6
+  - name: SW_RST_SERIAL
+    description: 'Software programmable: reset to Serial.'
+    value: 7
+  - name: ICUSB
+    description: IC-USB.
+    value: 8
+  - name: SW_RST_ICUSB
+    description: 'Software programmable: reset to IC-USB.'
+    value: 9
+  - name: HSIC
+    description: HSIC.
+    value: 10
+  - name: SW_RST_HSIC
+    description: 'Software programmable: reset to HSIC.'
+    value: 11
+enum/PHYW:
+  bit_size: 2
+  variants:
+  - name: DATA_BUS_8
+    description: 8-bit wide data bus (software nonprogrammable).
+    value: 0
+  - name: DATA_BUS_16
+    description: 16-bit wide data bus (software nonprogrammable).
+    value: 1
+  - name: SW_RST_8
+    description: Reset to 8-bit wide data bus (software programmable).
+    value: 2
+  - name: SW_RST_16
+    description: Reset to 16-bit wide data bus (software programmable).
+    value: 3
+enum/PIC:
+  bit_size: 2
+  variants:
+  - name: PORT_INDICATOR_OFF
+    description: Port indicators are off.
+    value: 0
+  - name: PORT_IND_AMBER
+    description: Amber.
+    value: 1
+  - name: PORT_IND_GREEN
+    description: Green.
+    value: 2
+  - name: UNDEFINED
+    description: Undefined.
+    value: 3
+enum/PP:
+  bit_size: 1
+  variants:
+  - name: OFF
+    description: Off.
+    value: 0
+  - name: ON
+    description: On.
+    value: 1
+enum/PPC:
+  bit_size: 1
+  variants:
+  - name: NO_SWITCHES
+    description: No port power switches.
+    value: 0
+  - name: PORT_SWITCHES
+    description: Port power switches exist.
+    value: 1
+enum/PR:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Port not in reset.
+    value: 0
+  - name: ENABLE
+    description: Port in reset.
+    value: 1
+enum/PS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disabled.
+    value: 0
+  - name: ENABLE
+    description: Enabled.
+    value: 1
+enum/PSE:
+  bit_size: 1
+  variants:
+  - name: DONT_PROCESS_PT
+    description: Do not process the periodic schedule.
+    value: 0
+  - name: PROCESS_PT_PERIODICLISTBASE
+    description: Process the periodic schedule.
+    value: 1
+enum/PSPD:
+  bit_size: 2
+  variants:
+  - name: FS
+    description: FS.
+    value: 0
+  - name: LS
+    description: LS.
+    value: 1
+  - name: HS
+    description: HS.
+    value: 2
+  - name: UNDEFINED
+    description: Undefined.
+    value: 3
+enum/PTC:
+  bit_size: 4
+  variants:
+  - name: TST_MODE_DIS
+    description: TEST_MODE_DISABLE.
+    value: 0
+  - name: J_STATE
+    description: J_STATE.
+    value: 1
+  - name: K_STATE
+    description: K_STATE.
+    value: 2
+  - name: SE0
+    description: SE0 (host) or NAK (device).
+    value: 3
+  - name: PCKT
+    description: Packet.
+    value: 4
+  - name: HS
+    description: FORCE_ENABLE_HS.
+    value: 5
+  - name: FS
+    description: FORCE_ENABLE_FS.
+    value: 6
+  - name: LS
+    description: FORCE_ENABLE_LS.
+    value: 7
+enum/PTW:
+  bit_size: 1
+  variants:
+  - name: UTMI_8
+    description: 8-bit UTMI interface (60 MHz).
+    value: 0
+  - name: UTMI_16
+    description: 16-bit UTMI interface (30 MHz).
+    value: 1
+enum/RCL:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Does not detect.
+    value: 0
+  - name: ENABLE
+    description: Detects.
+    value: 1
+enum/RS:
+  bit_size: 1
+  variants:
+  - name: STOP
+    description: Stopped executing.
+    value: 0
+  - name: RUN
+    description: Running.
+    value: 1
+enum/SDIS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/SEE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/SEI:
+  bit_size: 1
+  variants:
+  - name: INT_NO
+    description: Error response did not occur.
+    value: 0
+  - name: INT_YES
+    description: Error response occurred.
+    value: 1
+enum/SLE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/SLI:
+  bit_size: 1
+  variants:
+  - name: SUS_NO
+    description: Did not enter Suspended state.
+    value: 0
+  - name: SUS_YES
+    description: Entered Suspended state.
+    value: 1
+enum/SLOM:
+  bit_size: 1
+  variants:
+  - name: LOCKOUT_ON
+    description: On (default).
+    value: 0
+  - name: LOCKOUT_OFF
+    description: Off.
+    value: 1
+enum/SM:
+  bit_size: 2
+  variants:
+  - name: SERIAL_ENGINE_NO
+    description: No serial engine; always use parallel signaling.
+    value: 0
+  - name: SERIAL_ENGINE_EN
+    description: Serial engine present; always use serial signaling for FS and LS.
+    value: 1
+  - name: SW_RST_PARALLEL
+    description: Software programmable; reset to use parallel signaling for FS and LS.
+    value: 2
+  - name: SW_RST_SERIAL_ENG
+    description: Software programmable; reset to use serial signaling for FS and LS.
+    value: 3
+enum/SRE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/SRI:
+  bit_size: 1
+  variants:
+  - name: SOF_NO
+    description: SOF not received.
+    value: 0
+  - name: SOF_YES
+    description: SOF received.
+    value: 1
+enum/STS:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Parallel interface signals.
+    value: 0
+  - name: ENABLE
+    description: Serial interface engine.
+    value: 1
+enum/SUSP:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Port not in Suspended state.
+    value: 0
+  - name: ENABLE
+    description: Port in Suspended state.
+    value: 1
+enum/TI0:
+  bit_size: 1
+  variants:
+  - name: INT_NO
+    description: Interrupt did not occur.
+    value: 0
+  - name: INT_YES
+    description: Interrupt occurred.
+    value: 1
+enum/TI1:
+  bit_size: 1
+  variants:
+  - name: INT_NO
+    description: Interrupt did not occur.
+    value: 0
+  - name: INT_YES
+    description: Interrupt occurred.
+    value: 1
+enum/TIE0:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/TIE1:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/UAI:
+  bit_size: 1
+  variants:
+  - name: INT_NO
+    description: Interrupt did not occur.
+    value: 0
+  - name: INT_YES
+    description: Interrupt occurred.
+    value: 1
+enum/UAIE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/UE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/UEE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/UEI:
+  bit_size: 1
+  variants:
+  - name: INT_NO
+    description: Interrupt did not occur.
+    value: 0
+  - name: INT_YES
+    description: Interrupt occurred.
+    value: 1
+enum/UI:
+  bit_size: 1
+  variants:
+  - name: INT_NO
+    description: Interrupt did not occur.
+    value: 0
+  - name: INT_YES
+    description: Interrupt occurred.
+    value: 1
+enum/ULPII:
+  bit_size: 1
+  variants:
+  - name: EVENT_NO
+    description: Event completion did not occur.
+    value: 0
+  - name: EVENT_YES
+    description: Event completion occurred.
+    value: 1
+enum/UPI:
+  bit_size: 1
+  variants:
+  - name: INT_NO
+    description: Interrupt did not occur.
+    value: 0
+  - name: INT_YES
+    description: Interrupt occurred.
+    value: 1
+enum/UPIE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/URE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/URI:
+  bit_size: 1
+  variants:
+  - name: USB_NO
+    description: USB reset not received.
+    value: 0
+  - name: USB_YES
+    description: USB reset received.
+    value: 1
+enum/WKCN:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/WKDC:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1

--- a/data/metadata/peripherals/mcxa/USBNC.yaml
+++ b/data/metadata/peripherals/mcxa/USBNC.yaml
@@ -1,0 +1,660 @@
+block/Usbnc:
+  description: USBNC.
+  items:
+  - name: CTRL1
+    description: USB Control 1.
+    byte_offset: 0
+    fieldset: CTRL1
+  - name: CTRL2
+    description: USB Control 2.
+    byte_offset: 4
+    fieldset: CTRL2
+  - name: HSIC_DLL_CFG4
+    description: HSIC DLL Configure Register 4.
+    byte_offset: 44
+    fieldset: HSIC_DLL_CFG4
+  - name: LPM_CSR0
+    description: USB LPM Control and Status 0.
+    byte_offset: 160
+    fieldset: LPM_CSR0
+  - name: LPM_CSR1
+    description: USB LPM Control and Status 1.
+    byte_offset: 164
+    fieldset: LPM_CSR1
+  - name: LPM_CSR2
+    description: USB LPM Control and Status 2.
+    byte_offset: 168
+    fieldset: LPM_CSR2
+  - name: CLK_RECOVER_CTRL
+    description: USB Clock Recovery Control.
+    byte_offset: 512
+    bit_size: 8
+    fieldset: CLK_RECOVER_CTRL
+  - name: CLK_RECOVER_IRC_EN
+    description: FIRC Oscillator Enable.
+    byte_offset: 516
+    bit_size: 8
+    fieldset: CLK_RECOVER_IRC_EN
+  - name: CLK_RECOVER_INT_EN
+    description: Clock Recovery Combined Interrupt Enable.
+    byte_offset: 532
+    bit_size: 8
+    fieldset: CLK_RECOVER_INT_EN
+  - name: CLK_RECOVER_INT_STATUS
+    description: Clock Recovery Separated Interrupt Status.
+    byte_offset: 540
+    bit_size: 8
+    fieldset: CLK_RECOVER_INT_STATUS
+fieldset/CLK_RECOVER_CTRL:
+  description: USB Clock Recovery Control.
+  bit_size: 8
+  fields:
+  - name: TRIM_INIT_VAL_SEL
+    description: Selects the source for the initial FIRC192M trim fine value used after a reset.
+    bit_offset: 3
+    bit_size: 1
+    enum: TRIM_INIT_VAL_SEL
+  - name: RESTART_IFRTRIM_EN
+    description: Restart from IFR Trim Value.
+    bit_offset: 5
+    bit_size: 1
+    enum: RESTART_IFRTRIM_EN
+  - name: RESET_RESUME_ROUGH_EN
+    description: Reset or Resume to Rough Phase Enable.
+    bit_offset: 6
+    bit_size: 1
+    enum: RESET_RESUME_ROUGH_EN
+  - name: CLOCK_RECOVER_EN
+    description: Crystal-Less USB Enable.
+    bit_offset: 7
+    bit_size: 1
+    enum: CLOCK_RECOVER_EN
+fieldset/CLK_RECOVER_INT_EN:
+  description: Clock Recovery Combined Interrupt Enable.
+  bit_size: 8
+  fields:
+  - name: OVF_ERROR_EN
+    description: Overflow error interrupt enable.
+    bit_offset: 4
+    bit_size: 1
+    enum: OVF_ERROR_EN
+fieldset/CLK_RECOVER_INT_STATUS:
+  description: Clock Recovery Separated Interrupt Status.
+  bit_size: 8
+  fields:
+  - name: OVF_ERROR
+    description: Overflow Error Interrupt Status Flag.
+    bit_offset: 4
+    bit_size: 1
+    enum: OVF_ERROR
+fieldset/CLK_RECOVER_IRC_EN:
+  description: FIRC Oscillator Enable.
+  bit_size: 8
+  fields:
+  - name: IRC_EN
+    description: Fast IRC enable.
+    bit_offset: 1
+    bit_size: 1
+    enum: IRC_EN
+fieldset/CTRL1:
+  description: USB Control 1.
+  fields:
+  - name: OVER_CUR_DIS
+    description: Overcurrent Disable.
+    bit_offset: 7
+    bit_size: 1
+    enum: OVER_CUR_DIS
+  - name: OVER_CUR_POL
+    description: Overcurrent Polarity.
+    bit_offset: 8
+    bit_size: 1
+    enum: OVER_CUR_POL
+  - name: PWR_POL
+    description: Power Polarity.
+    bit_offset: 9
+    bit_size: 1
+    enum: PWR_POL
+  - name: WIE
+    description: Wake-Up Interrupt Enable.
+    bit_offset: 10
+    bit_size: 1
+    enum: WIE
+  - name: WKUP_SW_EN
+    description: Software Wake-Up Enable.
+    bit_offset: 14
+    bit_size: 1
+    enum: WKUP_SW_EN
+  - name: WKUP_SW
+    description: Software Wake-Up.
+    bit_offset: 15
+    bit_size: 1
+    enum: WKUP_SW
+  - name: WKUP_ID_EN
+    description: Wake-Up After ID Change Enable.
+    bit_offset: 16
+    bit_size: 1
+    enum: WKUP_ID_EN
+  - name: WKUP_VBUS_EN
+    description: Wake-Up After VBUS Change Enable.
+    bit_offset: 17
+    bit_size: 1
+    enum: WKUP_VBUS_EN
+  - name: REMOTE_WAKEUP_EN
+    description: Remote Wake-Up Enable.
+    bit_offset: 28
+    bit_size: 1
+    enum: REMOTE_WAKEUP_EN
+  - name: WKUP_DPDM_EN
+    description: Wake-Up After DP or DM Change Enable.
+    bit_offset: 29
+    bit_size: 1
+    enum: WKUP_DPDM_EN
+  - name: WIR
+    description: Wake-Up Interrupt Request.
+    bit_offset: 31
+    bit_size: 1
+    enum: WIR
+fieldset/CTRL2:
+  description: USB Control 2.
+  fields:
+  - name: VBUS_SOURCE_SEL
+    description: VBUS Source Select.
+    bit_offset: 0
+    bit_size: 2
+    enum: VBUS_SOURCE_SEL
+  - name: UTMI_CLK_VLD
+    description: UTMI Clock Valid Flag.
+    bit_offset: 31
+    bit_size: 1
+    enum: UTMI_CLK_VLD
+fieldset/HSIC_DLL_CFG4:
+  description: HSIC DLL Configure Register 4.
+  fields:
+  - name: LPM_EN_ENDP_CHK
+    description: LPM EXT token ENDP check enable.
+    bit_offset: 30
+    bit_size: 1
+    enum: LPM_EN_ENDP_CHK
+  - name: FS_ISO_B2B_FIXEN
+    description: FS Isochronous back to back transfer enable.
+    bit_offset: 31
+    bit_size: 1
+    enum: FS_ISO_B2B_FIXEN
+fieldset/LPM_CSR0:
+  description: USB LPM Control and Status 0.
+  fields:
+  - name: LPM_EN
+    description: Link Power Management Feature Enable.
+    bit_offset: 0
+    bit_size: 1
+    enum: LPM_EN
+  - name: LPM_ERRATA_EN
+    description: Link Power Management ECN Errata Feature Enable.
+    bit_offset: 1
+    bit_size: 1
+    enum: LPM_ERRATA_EN
+  - name: LPM_AUTO_PHCD
+    description: Auto Low-Power Mode.
+    bit_offset: 3
+    bit_size: 1
+    enum: LPM_AUTO_PHCD
+  - name: LPM_RESUMEOK
+    description: LPM Resume OK.
+    bit_offset: 30
+    bit_size: 1
+    enum: LPM_RESUMEOK
+  - name: LPM_L1_ACTIVE
+    description: LPM Active.
+    bit_offset: 31
+    bit_size: 1
+    enum: LPM_L1_ACTIVE
+fieldset/LPM_CSR1:
+  description: USB LPM Control and Status 1.
+  fields:
+  - name: LPM_DEV_BESLTHRES
+    description: Device Required Host Initiated Resume Duration.
+    bit_offset: 0
+    bit_size: 4
+    enum: LPM_DEV_BESLTHRES
+  - name: LPM_DEV_RES
+    description: LPM Device Response.
+    bit_offset: 4
+    bit_size: 1
+    enum: LPM_DEV_RES
+  - name: LPM_DEV_DP
+    description: LPM Device Data Pending.
+    bit_offset: 5
+    bit_size: 1
+    enum: LPM_DEV_DP
+  - name: LPM_DEV_RSPSTS
+    description: LPM Device Response Status.
+    bit_offset: 20
+    bit_size: 2
+    enum: LPM_DEV_RSPSTS
+  - name: LPM_DEV_RWKENRCVD
+    description: LPM Device Received bRemoteWake.
+    bit_offset: 23
+    bit_size: 1
+    enum: LPM_DEV_RWKENRCVD
+  - name: LPM_DEV_LNKSTRCVD
+    description: LPM Device Received bLinkState.
+    bit_offset: 24
+    bit_size: 4
+    enum: LPM_DEV_LNKSTRCVD
+  - name: LPM_DEV_BESLRCVD
+    description: LPM Device Received BESL.
+    bit_offset: 28
+    bit_size: 4
+fieldset/LPM_CSR2:
+  description: USB LPM Control and Status 2.
+  fields:
+  - name: LPM_HST_SEND
+    description: LPM Host Send Extension Token.
+    bit_offset: 0
+    bit_size: 1
+    enum: LPM_HST_SEND
+  - name: LPM_HST_DEVADD
+    description: LPM Host Extension Token's Device Address.
+    bit_offset: 1
+    bit_size: 7
+  - name: LPM_HST_BESL
+    description: LPM Host Extension Token's BESL or HIRD.
+    bit_offset: 8
+    bit_size: 4
+  - name: LPM_HST_RWKEN
+    description: LPM Host Extension Token's bRemoteWake.
+    bit_offset: 12
+    bit_size: 1
+    enum: LPM_HST_RWKEN
+  - name: LPM_HST_STSRCVD
+    description: LPM Host Response Status from the Device.
+    bit_offset: 28
+    bit_size: 3
+    enum: LPM_HST_STSRCVD
+enum/CLOCK_RECOVER_EN:
+  bit_size: 1
+  variants:
+  - name: DIS_CLK_RECOVER
+    description: Disable.
+    value: 0
+  - name: EN_CLK_RECOVER
+    description: Enable.
+    value: 1
+enum/FS_ISO_B2B_FIXEN:
+  bit_size: 1
+  variants:
+  - name: FS_ISO_B2B_FIXEN_0
+    description: Disabled.
+    value: 0
+  - name: FS_ISO_B2B_FIXEN_1
+    description: Enabled.
+    value: 1
+enum/IRC_EN:
+  bit_size: 1
+  variants:
+  - name: DIS_IRC
+    description: Disable.
+    value: 0
+  - name: EN_IRC
+    description: Enable.
+    value: 1
+enum/LPM_AUTO_PHCD:
+  bit_size: 1
+  variants:
+  - name: LPM_AUTO_PHCD0
+    description: Disable.
+    value: 0
+  - name: LPM_AUTO_PHCD1
+    description: Enable.
+    value: 1
+enum/LPM_DEV_BESLTHRES:
+  bit_size: 4
+  variants:
+  - name: LPM_DEV_BESLTHRES0
+    description: 75 us, if LPM_ERRATA_EN = 1; 50 us, if LPM_ERRATA_EN = 0.
+    value: 0
+  - name: LPM_DEV_BESLTHRES1
+    description: 100 us, if LPM_ERRATA_EN = 1; 125 us, if LPM_ERRATA_EN = 0.
+    value: 1
+  - name: LPM_DEV_BESLTHRES2
+    description: 150 us, if LPM_ERRATA_EN = 1; 200 us, if LPM_ERRATA_EN = 0.
+    value: 2
+  - name: LPM_DEV_BESLTHRES3
+    description: 250 us, if LPM_ERRATA_EN = 1; 275 us, if LPM_ERRATA_EN = 0.
+    value: 3
+  - name: LPM_DEV_BESLTHRES4
+    description: 350 us, if LPM_ERRATA_EN = 1; 350 us, if LPM_ERRATA_EN = 0.
+    value: 4
+  - name: LPM_DEV_BESLTHRES5
+    description: 450 us, if LPM_ERRATA_EN = 1; 425 us, if LPM_ERRATA_EN = 0.
+    value: 5
+  - name: LPM_DEV_BESLTHRES6
+    description: 950 us, if LPM_ERRATA_EN = 1; 500 us, if LPM_ERRATA_EN = 0.
+    value: 6
+  - name: LPM_DEV_BESLTHRES7
+    description: 1950 us, if LPM_ERRATA_EN = 1; 575 us, if LPM_ERRATA_EN = 0.
+    value: 7
+  - name: LPM_DEV_BESLTHRES8
+    description: 2950 us, if LPM_ERRATA_EN = 1; 650 us, if LPM_ERRATA_EN = 0.
+    value: 8
+  - name: LPM_DEV_BESLTHRES9
+    description: 3950 us, if LPM_ERRATA_EN = 1; 725 us, if LPM_ERRATA_EN = 0.
+    value: 9
+  - name: LPM_DEV_BESLTHRESA
+    description: 4950 us, if LPM_ERRATA_EN = 1; 800 us, if LPM_ERRATA_EN = 0.
+    value: 10
+  - name: LPM_DEV_BESLTHRESB
+    description: 5950 us, if LPM_ERRATA_EN = 1; 875 us, if LPM_ERRATA_EN = 0.
+    value: 11
+  - name: LPM_DEV_BESLTHRESC
+    description: 6950 us, if LPM_ERRATA_EN = 1; 950 us, if LPM_ERRATA_EN = 0.
+    value: 12
+  - name: LPM_DEV_BESLTHRESD
+    description: 7950 us, if LPM_ERRATA_EN = 1; 1025 us, if LPM_ERRATA_EN = 0.
+    value: 13
+  - name: LPM_DEV_BESLTHRESE
+    description: 8950 us, if LPM_ERRATA_EN = 1; 1100 us, if LPM_ERRATA_EN = 0.
+    value: 14
+  - name: LPM_DEV_BESLTHRESF
+    description: 9950 us, if LPM_ERRATA_EN = 1; 1175 us, if LPM_ERRATA_EN = 0.
+    value: 15
+enum/LPM_DEV_DP:
+  bit_size: 1
+  variants:
+  - name: LPM_DEV_DP0
+    description: Not pending.
+    value: 0
+  - name: LPM_DEV_DP1
+    description: Pending.
+    value: 1
+enum/LPM_DEV_LNKSTRCVD:
+  bit_size: 4
+  variants:
+  - name: LPM_DEV_LNKSTRCVD1
+    description: L1 (Sleep mode).
+    value: 1
+enum/LPM_DEV_RES:
+  bit_size: 1
+  variants:
+  - name: LPM_DEV_RES0
+    description: Fourth condition not needed.
+    value: 0
+  - name: LPM_DEV_RES1
+    description: Fourth condition needed.
+    value: 1
+enum/LPM_DEV_RSPSTS:
+  bit_size: 2
+  variants:
+  - name: LPM_DEV_RSPSTS0
+    description: Invalid.
+    value: 0
+  - name: LPM_DEV_RSPSTS1
+    description: ACK.
+    value: 1
+  - name: LPM_DEV_RSPSTS2
+    description: NYET.
+    value: 2
+  - name: LPM_DEV_RSPSTS3
+    description: STALL.
+    value: 3
+enum/LPM_DEV_RWKENRCVD:
+  bit_size: 1
+  variants:
+  - name: LPM_DEV_RWKENRCVD0
+    description: '0.'
+    value: 0
+  - name: LPM_DEV_RWKENRCVD1
+    description: '1.'
+    value: 1
+enum/LPM_EN:
+  bit_size: 1
+  variants:
+  - name: LPM_EN0
+    description: Disable.
+    value: 0
+  - name: LPM_EN1
+    description: Enable.
+    value: 1
+enum/LPM_EN_ENDP_CHK:
+  bit_size: 1
+  variants:
+  - name: LPM_EN_ENDP_CHK_0
+    description: Disabled.
+    value: 0
+  - name: LPM_EN_ENDP_CHK_1
+    description: Enabled.
+    value: 1
+enum/LPM_ERRATA_EN:
+  bit_size: 1
+  variants:
+  - name: LPM_ERRATA_EN0
+    description: Disable.
+    value: 0
+  - name: LPM_ERRATA_EN1
+    description: Enable.
+    value: 1
+enum/LPM_HST_RWKEN:
+  bit_size: 1
+  variants:
+  - name: LPM_HST_RWKEN0
+    description: Disable.
+    value: 0
+  - name: LPM_HST_RWKEN1
+    description: Enable.
+    value: 1
+enum/LPM_HST_SEND:
+  bit_size: 1
+  variants:
+  - name: LPM_HST_SEND0
+    description: LPM transaction did not happen or is complete.
+    value: 0
+  - name: LPM_HST_SEND1
+    description: LPM transaction is ongoing.
+    value: 1
+enum/LPM_HST_STSRCVD:
+  bit_size: 3
+  variants:
+  - name: LPM_HST_STSRCVD0
+    description: Invalid.
+    value: 0
+  - name: LPM_HST_STSRCVD1
+    description: ACK.
+    value: 1
+  - name: LPM_HST_STSRCVD2
+    description: NYET.
+    value: 2
+  - name: LPM_HST_STSRCVD3
+    description: STALL.
+    value: 3
+  - name: LPM_HST_STSRCVD4
+    description: Timeout.
+    value: 4
+  - name: LPM_HST_STSRCVD5
+    description: ERR.
+    value: 5
+enum/LPM_L1_ACTIVE:
+  bit_size: 1
+  variants:
+  - name: LPM_L1_ACTIVE0
+    description: Inactive.
+    value: 0
+  - name: LPM_L1_ACTIVE1
+    description: Active.
+    value: 1
+enum/LPM_RESUMEOK:
+  bit_size: 1
+  variants:
+  - name: LPM_RESUMEOK0
+    description: Cannot resume.
+    value: 0
+  - name: LPM_RESUMEOK1
+    description: Can resume.
+    value: 1
+enum/OVER_CUR_DIS:
+  bit_size: 1
+  variants:
+  - name: OVRCRNT_DETCT_EN
+    description: Enable.
+    value: 0
+  - name: OVRCRNT_DETCT_DIS
+    description: Disable.
+    value: 1
+enum/OVER_CUR_POL:
+  bit_size: 1
+  variants:
+  - name: ACTIVE_HI_OVRCRNT
+    description: Active high.
+    value: 0
+  - name: ACTIVE_LOW_OVRCRNT
+    description: Active low.
+    value: 1
+enum/OVF_ERROR:
+  bit_size: 1
+  variants:
+  - name: INT_NO
+    description: Interrupt did not occur.
+    value: 0
+  - name: INT_YES
+    description: Unmasked interrupt occurred.
+    value: 1
+enum/OVF_ERROR_EN:
+  bit_size: 1
+  variants:
+  - name: MASK_OVF_ERR_INT
+    description: The interrupt is masked.
+    value: 0
+  - name: EN_OVF_ERR_INT
+    description: The interrupt is enabled.
+    value: 1
+enum/PWR_POL:
+  bit_size: 1
+  variants:
+  - name: ACTIVE_LO_PMIC
+    description: Active low.
+    value: 0
+  - name: ACTIVE_HI_PMIC
+    description: Active high.
+    value: 1
+enum/REMOTE_WAKEUP_EN:
+  bit_size: 1
+  variants:
+  - name: REMOTE_WKUP_DIS
+    description: Disable.
+    value: 0
+  - name: REMOTE_WKUP_EN
+    description: Enable.
+    value: 1
+enum/RESET_RESUME_ROUGH_EN:
+  bit_size: 1
+  variants:
+  - name: KEEP_TRIM_FINE_ON_RESET
+    description: Always works in tracking phase after the first time rough phase, to track transition.
+    value: 0
+  - name: USE_IFR_TRIM_FINE_ON_RESET
+    description: Go back to rough stage whenever a bus reset or bus resume occurs.
+    value: 1
+enum/RESTART_IFRTRIM_EN:
+  bit_size: 1
+  variants:
+  - name: LOAD_TRIM_FINE_MID
+    description: Trim fine adjustment always works based on the previous updated trim fine value.
+    value: 0
+  - name: LOAD_TRIM_FINE_IFR
+    description: Trim fine restarts from the IFR trim value whenever you detect bus_reset or bus_resume or deassert module enable.
+    value: 1
+enum/TRIM_INIT_VAL_SEL:
+  bit_size: 1
+  variants:
+  - name: INIT_TRIM_FINE_MID
+    description: Mid-scale.
+    value: 0
+  - name: INIT_TRIM_FINE_IFR
+    description: IFR.
+    value: 1
+enum/UTMI_CLK_VLD:
+  bit_size: 1
+  variants:
+  - name: NOTVALID
+    description: Not valid.
+    value: 0
+  - name: VALID
+    description: Valid.
+    value: 1
+enum/VBUS_SOURCE_SEL:
+  bit_size: 2
+  variants:
+  - name: VBUS_VALID
+    description: vbus_valid.
+    value: 0
+  - name: SESS_VALID_1
+    description: sess_valid.
+    value: 1
+  - name: SESS_VALID_2
+    description: sess_valid.
+    value: 2
+  - name: SESS_VALID_3
+    description: sess_valid.
+    value: 3
+enum/WIE:
+  bit_size: 1
+  variants:
+  - name: INT_DIS
+    description: Disable.
+    value: 0
+  - name: INT_EN
+    description: Enable.
+    value: 1
+enum/WIR:
+  bit_size: 1
+  variants:
+  - name: NO_WKUP_REQ
+    description: Not received.
+    value: 0
+  - name: WKUP_REQ
+    description: Received.
+    value: 1
+enum/WKUP_DPDM_EN:
+  bit_size: 1
+  variants:
+  - name: DPDM_WKUP_DIS
+    description: Disable only when VBUS is invalid.
+    value: 0
+  - name: DPDM_WKUP_EN
+    description: Enable (default).
+    value: 1
+enum/WKUP_ID_EN:
+  bit_size: 1
+  variants:
+  - name: WKUP_ID_DIS
+    description: Disable.
+    value: 0
+  - name: WKUP_ID_EN
+    description: Enable.
+    value: 1
+enum/WKUP_SW:
+  bit_size: 1
+  variants:
+  - name: INACTIVE
+    description: Inactive.
+    value: 0
+  - name: FORCE_WKUP
+    description: Force wake-up.
+    value: 1
+enum/WKUP_SW_EN:
+  bit_size: 1
+  variants:
+  - name: SW_WKUP_DIS
+    description: Disable.
+    value: 0
+  - name: SW_WKUP_EN
+    description: Enable.
+    value: 1
+enum/WKUP_VBUS_EN:
+  bit_size: 1
+  variants:
+  - name: WKUP_VBUS_DIS
+    description: Disable.
+    value: 0
+  - name: WKUP_VBUS_EN
+    description: Enable.
+    value: 1

--- a/data/metadata/peripherals/mcxa/USBPHY.yaml
+++ b/data/metadata/peripherals/mcxa/USBPHY.yaml
@@ -1,0 +1,2966 @@
+block/Usbphy:
+  description: Universal Serial Bus 2.0 Integrated PHY.
+  items:
+  - name: PWD
+    description: Power Down.
+    byte_offset: 0
+    fieldset: PWD
+  - name: PWD_SET
+    description: Power Down.
+    byte_offset: 4
+    fieldset: PWD_SET
+  - name: PWD_CLR
+    description: Power Down.
+    byte_offset: 8
+    fieldset: PWD_CLR
+  - name: PWD_TOG
+    description: Power Down.
+    byte_offset: 12
+    fieldset: PWD_TOG
+  - name: TX
+    description: TX Control.
+    byte_offset: 16
+    fieldset: TX
+  - name: TX_SET
+    description: TX Control.
+    byte_offset: 20
+    fieldset: TX_SET
+  - name: TX_CLR
+    description: TX Control.
+    byte_offset: 24
+    fieldset: TX_CLR
+  - name: TX_TOG
+    description: TX Control.
+    byte_offset: 28
+    fieldset: TX_TOG
+  - name: RX
+    description: RX Control.
+    byte_offset: 32
+    fieldset: RX
+  - name: RX_SET
+    description: RX Control.
+    byte_offset: 36
+    fieldset: RX_SET
+  - name: RX_CLR
+    description: RX Control.
+    byte_offset: 40
+    fieldset: RX_CLR
+  - name: RX_TOG
+    description: RX Control.
+    byte_offset: 44
+    fieldset: RX_TOG
+  - name: CTRL
+    description: General Purpose Control.
+    byte_offset: 48
+    fieldset: CTRL
+  - name: CTRL_SET
+    description: General Purpose Control.
+    byte_offset: 52
+    fieldset: CTRL_SET
+  - name: CTRL_CLR
+    description: General Purpose Control.
+    byte_offset: 56
+    fieldset: CTRL_CLR
+  - name: CTRL_TOG
+    description: General Purpose Control.
+    byte_offset: 60
+    fieldset: CTRL_TOG
+  - name: STATUS
+    description: Status.
+    byte_offset: 64
+    fieldset: STATUS
+  - name: DEBUG0
+    description: Debug 0.
+    byte_offset: 80
+    fieldset: DEBUG0
+  - name: DEBUG0_SET
+    description: Debug 0.
+    byte_offset: 84
+    fieldset: DEBUG0_SET
+  - name: DEBUG0_CLR
+    description: Debug 0.
+    byte_offset: 88
+    fieldset: DEBUG0_CLR
+  - name: DEBUG0_TOG
+    description: Debug 0.
+    byte_offset: 92
+    fieldset: DEBUG0_TOG
+  - name: VERSION
+    description: Version.
+    byte_offset: 128
+    access: Read
+    fieldset: VERSION
+  - name: IP
+    description: IP Block.
+    byte_offset: 144
+    fieldset: IP
+  - name: IP_SET
+    description: IP Block.
+    byte_offset: 148
+    fieldset: IP_SET
+  - name: IP_CLR
+    description: IP Block.
+    byte_offset: 152
+    fieldset: IP_CLR
+  - name: IP_TOG
+    description: IP Block.
+    byte_offset: 156
+    fieldset: IP_TOG
+  - name: PLL_SIC
+    description: PLL SIC.
+    byte_offset: 160
+    fieldset: PLL_SIC
+  - name: PLL_SIC_SET
+    description: PLL SIC.
+    byte_offset: 164
+    fieldset: PLL_SIC_SET
+  - name: PLL_SIC_CLR
+    description: PLL SIC.
+    byte_offset: 168
+    fieldset: PLL_SIC_CLR
+  - name: PLL_SIC_TOG
+    description: PLL SIC.
+    byte_offset: 172
+    fieldset: PLL_SIC_TOG
+  - name: USB1_VBUS_DETECT
+    description: VBUS Detect.
+    byte_offset: 192
+    fieldset: USB1_VBUS_DETECT
+  - name: USB1_VBUS_DETECT_SET
+    description: VBUS Detect.
+    byte_offset: 196
+    fieldset: USB1_VBUS_DETECT_SET
+  - name: USB1_VBUS_DETECT_CLR
+    description: VBUS Detect.
+    byte_offset: 200
+    fieldset: USB1_VBUS_DETECT_CLR
+  - name: USB1_VBUS_DETECT_TOG
+    description: VBUS Detect.
+    byte_offset: 204
+    fieldset: USB1_VBUS_DETECT_TOG
+  - name: USB1_VBUS_DET_STAT
+    description: VBUS Detect Status.
+    byte_offset: 208
+    access: Read
+    fieldset: USB1_VBUS_DET_STAT
+  - name: USB1_VBUS_DET_STAT_SET
+    description: VBUS Detect Status.
+    byte_offset: 212
+    access: Read
+    fieldset: USB1_VBUS_DET_STAT_SET
+  - name: USB1_VBUS_DET_STAT_CLR
+    description: VBUS Detect Status.
+    byte_offset: 216
+    access: Read
+    fieldset: USB1_VBUS_DET_STAT_CLR
+  - name: USB1_VBUS_DET_STAT_TOG
+    description: VBUS Detect Status.
+    byte_offset: 220
+    access: Read
+    fieldset: USB1_VBUS_DET_STAT_TOG
+  - name: USB1_CHRG_DETECT
+    description: Charger Detect.
+    byte_offset: 224
+    fieldset: USB1_CHRG_DETECT
+  - name: USB1_CHRG_DETECT_SET
+    description: Charger Detect.
+    byte_offset: 228
+    fieldset: USB1_CHRG_DETECT_SET
+  - name: USB1_CHRG_DETECT_CLR
+    description: Charger Detect.
+    byte_offset: 232
+    fieldset: USB1_CHRG_DETECT_CLR
+  - name: USB1_CHRG_DETECT_TOG
+    description: Charger Detect.
+    byte_offset: 236
+    fieldset: USB1_CHRG_DETECT_TOG
+  - name: USB1_CHRG_DET_STAT
+    description: Charger Detect Status.
+    byte_offset: 240
+    access: Read
+    fieldset: USB1_CHRG_DET_STAT
+  - name: USB1_CHRG_DET_STAT_SET
+    description: Charger Detect Status.
+    byte_offset: 244
+    access: Read
+    fieldset: USB1_CHRG_DET_STAT_SET
+  - name: USB1_CHRG_DET_STAT_CLR
+    description: Charger Detect Status.
+    byte_offset: 248
+    access: Read
+    fieldset: USB1_CHRG_DET_STAT_CLR
+  - name: USB1_CHRG_DET_STAT_TOG
+    description: Charger Detect Status.
+    byte_offset: 252
+    access: Read
+    fieldset: USB1_CHRG_DET_STAT_TOG
+  - name: ANACTRL
+    description: Analog Control.
+    byte_offset: 256
+    fieldset: ANACTRL
+  - name: ANACTRL_SET
+    description: Analog Control.
+    byte_offset: 260
+    fieldset: ANACTRL_SET
+  - name: ANACTRL_CLR
+    description: Analog Control.
+    byte_offset: 264
+    fieldset: ANACTRL_CLR
+  - name: ANACTRL_TOG
+    description: Analog Control.
+    byte_offset: 268
+    fieldset: ANACTRL_TOG
+  - name: TRIM_OVERRIDE_EN
+    description: Trim.
+    byte_offset: 304
+    fieldset: TRIM_OVERRIDE_EN
+  - name: TRIM_OVERRIDE_EN_SET
+    description: Trim.
+    byte_offset: 308
+    fieldset: TRIM_OVERRIDE_EN_SET
+  - name: TRIM_OVERRIDE_EN_CLR
+    description: Trim.
+    byte_offset: 312
+    fieldset: TRIM_OVERRIDE_EN_CLR
+  - name: TRIM_OVERRIDE_EN_TOG
+    description: Trim.
+    byte_offset: 316
+    fieldset: TRIM_OVERRIDE_EN_TOG
+  - name: PFDA
+    description: PFD A.
+    byte_offset: 320
+    fieldset: PFDA
+  - name: PFDA_SET
+    description: PFD A.
+    byte_offset: 324
+    fieldset: PFDA_SET
+  - name: PFDA_CLR
+    description: PFD A.
+    byte_offset: 328
+    fieldset: PFDA_CLR
+  - name: PFDA_TOG
+    description: PFD A.
+    byte_offset: 332
+    fieldset: PFDA_TOG
+fieldset/ANACTRL:
+  description: Analog Control.
+  fields:
+  - name: LVI_EN
+    description: Internal Low Voltage Detector Enable.
+    bit_offset: 1
+    bit_size: 1
+    enum: LVI_EN
+  - name: PFD_CLK_SEL
+    description: PFD Clock Selection.
+    bit_offset: 2
+    bit_size: 2
+    enum: PFD_CLK_SEL
+  - name: DEV_PULLDOWN
+    description: Device Pulldown Enable.
+    bit_offset: 10
+    bit_size: 1
+    enum: DEV_PULLDOWN
+fieldset/ANACTRL_CLR:
+  description: Analog Control.
+  fields:
+  - name: LVI_EN
+    description: Internal Low Voltage Detector Enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: PFD_CLK_SEL
+    description: PFD Clock Selection.
+    bit_offset: 2
+    bit_size: 2
+  - name: DEV_PULLDOWN
+    description: Device Pulldown Enable.
+    bit_offset: 10
+    bit_size: 1
+fieldset/ANACTRL_SET:
+  description: Analog Control.
+  fields:
+  - name: LVI_EN
+    description: Internal Low Voltage Detector Enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: PFD_CLK_SEL
+    description: PFD Clock Selection.
+    bit_offset: 2
+    bit_size: 2
+  - name: DEV_PULLDOWN
+    description: Device Pulldown Enable.
+    bit_offset: 10
+    bit_size: 1
+fieldset/ANACTRL_TOG:
+  description: Analog Control.
+  fields:
+  - name: LVI_EN
+    description: Internal Low Voltage Detector Enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: PFD_CLK_SEL
+    description: PFD Clock Selection.
+    bit_offset: 2
+    bit_size: 2
+  - name: DEV_PULLDOWN
+    description: Device Pulldown Enable.
+    bit_offset: 10
+    bit_size: 1
+fieldset/CTRL:
+  description: General Purpose Control.
+  fields:
+  - name: ENOTG_ID_CHG_IRQ
+    description: OTG ID Change Interrupt Enable.
+    bit_offset: 0
+    bit_size: 1
+    enum: ENOTG_ID_CHG_IRQ
+  - name: ENHOSTDISCONDETECT
+    description: Host Disconnect Detection Enable.
+    bit_offset: 1
+    bit_size: 1
+    enum: ENHOSTDISCONDETECT
+  - name: ENIRQHOSTDISCON
+    description: Enable Interrupt for Host Disconnect.
+    bit_offset: 2
+    bit_size: 1
+    enum: ENIRQHOSTDISCON
+  - name: HOSTDISCONDETECT_IRQ
+    description: Host Disconnect Detection Interrupt.
+    bit_offset: 3
+    bit_size: 1
+    enum: HOSTDISCONDETECT_IRQ
+  - name: ENDEVPLUGINDETECT
+    description: Enable Nonstandard Resistive Plugged-In Detection.
+    bit_offset: 4
+    bit_size: 1
+    enum: ENDEVPLUGINDETECT
+  - name: DEVPLUGIN_POLARITY
+    description: Device Plug-In Polarity.
+    bit_offset: 5
+    bit_size: 1
+    enum: DEVPLUGIN_POLARITY
+  - name: OTG_ID_CHG_IRQ
+    description: OTG ID Change Interrupt.
+    bit_offset: 6
+    bit_size: 1
+    enum: OTG_ID_CHG_IRQ
+  - name: ENOTGIDDETECT
+    description: Enable Internal OTG ID Detector.
+    bit_offset: 7
+    bit_size: 1
+    enum: ENOTGIDDETECT
+  - name: RESUMEIRQSTICKY
+    description: Resume Interrupt Sticky.
+    bit_offset: 8
+    bit_size: 1
+    enum: RESUMEIRQSTICKY
+  - name: ENIRQRESUMEDETECT
+    description: Resume Detection Interrupt Enable.
+    bit_offset: 9
+    bit_size: 1
+    enum: ENIRQRESUMEDETECT
+  - name: RESUME_IRQ
+    description: Resume Interrupt.
+    bit_offset: 10
+    bit_size: 1
+    enum: RESUME_IRQ
+  - name: ENIRQDEVPLUGIN
+    description: Enable Interrupt for Nonstandard Resistive Plugged-In Detection.
+    bit_offset: 11
+    bit_size: 1
+    enum: ENIRQDEVPLUGIN
+  - name: DEVPLUGIN_IRQ
+    description: Device Plug-In Interrupt.
+    bit_offset: 12
+    bit_size: 1
+  - name: DATA_ON_LRADC
+    description: APB Clock Switch Option.
+    bit_offset: 13
+    bit_size: 1
+  - name: ENUTMILEVEL2
+    description: UTMI Level 2 Enable.
+    bit_offset: 14
+    bit_size: 1
+    enum: ENUTMILEVEL2
+  - name: ENUTMILEVEL3
+    description: UTMI Level 3 Enable.
+    bit_offset: 15
+    bit_size: 1
+    enum: ENUTMILEVEL3
+  - name: ENIRQWAKEUP
+    description: Wake-Up Interrupt Enable.
+    bit_offset: 16
+    bit_size: 1
+    enum: ENIRQWAKEUP
+  - name: WAKEUP_IRQ
+    description: Wake-Up Interrupt.
+    bit_offset: 17
+    bit_size: 1
+  - name: AUTORESUME_EN
+    description: Autoresume Enable.
+    bit_offset: 18
+    bit_size: 1
+    enum: AUTORESUME_EN
+  - name: ENAUTOCLR_CLKGATE
+    description: Autoclear Clock Gate Enable.
+    bit_offset: 19
+    bit_size: 1
+    enum: ENAUTOCLR_CLKGATE
+  - name: ENAUTOCLR_PHY_PWD
+    description: PHY PWD Autoclear Enable.
+    bit_offset: 20
+    bit_size: 1
+    enum: ENAUTOCLR_PHY_PWD
+  - name: OTG_ID_VALUE
+    description: OTG ID Value.
+    bit_offset: 27
+    bit_size: 1
+    enum: OTG_ID_VALUE
+  - name: UTMI_SUSPENDM
+    description: UTMI Suspend.
+    bit_offset: 29
+    bit_size: 1
+    enum: UTMI_SUSPENDM
+  - name: CLKGATE
+    description: UTMI Clock Gate.
+    bit_offset: 30
+    bit_size: 1
+    enum: CLKGATE
+  - name: SFTRST
+    description: Software Reset.
+    bit_offset: 31
+    bit_size: 1
+    enum: SFTRST
+fieldset/CTRL_CLR:
+  description: General Purpose Control.
+  fields:
+  - name: ENOTG_ID_CHG_IRQ
+    description: OTG ID Change Interrupt Enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: ENHOSTDISCONDETECT
+    description: Host Disconnect Detection Enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: ENIRQHOSTDISCON
+    description: Enable Interrupt for Host Disconnect.
+    bit_offset: 2
+    bit_size: 1
+  - name: HOSTDISCONDETECT_IRQ
+    description: Host Disconnect Detection Interrupt.
+    bit_offset: 3
+    bit_size: 1
+  - name: ENDEVPLUGINDETECT
+    description: Enable Nonstandard Resistive Plugged-In Detection.
+    bit_offset: 4
+    bit_size: 1
+  - name: DEVPLUGIN_POLARITY
+    description: Device Plug-In Polarity.
+    bit_offset: 5
+    bit_size: 1
+  - name: OTG_ID_CHG_IRQ
+    description: OTG ID Change Interrupt.
+    bit_offset: 6
+    bit_size: 1
+  - name: ENOTGIDDETECT
+    description: Enable Internal OTG ID Detector.
+    bit_offset: 7
+    bit_size: 1
+  - name: RESUMEIRQSTICKY
+    description: Resume Interrupt Sticky.
+    bit_offset: 8
+    bit_size: 1
+  - name: ENIRQRESUMEDETECT
+    description: Resume Detection Interrupt Enable.
+    bit_offset: 9
+    bit_size: 1
+  - name: RESUME_IRQ
+    description: Resume Interrupt.
+    bit_offset: 10
+    bit_size: 1
+  - name: ENIRQDEVPLUGIN
+    description: Enable Interrupt for Nonstandard Resistive Plugged-In Detection.
+    bit_offset: 11
+    bit_size: 1
+  - name: DEVPLUGIN_IRQ
+    description: Device Plug-In Interrupt.
+    bit_offset: 12
+    bit_size: 1
+  - name: DATA_ON_LRADC
+    description: APB Clock Switch Option.
+    bit_offset: 13
+    bit_size: 1
+  - name: ENUTMILEVEL2
+    description: UTMI Level 2 Enable.
+    bit_offset: 14
+    bit_size: 1
+  - name: ENUTMILEVEL3
+    description: UTMI Level 3 Enable.
+    bit_offset: 15
+    bit_size: 1
+  - name: ENIRQWAKEUP
+    description: Wake-Up Interrupt Enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: WAKEUP_IRQ
+    description: Wake-Up Interrupt.
+    bit_offset: 17
+    bit_size: 1
+  - name: AUTORESUME_EN
+    description: Autoresume Enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: ENAUTOCLR_CLKGATE
+    description: Autoclear Clock Gate Enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: ENAUTOCLR_PHY_PWD
+    description: PHY PWD Autoclear Enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: OTG_ID_VALUE
+    description: OTG ID Value.
+    bit_offset: 27
+    bit_size: 1
+  - name: UTMI_SUSPENDM
+    description: UTMI Suspend.
+    bit_offset: 29
+    bit_size: 1
+  - name: CLKGATE
+    description: UTMI Clock Gate.
+    bit_offset: 30
+    bit_size: 1
+  - name: SFTRST
+    description: Software Reset.
+    bit_offset: 31
+    bit_size: 1
+fieldset/CTRL_SET:
+  description: General Purpose Control.
+  fields:
+  - name: ENOTG_ID_CHG_IRQ
+    description: OTG ID Change Interrupt Enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: ENHOSTDISCONDETECT
+    description: Host Disconnect Detection Enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: ENIRQHOSTDISCON
+    description: Enable Interrupt for Host Disconnect.
+    bit_offset: 2
+    bit_size: 1
+  - name: HOSTDISCONDETECT_IRQ
+    description: Host Disconnect Detection Interrupt.
+    bit_offset: 3
+    bit_size: 1
+  - name: ENDEVPLUGINDETECT
+    description: Enable Nonstandard Resistive Plugged-In Detection.
+    bit_offset: 4
+    bit_size: 1
+  - name: DEVPLUGIN_POLARITY
+    description: Device Plug-In Polarity.
+    bit_offset: 5
+    bit_size: 1
+  - name: OTG_ID_CHG_IRQ
+    description: OTG ID Change Interrupt.
+    bit_offset: 6
+    bit_size: 1
+  - name: ENOTGIDDETECT
+    description: Enable Internal OTG ID Detector.
+    bit_offset: 7
+    bit_size: 1
+  - name: RESUMEIRQSTICKY
+    description: Resume Interrupt Sticky.
+    bit_offset: 8
+    bit_size: 1
+  - name: ENIRQRESUMEDETECT
+    description: Resume Detection Interrupt Enable.
+    bit_offset: 9
+    bit_size: 1
+  - name: RESUME_IRQ
+    description: Resume Interrupt.
+    bit_offset: 10
+    bit_size: 1
+  - name: ENIRQDEVPLUGIN
+    description: Enable Interrupt for Nonstandard Resistive Plugged-In Detection.
+    bit_offset: 11
+    bit_size: 1
+  - name: DEVPLUGIN_IRQ
+    description: Device Plug-In Interrupt.
+    bit_offset: 12
+    bit_size: 1
+  - name: DATA_ON_LRADC
+    description: APB Clock Switch Option.
+    bit_offset: 13
+    bit_size: 1
+  - name: ENUTMILEVEL2
+    description: UTMI Level 2 Enable.
+    bit_offset: 14
+    bit_size: 1
+  - name: ENUTMILEVEL3
+    description: UTMI Level 3 Enable.
+    bit_offset: 15
+    bit_size: 1
+  - name: ENIRQWAKEUP
+    description: Wake-Up Interrupt Enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: WAKEUP_IRQ
+    description: Wake-Up Interrupt.
+    bit_offset: 17
+    bit_size: 1
+  - name: AUTORESUME_EN
+    description: Autoresume Enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: ENAUTOCLR_CLKGATE
+    description: Autoclear Clock Gate Enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: ENAUTOCLR_PHY_PWD
+    description: PHY PWD Autoclear Enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: OTG_ID_VALUE
+    description: OTG ID Value.
+    bit_offset: 27
+    bit_size: 1
+  - name: UTMI_SUSPENDM
+    description: UTMI Suspend.
+    bit_offset: 29
+    bit_size: 1
+  - name: CLKGATE
+    description: UTMI Clock Gate.
+    bit_offset: 30
+    bit_size: 1
+  - name: SFTRST
+    description: Software Reset.
+    bit_offset: 31
+    bit_size: 1
+fieldset/CTRL_TOG:
+  description: General Purpose Control.
+  fields:
+  - name: ENOTG_ID_CHG_IRQ
+    description: OTG ID Change Interrupt Enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: ENHOSTDISCONDETECT
+    description: Host Disconnect Detection Enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: ENIRQHOSTDISCON
+    description: Enable Interrupt for Host Disconnect.
+    bit_offset: 2
+    bit_size: 1
+  - name: HOSTDISCONDETECT_IRQ
+    description: Host Disconnect Detection Interrupt.
+    bit_offset: 3
+    bit_size: 1
+  - name: ENDEVPLUGINDETECT
+    description: Enable Nonstandard Resistive Plugged-In Detection.
+    bit_offset: 4
+    bit_size: 1
+  - name: DEVPLUGIN_POLARITY
+    description: Device Plug-In Polarity.
+    bit_offset: 5
+    bit_size: 1
+  - name: OTG_ID_CHG_IRQ
+    description: OTG ID Change Interrupt.
+    bit_offset: 6
+    bit_size: 1
+  - name: ENOTGIDDETECT
+    description: Enable Internal OTG ID Detector.
+    bit_offset: 7
+    bit_size: 1
+  - name: RESUMEIRQSTICKY
+    description: Resume Interrupt Sticky.
+    bit_offset: 8
+    bit_size: 1
+  - name: ENIRQRESUMEDETECT
+    description: Resume Detection Interrupt Enable.
+    bit_offset: 9
+    bit_size: 1
+  - name: RESUME_IRQ
+    description: Resume Interrupt.
+    bit_offset: 10
+    bit_size: 1
+  - name: ENIRQDEVPLUGIN
+    description: Enable Interrupt for Nonstandard Resistive Plugged-In Detection.
+    bit_offset: 11
+    bit_size: 1
+  - name: DEVPLUGIN_IRQ
+    description: Device Plug-In Interrupt.
+    bit_offset: 12
+    bit_size: 1
+  - name: DATA_ON_LRADC
+    description: APB Clock Switch Option.
+    bit_offset: 13
+    bit_size: 1
+  - name: ENUTMILEVEL2
+    description: UTMI Level 2 Enable.
+    bit_offset: 14
+    bit_size: 1
+  - name: ENUTMILEVEL3
+    description: UTMI Level 3 Enable.
+    bit_offset: 15
+    bit_size: 1
+  - name: ENIRQWAKEUP
+    description: Wake-Up Interrupt Enable.
+    bit_offset: 16
+    bit_size: 1
+  - name: WAKEUP_IRQ
+    description: Wake-Up Interrupt.
+    bit_offset: 17
+    bit_size: 1
+  - name: AUTORESUME_EN
+    description: Autoresume Enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: ENAUTOCLR_CLKGATE
+    description: Autoclear Clock Gate Enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: ENAUTOCLR_PHY_PWD
+    description: PHY PWD Autoclear Enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: OTG_ID_VALUE
+    description: OTG ID Value.
+    bit_offset: 27
+    bit_size: 1
+  - name: UTMI_SUSPENDM
+    description: UTMI Suspend.
+    bit_offset: 29
+    bit_size: 1
+  - name: CLKGATE
+    description: UTMI Clock Gate.
+    bit_offset: 30
+    bit_size: 1
+  - name: SFTRST
+    description: Software Reset.
+    bit_offset: 31
+    bit_size: 1
+fieldset/DEBUG0:
+  description: Debug 0.
+  fields:
+  - name: OTGIDPIOLOCK
+    description: Hold OTG_ID.
+    bit_offset: 0
+    bit_size: 1
+  - name: HSTPULLDOWN
+    description: Host Pulldown Overdrive Mode.
+    bit_offset: 2
+    bit_size: 2
+    enum: HSTPULLDOWN
+  - name: ENHSTPULLDOWN
+    description: Enable Host Pulldown Overdrive Mode.
+    bit_offset: 4
+    bit_size: 2
+    enum: ENHSTPULLDOWN
+fieldset/DEBUG0_CLR:
+  description: Debug 0.
+  fields:
+  - name: OTGIDPIOLOCK
+    description: Hold OTG_ID.
+    bit_offset: 0
+    bit_size: 1
+  - name: HSTPULLDOWN
+    description: Host Pulldown Overdrive Mode.
+    bit_offset: 2
+    bit_size: 2
+  - name: ENHSTPULLDOWN
+    description: Enable Host Pulldown Overdrive Mode.
+    bit_offset: 4
+    bit_size: 2
+fieldset/DEBUG0_SET:
+  description: Debug 0.
+  fields:
+  - name: OTGIDPIOLOCK
+    description: Hold OTG_ID.
+    bit_offset: 0
+    bit_size: 1
+  - name: HSTPULLDOWN
+    description: Host Pulldown Overdrive Mode.
+    bit_offset: 2
+    bit_size: 2
+  - name: ENHSTPULLDOWN
+    description: Enable Host Pulldown Overdrive Mode.
+    bit_offset: 4
+    bit_size: 2
+fieldset/DEBUG0_TOG:
+  description: Debug 0.
+  fields:
+  - name: OTGIDPIOLOCK
+    description: Hold OTG_ID.
+    bit_offset: 0
+    bit_size: 1
+  - name: HSTPULLDOWN
+    description: Host Pulldown Overdrive Mode.
+    bit_offset: 2
+    bit_size: 2
+  - name: ENHSTPULLDOWN
+    description: Enable Host Pulldown Overdrive Mode.
+    bit_offset: 4
+    bit_size: 2
+fieldset/IP:
+  description: IP Block.
+  fields:
+  - name: POWER_CONTROL_SUSPEND_OPTION
+    description: Power Control Suspend Option.
+    bit_offset: 0
+    bit_size: 1
+fieldset/IP_CLR:
+  description: IP Block.
+  fields:
+  - name: POWER_CONTROL_SUSPEND_OPTION
+    description: Power Control Suspend Option.
+    bit_offset: 0
+    bit_size: 1
+fieldset/IP_SET:
+  description: IP Block.
+  fields:
+  - name: POWER_CONTROL_SUSPEND_OPTION
+    description: Power Control Suspend Option.
+    bit_offset: 0
+    bit_size: 1
+fieldset/IP_TOG:
+  description: IP Block.
+  fields:
+  - name: POWER_CONTROL_SUSPEND_OPTION
+    description: Power Control Suspend Option.
+    bit_offset: 0
+    bit_size: 1
+fieldset/PFDA:
+  description: PFD A.
+  fields:
+  - name: PFD0_CLKGATE
+    description: PFD0 Clock Gate.
+    bit_offset: 0
+    bit_size: 1
+    enum: PFD0_CLKGATE
+  - name: PFD0_FRAC
+    description: PFD0 Fractional Divider.
+    bit_offset: 1
+    bit_size: 6
+  - name: PFD0_STABLE
+    description: PFD0 Stable Signal.
+    bit_offset: 7
+    bit_size: 1
+    enum: PFD0_STABLE
+fieldset/PFDA_CLR:
+  description: PFD A.
+  fields:
+  - name: PFD0_CLKGATE
+    description: PFD0 Clock Gate.
+    bit_offset: 0
+    bit_size: 1
+  - name: PFD0_FRAC
+    description: PFD0 Fractional Divider.
+    bit_offset: 1
+    bit_size: 6
+  - name: PFD0_STABLE
+    description: PFD0 Stable Signal.
+    bit_offset: 7
+    bit_size: 1
+fieldset/PFDA_SET:
+  description: PFD A.
+  fields:
+  - name: PFD0_CLKGATE
+    description: PFD0 Clock Gate.
+    bit_offset: 0
+    bit_size: 1
+  - name: PFD0_FRAC
+    description: PFD0 Fractional Divider.
+    bit_offset: 1
+    bit_size: 6
+  - name: PFD0_STABLE
+    description: PFD0 Stable Signal.
+    bit_offset: 7
+    bit_size: 1
+fieldset/PFDA_TOG:
+  description: PFD A.
+  fields:
+  - name: PFD0_CLKGATE
+    description: PFD0 Clock Gate.
+    bit_offset: 0
+    bit_size: 1
+  - name: PFD0_FRAC
+    description: PFD0 Fractional Divider.
+    bit_offset: 1
+    bit_size: 6
+  - name: PFD0_STABLE
+    description: PFD0 Stable Signal.
+    bit_offset: 7
+    bit_size: 1
+fieldset/PLL_SIC:
+  description: PLL SIC.
+  fields:
+  - name: MISC2_CONTROL0
+    description: Miscellaneous Control.
+    bit_offset: 5
+    bit_size: 1
+    enum: MISC2_CONTROL0
+  - name: PLL_EN_USB_CLKS
+    description: PLL Multi-Phase Clock Outputs Enable.
+    bit_offset: 6
+    bit_size: 1
+    enum: PLL_EN_USB_CLKS
+  - name: PLL_POWER
+    description: USB PLL Powerup Control.
+    bit_offset: 12
+    bit_size: 1
+    enum: PLL_POWER
+  - name: PLL_ENABLE
+    description: PLL Output Clock Enable.
+    bit_offset: 13
+    bit_size: 1
+    enum: PLL_ENABLE
+  - name: PLL_BYPASS
+    description: Bypass USB PLL.
+    bit_offset: 16
+    bit_size: 1
+    enum: PLL_BYPASS
+  - name: REFBIAS_PWD_SEL
+    description: Reference Bias Power Control.
+    bit_offset: 19
+    bit_size: 1
+    enum: REFBIAS_PWD_SEL
+  - name: REFBIAS_PWD
+    description: Power Down Reference Bias.
+    bit_offset: 20
+    bit_size: 1
+    enum: REFBIAS_PWD
+  - name: PLL_REG_ENABLE
+    description: Enable PLL Regulator.
+    bit_offset: 21
+    bit_size: 1
+    enum: PLL_REG_ENABLE
+  - name: PLL_DIV_SEL
+    description: PLL Divider Value Configuration.
+    bit_offset: 22
+    bit_size: 3
+    enum: PLL_DIV_SEL
+  - name: PLL_PREDIV
+    description: PLL Pre-Divider.
+    bit_offset: 30
+    bit_size: 1
+    enum: PLL_PREDIV
+  - name: PLL_LOCK
+    description: USB PLL Lock Status Indicator.
+    bit_offset: 31
+    bit_size: 1
+    enum: PLL_LOCK
+fieldset/PLL_SIC_CLR:
+  description: PLL SIC.
+  fields:
+  - name: MISC2_CONTROL0
+    description: Miscellaneous Control.
+    bit_offset: 5
+    bit_size: 1
+  - name: PLL_EN_USB_CLKS
+    description: PLL Multi-Phase Clock Outputs Enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: PLL_POWER
+    description: USB PLL Powerup Control.
+    bit_offset: 12
+    bit_size: 1
+  - name: PLL_ENABLE
+    description: PLL Output Clock Enable.
+    bit_offset: 13
+    bit_size: 1
+  - name: PLL_BYPASS
+    description: Bypass USB PLL.
+    bit_offset: 16
+    bit_size: 1
+  - name: REFBIAS_PWD_SEL
+    description: Reference Bias Power Control.
+    bit_offset: 19
+    bit_size: 1
+  - name: REFBIAS_PWD
+    description: Power Down Reference Bias.
+    bit_offset: 20
+    bit_size: 1
+  - name: PLL_REG_ENABLE
+    description: Enable PLL Regulator.
+    bit_offset: 21
+    bit_size: 1
+  - name: PLL_DIV_SEL
+    description: PLL Divider Value Configuration.
+    bit_offset: 22
+    bit_size: 3
+  - name: PLL_PREDIV
+    description: PLL Pre-Divider.
+    bit_offset: 30
+    bit_size: 1
+  - name: PLL_LOCK
+    description: USB PLL Lock Status Indicator.
+    bit_offset: 31
+    bit_size: 1
+fieldset/PLL_SIC_SET:
+  description: PLL SIC.
+  fields:
+  - name: MISC2_CONTROL0
+    description: Miscellaneous Control.
+    bit_offset: 5
+    bit_size: 1
+  - name: PLL_EN_USB_CLKS
+    description: PLL Multi-Phase Clock Outputs Enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: PLL_POWER
+    description: USB PLL Powerup Control.
+    bit_offset: 12
+    bit_size: 1
+  - name: PLL_ENABLE
+    description: PLL Output Clock Enable.
+    bit_offset: 13
+    bit_size: 1
+  - name: PLL_BYPASS
+    description: Bypass USB PLL.
+    bit_offset: 16
+    bit_size: 1
+  - name: REFBIAS_PWD_SEL
+    description: Reference Bias Power Control.
+    bit_offset: 19
+    bit_size: 1
+  - name: REFBIAS_PWD
+    description: Power Down Reference Bias.
+    bit_offset: 20
+    bit_size: 1
+  - name: PLL_REG_ENABLE
+    description: Enable PLL Regulator.
+    bit_offset: 21
+    bit_size: 1
+  - name: PLL_DIV_SEL
+    description: PLL Divider Value Configuration.
+    bit_offset: 22
+    bit_size: 3
+  - name: PLL_PREDIV
+    description: PLL Pre-Divider.
+    bit_offset: 30
+    bit_size: 1
+  - name: PLL_LOCK
+    description: USB PLL Lock Status Indicator.
+    bit_offset: 31
+    bit_size: 1
+fieldset/PLL_SIC_TOG:
+  description: PLL SIC.
+  fields:
+  - name: MISC2_CONTROL0
+    description: Miscellaneous Control.
+    bit_offset: 5
+    bit_size: 1
+  - name: PLL_EN_USB_CLKS
+    description: PLL Multi-Phase Clock Outputs Enable.
+    bit_offset: 6
+    bit_size: 1
+  - name: PLL_POWER
+    description: USB PLL Powerup Control.
+    bit_offset: 12
+    bit_size: 1
+  - name: PLL_ENABLE
+    description: PLL Output Clock Enable.
+    bit_offset: 13
+    bit_size: 1
+  - name: PLL_BYPASS
+    description: Bypass USB PLL.
+    bit_offset: 16
+    bit_size: 1
+  - name: REFBIAS_PWD_SEL
+    description: Reference Bias Power Control.
+    bit_offset: 19
+    bit_size: 1
+  - name: REFBIAS_PWD
+    description: Power Down Reference Bias.
+    bit_offset: 20
+    bit_size: 1
+  - name: PLL_REG_ENABLE
+    description: Enable PLL Regulator.
+    bit_offset: 21
+    bit_size: 1
+  - name: PLL_DIV_SEL
+    description: PLL Divider Value Configuration.
+    bit_offset: 22
+    bit_size: 3
+  - name: PLL_PREDIV
+    description: PLL Pre-Divider.
+    bit_offset: 30
+    bit_size: 1
+  - name: PLL_LOCK
+    description: USB PLL Lock Status Indicator.
+    bit_offset: 31
+    bit_size: 1
+fieldset/PWD:
+  description: Power Down.
+  fields:
+  - name: TXPWDFS
+    description: Power Down USB FS TX Drivers.
+    bit_offset: 10
+    bit_size: 1
+    enum: TXPWDFS
+  - name: TXPWDIBIAS
+    description: Power Down USBPHY TX Current Bias Block.
+    bit_offset: 11
+    bit_size: 1
+    enum: TXPWDIBIAS
+  - name: TXPWDV2I
+    description: Power Down USBPHY TX V-I Converter and Current Mirror.
+    bit_offset: 12
+    bit_size: 1
+    enum: TXPWDV2I
+  - name: RXPWDENV
+    description: Power Down USB HS RX Envelope Detector.
+    bit_offset: 17
+    bit_size: 1
+    enum: RXPWDENV
+  - name: RXPWD1PT1
+    description: Power Down USB FS Differential Receiver.
+    bit_offset: 18
+    bit_size: 1
+    enum: RXPWD1PT1
+  - name: RXPWDDIFF
+    description: Power Down USB HS Differential Receiver.
+    bit_offset: 19
+    bit_size: 1
+    enum: RXPWDDIFF
+  - name: RXPWDRX
+    description: Power Down USBPHY Receiver Circuits.
+    bit_offset: 20
+    bit_size: 1
+    enum: RXPWDRX
+fieldset/PWD_CLR:
+  description: Power Down.
+  fields:
+  - name: TXPWDFS
+    description: Power Down USB FS TX Drivers.
+    bit_offset: 10
+    bit_size: 1
+  - name: TXPWDIBIAS
+    description: Power Down USBPHY TX Current Bias Block.
+    bit_offset: 11
+    bit_size: 1
+  - name: TXPWDV2I
+    description: Power Down USBPHY TX V-I Converter and Current Mirror.
+    bit_offset: 12
+    bit_size: 1
+  - name: RXPWDENV
+    description: Power Down USB HS RX Envelope Detector.
+    bit_offset: 17
+    bit_size: 1
+  - name: RXPWD1PT1
+    description: Power Down USB FS Differential Receiver.
+    bit_offset: 18
+    bit_size: 1
+  - name: RXPWDDIFF
+    description: Power Down USB HS Differential Receiver.
+    bit_offset: 19
+    bit_size: 1
+  - name: RXPWDRX
+    description: Power Down USBPHY Receiver Circuits.
+    bit_offset: 20
+    bit_size: 1
+fieldset/PWD_SET:
+  description: Power Down.
+  fields:
+  - name: TXPWDFS
+    description: Power Down USB FS TX Drivers.
+    bit_offset: 10
+    bit_size: 1
+  - name: TXPWDIBIAS
+    description: Power Down USBPHY TX Current Bias Block.
+    bit_offset: 11
+    bit_size: 1
+  - name: TXPWDV2I
+    description: Power Down USBPHY TX V-I Converter and Current Mirror.
+    bit_offset: 12
+    bit_size: 1
+  - name: RXPWDENV
+    description: Power Down USB HS RX Envelope Detector.
+    bit_offset: 17
+    bit_size: 1
+  - name: RXPWD1PT1
+    description: Power Down USB FS Differential Receiver.
+    bit_offset: 18
+    bit_size: 1
+  - name: RXPWDDIFF
+    description: Power Down USB HS Differential Receiver.
+    bit_offset: 19
+    bit_size: 1
+  - name: RXPWDRX
+    description: Power Down USBPHY Receiver Circuits.
+    bit_offset: 20
+    bit_size: 1
+fieldset/PWD_TOG:
+  description: Power Down.
+  fields:
+  - name: TXPWDFS
+    description: Power Down USB FS TX Drivers.
+    bit_offset: 10
+    bit_size: 1
+  - name: TXPWDIBIAS
+    description: Power Down USBPHY TX Current Bias Block.
+    bit_offset: 11
+    bit_size: 1
+  - name: TXPWDV2I
+    description: Power Down USBPHY TX V-I Converter and Current Mirror.
+    bit_offset: 12
+    bit_size: 1
+  - name: RXPWDENV
+    description: Power Down USB HS RX Envelope Detector.
+    bit_offset: 17
+    bit_size: 1
+  - name: RXPWD1PT1
+    description: Power Down USB FS Differential Receiver.
+    bit_offset: 18
+    bit_size: 1
+  - name: RXPWDDIFF
+    description: Power Down USB HS Differential Receiver.
+    bit_offset: 19
+    bit_size: 1
+  - name: RXPWDRX
+    description: Power Down USBPHY Receiver Circuits.
+    bit_offset: 20
+    bit_size: 1
+fieldset/RX:
+  description: RX Control.
+  fields:
+  - name: ENVADJ
+    description: Envelope Detector Trip Point.
+    bit_offset: 0
+    bit_size: 3
+    enum: ENVADJ
+  - name: DISCONADJ
+    description: Disconnect Detector Trip Point.
+    bit_offset: 4
+    bit_size: 3
+    enum: DISCONADJ
+fieldset/RX_CLR:
+  description: RX Control.
+  fields:
+  - name: ENVADJ
+    description: Envelope Detector Trip Point.
+    bit_offset: 0
+    bit_size: 3
+  - name: DISCONADJ
+    description: Disconnect Detector Trip Point.
+    bit_offset: 4
+    bit_size: 3
+fieldset/RX_SET:
+  description: RX Control.
+  fields:
+  - name: ENVADJ
+    description: Envelope Detector Trip Point.
+    bit_offset: 0
+    bit_size: 3
+  - name: DISCONADJ
+    description: Disconnect Detector Trip Point.
+    bit_offset: 4
+    bit_size: 3
+fieldset/RX_TOG:
+  description: RX Control.
+  fields:
+  - name: ENVADJ
+    description: Envelope Detector Trip Point.
+    bit_offset: 0
+    bit_size: 3
+  - name: DISCONADJ
+    description: Disconnect Detector Trip Point.
+    bit_offset: 4
+    bit_size: 3
+fieldset/STATUS:
+  description: Status.
+  fields:
+  - name: OK_STATUS_3V
+    description: USB 3.3 V and 1.8 V Supply Status.
+    bit_offset: 0
+    bit_size: 1
+    enum: OK_STATUS_3V
+  - name: HOSTDISCONDETECT_STATUS
+    description: Host Disconnect Status.
+    bit_offset: 3
+    bit_size: 1
+    enum: HOSTDISCONDETECT_STATUS
+  - name: DEVPLUGIN_STATUS
+    description: Status Indicator for Nonstandard Resistive Plugged-In Detection.
+    bit_offset: 6
+    bit_size: 1
+    enum: DEVPLUGIN_STATUS
+  - name: OTGID_STATUS
+    description: OTG ID Status.
+    bit_offset: 8
+    bit_size: 1
+    enum: OTGID_STATUS
+  - name: RESUME_STATUS
+    description: Resume Status.
+    bit_offset: 10
+    bit_size: 1
+fieldset/TRIM_OVERRIDE_EN:
+  description: Trim.
+  fields:
+  - name: DIV_SEL_OVERRIDE
+    description: Override Enable for PLL Divider Value.
+    bit_offset: 0
+    bit_size: 1
+    enum: DIV_SEL_OVERRIDE
+  - name: TX_D_CAL_OVERRIDE
+    description: Override Enable for HS TX Output Current Trim.
+    bit_offset: 2
+    bit_size: 1
+    enum: TX_D_CAL_OVERRIDE
+  - name: TX_CAL45DP_OVERRIDE
+    description: Override Enable for USB_DP Series Termination Trim.
+    bit_offset: 3
+    bit_size: 1
+    enum: TX_CAL45DP_OVERRIDE
+  - name: TX_CAL45DM_OVERRIDE
+    description: Override Enable for USB_DM Series Termination Trim.
+    bit_offset: 4
+    bit_size: 1
+    enum: TX_CAL45DM_OVERRIDE
+  - name: PLL_CTRL0_DIV_SEL
+    description: PLL Divider Value Configuration Bits from Outside USBPHY.
+    bit_offset: 15
+    bit_size: 3
+  - name: USBPHY_TX_D_CAL
+    description: HS TX Output Current Trim Bits from Outside USBPHY.
+    bit_offset: 20
+    bit_size: 4
+    enum: USBPHY_TX_D_CAL
+  - name: USBPHY_TX_CAL45DP
+    description: DP Series Termination Resistance Trim Bits from Outside USBPHY.
+    bit_offset: 24
+    bit_size: 4
+  - name: USBPHY_TX_CAL45DN
+    description: DM Series Termination Resistance Trim Bits from Outside USBPHY.
+    bit_offset: 28
+    bit_size: 4
+fieldset/TRIM_OVERRIDE_EN_CLR:
+  description: Trim.
+  fields:
+  - name: DIV_SEL_OVERRIDE
+    description: Override Enable for PLL Divider Value.
+    bit_offset: 0
+    bit_size: 1
+  - name: TX_D_CAL_OVERRIDE
+    description: Override Enable for HS TX Output Current Trim.
+    bit_offset: 2
+    bit_size: 1
+  - name: TX_CAL45DP_OVERRIDE
+    description: Override Enable for USB_DP Series Termination Trim.
+    bit_offset: 3
+    bit_size: 1
+  - name: TX_CAL45DM_OVERRIDE
+    description: Override Enable for USB_DM Series Termination Trim.
+    bit_offset: 4
+    bit_size: 1
+  - name: PLL_CTRL0_DIV_SEL
+    description: PLL Divider Value Configuration Bits from Outside USBPHY.
+    bit_offset: 15
+    bit_size: 3
+  - name: USBPHY_TX_D_CAL
+    description: HS TX Output Current Trim Bits from Outside USBPHY.
+    bit_offset: 20
+    bit_size: 4
+  - name: USBPHY_TX_CAL45DP
+    description: DP Series Termination Resistance Trim Bits from Outside USBPHY.
+    bit_offset: 24
+    bit_size: 4
+  - name: USBPHY_TX_CAL45DN
+    description: DM Series Termination Resistance Trim Bits from Outside USBPHY.
+    bit_offset: 28
+    bit_size: 4
+fieldset/TRIM_OVERRIDE_EN_SET:
+  description: Trim.
+  fields:
+  - name: DIV_SEL_OVERRIDE
+    description: Override Enable for PLL Divider Value.
+    bit_offset: 0
+    bit_size: 1
+  - name: TX_D_CAL_OVERRIDE
+    description: Override Enable for HS TX Output Current Trim.
+    bit_offset: 2
+    bit_size: 1
+  - name: TX_CAL45DP_OVERRIDE
+    description: Override Enable for USB_DP Series Termination Trim.
+    bit_offset: 3
+    bit_size: 1
+  - name: TX_CAL45DM_OVERRIDE
+    description: Override Enable for USB_DM Series Termination Trim.
+    bit_offset: 4
+    bit_size: 1
+  - name: PLL_CTRL0_DIV_SEL
+    description: PLL Divider Value Configuration Bits from Outside USBPHY.
+    bit_offset: 15
+    bit_size: 3
+  - name: USBPHY_TX_D_CAL
+    description: HS TX Output Current Trim Bits from Outside USBPHY.
+    bit_offset: 20
+    bit_size: 4
+  - name: USBPHY_TX_CAL45DP
+    description: DP Series Termination Resistance Trim Bits from Outside USBPHY.
+    bit_offset: 24
+    bit_size: 4
+  - name: USBPHY_TX_CAL45DN
+    description: DM Series Termination Resistance Trim Bits from Outside USBPHY.
+    bit_offset: 28
+    bit_size: 4
+fieldset/TRIM_OVERRIDE_EN_TOG:
+  description: Trim.
+  fields:
+  - name: DIV_SEL_OVERRIDE
+    description: Override Enable for PLL Divider Value.
+    bit_offset: 0
+    bit_size: 1
+  - name: TX_D_CAL_OVERRIDE
+    description: Override Enable for HS TX Output Current Trim.
+    bit_offset: 2
+    bit_size: 1
+  - name: TX_CAL45DP_OVERRIDE
+    description: Override Enable for USB_DP Series Termination Trim.
+    bit_offset: 3
+    bit_size: 1
+  - name: TX_CAL45DM_OVERRIDE
+    description: Override Enable for USB_DM Series Termination Trim.
+    bit_offset: 4
+    bit_size: 1
+  - name: PLL_CTRL0_DIV_SEL
+    description: PLL Divider Value Configuration Bits from Outside USBPHY.
+    bit_offset: 15
+    bit_size: 3
+  - name: USBPHY_TX_D_CAL
+    description: HS TX Output Current Trim Bits from Outside USBPHY.
+    bit_offset: 20
+    bit_size: 4
+  - name: USBPHY_TX_CAL45DP
+    description: DP Series Termination Resistance Trim Bits from Outside USBPHY.
+    bit_offset: 24
+    bit_size: 4
+  - name: USBPHY_TX_CAL45DN
+    description: DM Series Termination Resistance Trim Bits from Outside USBPHY.
+    bit_offset: 28
+    bit_size: 4
+fieldset/TX:
+  description: TX Control.
+  fields:
+  - name: D_CAL
+    description: HS TX Output Current Trim.
+    bit_offset: 0
+    bit_size: 4
+    enum: D_CAL
+  - name: TXCAL45DN
+    description: DM Series Termination Resistance Trim.
+    bit_offset: 8
+    bit_size: 4
+  - name: TXCAL45DP
+    description: DP Series Termination Resistance Trim.
+    bit_offset: 16
+    bit_size: 4
+fieldset/TX_CLR:
+  description: TX Control.
+  fields:
+  - name: D_CAL
+    description: HS TX Output Current Trim.
+    bit_offset: 0
+    bit_size: 4
+  - name: TXCAL45DN
+    description: DM Series Termination Resistance Trim.
+    bit_offset: 8
+    bit_size: 4
+  - name: TXCAL45DP
+    description: DP Series Termination Resistance Trim.
+    bit_offset: 16
+    bit_size: 4
+fieldset/TX_SET:
+  description: TX Control.
+  fields:
+  - name: D_CAL
+    description: HS TX Output Current Trim.
+    bit_offset: 0
+    bit_size: 4
+  - name: TXCAL45DN
+    description: DM Series Termination Resistance Trim.
+    bit_offset: 8
+    bit_size: 4
+  - name: TXCAL45DP
+    description: DP Series Termination Resistance Trim.
+    bit_offset: 16
+    bit_size: 4
+fieldset/TX_TOG:
+  description: TX Control.
+  fields:
+  - name: D_CAL
+    description: HS TX Output Current Trim.
+    bit_offset: 0
+    bit_size: 4
+  - name: TXCAL45DN
+    description: DM Series Termination Resistance Trim.
+    bit_offset: 8
+    bit_size: 4
+  - name: TXCAL45DP
+    description: DP Series Termination Resistance Trim.
+    bit_offset: 16
+    bit_size: 4
+fieldset/USB1_CHRG_DETECT:
+  description: Charger Detect.
+  fields:
+  - name: DETECT_SEC
+    description: Secondary Detection Function Enable.
+    bit_offset: 1
+    bit_size: 1
+    enum: DETECT_SEC
+  - name: PULLUP_DP
+    description: DP Pullup Resistor Enable Override Control.
+    bit_offset: 2
+    bit_size: 1
+    enum: PULLUP_DP
+  - name: VDM_SRC_ENABLE
+    description: VDM_SRC Function Enable.
+    bit_offset: 4
+    bit_size: 1
+    enum: VDM_SRC_ENABLE
+  - name: CHK_CONTACT
+    description: BC Data Contact Detect Function Enable.
+    bit_offset: 18
+    bit_size: 1
+    enum: CHK_CONTACT
+  - name: CHK_CHRG_B
+    description: BC Charger Detection Function Enable.
+    bit_offset: 19
+    bit_size: 1
+    enum: CHK_CHRG_B
+  - name: EN_B
+    description: Selection of BC v1.2 Function Enable.
+    bit_offset: 20
+    bit_size: 1
+    enum: EN_B
+  - name: DCDSEL
+    description: DCD Selection.
+    bit_offset: 31
+    bit_size: 1
+    enum: DCDSEL
+fieldset/USB1_CHRG_DETECT_CLR:
+  description: Charger Detect.
+  fields:
+  - name: DETECT_SEC
+    description: Secondary Detection Function Enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: PULLUP_DP
+    description: DP Pullup Resistor Enable Override Control.
+    bit_offset: 2
+    bit_size: 1
+  - name: VDM_SRC_ENABLE
+    description: VDM_SRC Function Enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: CHK_CONTACT
+    description: BC Data Contact Detect Function Enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: CHK_CHRG_B
+    description: BC Charger Detection Function Enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: EN_B
+    description: Selection of BC v1.2 Function Enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: DCDSEL
+    description: DCD Selection.
+    bit_offset: 31
+    bit_size: 1
+fieldset/USB1_CHRG_DETECT_SET:
+  description: Charger Detect.
+  fields:
+  - name: DETECT_SEC
+    description: Secondary Detection Function Enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: PULLUP_DP
+    description: DP Pullup Resistor Enable Override Control.
+    bit_offset: 2
+    bit_size: 1
+  - name: VDM_SRC_ENABLE
+    description: VDM_SRC Function Enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: CHK_CONTACT
+    description: BC Data Contact Detect Function Enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: CHK_CHRG_B
+    description: BC Charger Detection Function Enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: EN_B
+    description: Selection of BC v1.2 Function Enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: DCDSEL
+    description: DCD Selection.
+    bit_offset: 31
+    bit_size: 1
+fieldset/USB1_CHRG_DETECT_TOG:
+  description: Charger Detect.
+  fields:
+  - name: DETECT_SEC
+    description: Secondary Detection Function Enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: PULLUP_DP
+    description: DP Pullup Resistor Enable Override Control.
+    bit_offset: 2
+    bit_size: 1
+  - name: VDM_SRC_ENABLE
+    description: VDM_SRC Function Enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: CHK_CONTACT
+    description: BC Data Contact Detect Function Enable.
+    bit_offset: 18
+    bit_size: 1
+  - name: CHK_CHRG_B
+    description: BC Charger Detection Function Enable.
+    bit_offset: 19
+    bit_size: 1
+  - name: EN_B
+    description: Selection of BC v1.2 Function Enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: DCDSEL
+    description: DCD Selection.
+    bit_offset: 31
+    bit_size: 1
+fieldset/USB1_CHRG_DET_STAT:
+  description: Charger Detect Status.
+  fields:
+  - name: PLUG_CONTACT
+    description: Battery Charging Data Contact Detection Phase Output.
+    bit_offset: 0
+    bit_size: 1
+    enum: PLUG_CONTACT
+  - name: CHRG_DETECTED
+    description: Battery Charging Primary Detection Phase Output.
+    bit_offset: 1
+    bit_size: 1
+    enum: CHRG_DETECTED
+  - name: DM_STATE
+    description: DM Voltage.
+    bit_offset: 2
+    bit_size: 1
+    enum: DM_STATE
+  - name: DP_STATE
+    description: DP Voltage.
+    bit_offset: 3
+    bit_size: 1
+    enum: DP_STATE
+  - name: SECDET_DCP
+    description: Battery Charging Secondary Detection Phase Output.
+    bit_offset: 4
+    bit_size: 1
+    enum: SECDET_DCP
+fieldset/USB1_CHRG_DET_STAT_CLR:
+  description: Charger Detect Status.
+  fields:
+  - name: PLUG_CONTACT
+    description: Battery Charging Data Contact Detection Phase Output.
+    bit_offset: 0
+    bit_size: 1
+  - name: CHRG_DETECTED
+    description: Battery Charging Primary Detection Phase Output.
+    bit_offset: 1
+    bit_size: 1
+  - name: DM_STATE
+    description: DM Voltage.
+    bit_offset: 2
+    bit_size: 1
+  - name: DP_STATE
+    description: DP Voltage.
+    bit_offset: 3
+    bit_size: 1
+  - name: SECDET_DCP
+    description: Battery Charging Secondary Detection Phase Output.
+    bit_offset: 4
+    bit_size: 1
+fieldset/USB1_CHRG_DET_STAT_SET:
+  description: Charger Detect Status.
+  fields:
+  - name: PLUG_CONTACT
+    description: Battery Charging Data Contact Detection Phase Output.
+    bit_offset: 0
+    bit_size: 1
+  - name: CHRG_DETECTED
+    description: Battery Charging Primary Detection Phase Output.
+    bit_offset: 1
+    bit_size: 1
+  - name: DM_STATE
+    description: DM Voltage.
+    bit_offset: 2
+    bit_size: 1
+  - name: DP_STATE
+    description: DP Voltage.
+    bit_offset: 3
+    bit_size: 1
+  - name: SECDET_DCP
+    description: Battery Charging Secondary Detection Phase Output.
+    bit_offset: 4
+    bit_size: 1
+fieldset/USB1_CHRG_DET_STAT_TOG:
+  description: Charger Detect Status.
+  fields:
+  - name: PLUG_CONTACT
+    description: Battery Charging Data Contact Detection Phase Output.
+    bit_offset: 0
+    bit_size: 1
+  - name: CHRG_DETECTED
+    description: Battery Charging Primary Detection Phase Output.
+    bit_offset: 1
+    bit_size: 1
+  - name: DM_STATE
+    description: DM Voltage.
+    bit_offset: 2
+    bit_size: 1
+  - name: DP_STATE
+    description: DP Voltage.
+    bit_offset: 3
+    bit_size: 1
+  - name: SECDET_DCP
+    description: Battery Charging Secondary Detection Phase Output.
+    bit_offset: 4
+    bit_size: 1
+fieldset/USB1_VBUS_DETECT:
+  description: VBUS Detect.
+  fields:
+  - name: VBUSVALID_THRESH
+    description: VBUS Comparator Threshold.
+    bit_offset: 0
+    bit_size: 3
+    enum: VBUSVALID_THRESH
+  - name: VBUS_OVERRIDE_EN
+    description: VBUS Detect Signal Local Override Enable.
+    bit_offset: 3
+    bit_size: 1
+    enum: VBUS_OVERRIDE_EN
+  - name: SESSEND_OVERRIDE
+    description: Override Value for SESSEND.
+    bit_offset: 4
+    bit_size: 1
+  - name: BVALID_OVERRIDE
+    description: Override Value for B-Device Session Valid.
+    bit_offset: 5
+    bit_size: 1
+  - name: AVALID_OVERRIDE
+    description: Override Value for A-Device Session Valid.
+    bit_offset: 6
+    bit_size: 1
+  - name: VBUSVALID_OVERRIDE
+    description: Override Value for the VBUS_VALID Signal.
+    bit_offset: 7
+    bit_size: 1
+  - name: VBUSVALID_SEL
+    description: VBUS_VALID Selection.
+    bit_offset: 8
+    bit_size: 1
+    enum: VBUSVALID_SEL
+  - name: VBUS_SOURCE_SEL
+    description: VBUS_VALID Source Selection.
+    bit_offset: 9
+    bit_size: 2
+    enum: VBUS_SOURCE_SEL
+  - name: ID_OVERRIDE_EN
+    description: Enable Local ID Pin Status Override.
+    bit_offset: 11
+    bit_size: 1
+    enum: ID_OVERRIDE_EN
+  - name: ID_OVERRIDE
+    description: ID Pin Status Local Override.
+    bit_offset: 12
+    bit_size: 1
+  - name: EXT_ID_OVERRIDE_EN
+    description: External ID Override Enable.
+    bit_offset: 13
+    bit_size: 1
+    enum: EXT_ID_OVERRIDE_EN
+  - name: EXT_VBUS_OVERRIDE_EN
+    description: External VBUS Override Enable.
+    bit_offset: 14
+    bit_size: 1
+    enum: EXT_VBUS_OVERRIDE_EN
+  - name: VBUSVALID_TO_B
+    description: VBUS_VALID Comparator Selection.
+    bit_offset: 18
+    bit_size: 1
+    enum: VBUSVALID_TO_B
+  - name: VBUSVALID_PWRUP_CMPS
+    description: VBUS_VALID Comparator Enable.
+    bit_offset: 20
+    bit_size: 3
+    enum: VBUSVALID_PWRUP_CMPS
+  - name: DISCHARGE_VBUS
+    description: VBUS Discharge Resistor.
+    bit_offset: 26
+    bit_size: 1
+    enum: DISCHARGE_VBUS
+fieldset/USB1_VBUS_DETECT_CLR:
+  description: VBUS Detect.
+  fields:
+  - name: VBUSVALID_THRESH
+    description: VBUS Comparator Threshold.
+    bit_offset: 0
+    bit_size: 3
+  - name: VBUS_OVERRIDE_EN
+    description: VBUS Detect Signal Local Override Enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: SESSEND_OVERRIDE
+    description: Override Value for SESSEND.
+    bit_offset: 4
+    bit_size: 1
+  - name: BVALID_OVERRIDE
+    description: Override Value for B-Device Session Valid.
+    bit_offset: 5
+    bit_size: 1
+  - name: AVALID_OVERRIDE
+    description: Override Value for A-Device Session Valid.
+    bit_offset: 6
+    bit_size: 1
+  - name: VBUSVALID_OVERRIDE
+    description: Override Value for the VBUS_VALID Signal.
+    bit_offset: 7
+    bit_size: 1
+  - name: VBUSVALID_SEL
+    description: VBUS_VALID Selection.
+    bit_offset: 8
+    bit_size: 1
+  - name: VBUS_SOURCE_SEL
+    description: VBUS_VALID Source Selection.
+    bit_offset: 9
+    bit_size: 2
+  - name: ID_OVERRIDE_EN
+    description: Enable Local ID Pin Status Override.
+    bit_offset: 11
+    bit_size: 1
+  - name: ID_OVERRIDE
+    description: ID Pin Status Local Override.
+    bit_offset: 12
+    bit_size: 1
+  - name: EXT_ID_OVERRIDE_EN
+    description: External ID Override Enable.
+    bit_offset: 13
+    bit_size: 1
+  - name: EXT_VBUS_OVERRIDE_EN
+    description: External VBUS Override Enable.
+    bit_offset: 14
+    bit_size: 1
+  - name: VBUSVALID_TO_B
+    description: VBUS_VALID Comparator Selection.
+    bit_offset: 18
+    bit_size: 1
+  - name: VBUSVALID_PWRUP_CMPS
+    description: VBUS_VALID Comparator Enable.
+    bit_offset: 20
+    bit_size: 3
+  - name: DISCHARGE_VBUS
+    description: VBUS Discharge Resistor.
+    bit_offset: 26
+    bit_size: 1
+fieldset/USB1_VBUS_DETECT_SET:
+  description: VBUS Detect.
+  fields:
+  - name: VBUSVALID_THRESH
+    description: VBUS Comparator Threshold.
+    bit_offset: 0
+    bit_size: 3
+  - name: VBUS_OVERRIDE_EN
+    description: VBUS Detect Signal Local Override Enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: SESSEND_OVERRIDE
+    description: Override Value for SESSEND.
+    bit_offset: 4
+    bit_size: 1
+  - name: BVALID_OVERRIDE
+    description: Override Value for B-Device Session Valid.
+    bit_offset: 5
+    bit_size: 1
+  - name: AVALID_OVERRIDE
+    description: Override Value for A-Device Session Valid.
+    bit_offset: 6
+    bit_size: 1
+  - name: VBUSVALID_OVERRIDE
+    description: Override Value for the VBUS_VALID Signal.
+    bit_offset: 7
+    bit_size: 1
+  - name: VBUSVALID_SEL
+    description: VBUS_VALID Selection.
+    bit_offset: 8
+    bit_size: 1
+  - name: VBUS_SOURCE_SEL
+    description: VBUS_VALID Source Selection.
+    bit_offset: 9
+    bit_size: 2
+  - name: ID_OVERRIDE_EN
+    description: Enable Local ID Pin Status Override.
+    bit_offset: 11
+    bit_size: 1
+  - name: ID_OVERRIDE
+    description: ID Pin Status Local Override.
+    bit_offset: 12
+    bit_size: 1
+  - name: EXT_ID_OVERRIDE_EN
+    description: External ID Override Enable.
+    bit_offset: 13
+    bit_size: 1
+  - name: EXT_VBUS_OVERRIDE_EN
+    description: External VBUS Override Enable.
+    bit_offset: 14
+    bit_size: 1
+  - name: VBUSVALID_TO_B
+    description: VBUS_VALID Comparator Selection.
+    bit_offset: 18
+    bit_size: 1
+  - name: VBUSVALID_PWRUP_CMPS
+    description: VBUS_VALID Comparator Enable.
+    bit_offset: 20
+    bit_size: 3
+  - name: DISCHARGE_VBUS
+    description: VBUS Discharge Resistor.
+    bit_offset: 26
+    bit_size: 1
+fieldset/USB1_VBUS_DETECT_TOG:
+  description: VBUS Detect.
+  fields:
+  - name: VBUSVALID_THRESH
+    description: VBUS Comparator Threshold.
+    bit_offset: 0
+    bit_size: 3
+  - name: VBUS_OVERRIDE_EN
+    description: VBUS Detect Signal Local Override Enable.
+    bit_offset: 3
+    bit_size: 1
+  - name: SESSEND_OVERRIDE
+    description: Override Value for SESSEND.
+    bit_offset: 4
+    bit_size: 1
+  - name: BVALID_OVERRIDE
+    description: Override Value for B-Device Session Valid.
+    bit_offset: 5
+    bit_size: 1
+  - name: AVALID_OVERRIDE
+    description: Override Value for A-Device Session Valid.
+    bit_offset: 6
+    bit_size: 1
+  - name: VBUSVALID_OVERRIDE
+    description: Override Value for the VBUS_VALID Signal.
+    bit_offset: 7
+    bit_size: 1
+  - name: VBUSVALID_SEL
+    description: VBUS_VALID Selection.
+    bit_offset: 8
+    bit_size: 1
+  - name: VBUS_SOURCE_SEL
+    description: VBUS_VALID Source Selection.
+    bit_offset: 9
+    bit_size: 2
+  - name: ID_OVERRIDE_EN
+    description: Enable Local ID Pin Status Override.
+    bit_offset: 11
+    bit_size: 1
+  - name: ID_OVERRIDE
+    description: ID Pin Status Local Override.
+    bit_offset: 12
+    bit_size: 1
+  - name: EXT_ID_OVERRIDE_EN
+    description: External ID Override Enable.
+    bit_offset: 13
+    bit_size: 1
+  - name: EXT_VBUS_OVERRIDE_EN
+    description: External VBUS Override Enable.
+    bit_offset: 14
+    bit_size: 1
+  - name: VBUSVALID_TO_B
+    description: VBUS_VALID Comparator Selection.
+    bit_offset: 18
+    bit_size: 1
+  - name: VBUSVALID_PWRUP_CMPS
+    description: VBUS_VALID Comparator Enable.
+    bit_offset: 20
+    bit_size: 3
+  - name: DISCHARGE_VBUS
+    description: VBUS Discharge Resistor.
+    bit_offset: 26
+    bit_size: 1
+fieldset/USB1_VBUS_DET_STAT:
+  description: VBUS Detect Status.
+  fields:
+  - name: SESSEND
+    description: Session End Indicator.
+    bit_offset: 0
+    bit_size: 1
+    enum: SESSEND
+  - name: BVALID
+    description: B-Device Session Valid Status.
+    bit_offset: 1
+    bit_size: 1
+    enum: BVALID
+  - name: AVALID
+    description: A-Device Session Valid Status.
+    bit_offset: 2
+    bit_size: 1
+    enum: AVALID
+  - name: VBUS_VALID
+    description: VBUS Voltage Status.
+    bit_offset: 3
+    bit_size: 1
+    enum: VBUS_VALID
+  - name: VBUS_VALID_3V
+    description: VBUS_VALID_3V Detector Status.
+    bit_offset: 4
+    bit_size: 1
+    enum: VBUS_VALID_3V
+  - name: EXT_ID
+    description: OTG ID External Override Status.
+    bit_offset: 5
+    bit_size: 1
+fieldset/USB1_VBUS_DET_STAT_CLR:
+  description: VBUS Detect Status.
+  fields:
+  - name: SESSEND
+    description: Session End Indicator.
+    bit_offset: 0
+    bit_size: 1
+  - name: BVALID
+    description: B-Device Session Valid Status.
+    bit_offset: 1
+    bit_size: 1
+  - name: AVALID
+    description: A-Device Session Valid Status.
+    bit_offset: 2
+    bit_size: 1
+  - name: VBUS_VALID
+    description: VBUS Voltage Status.
+    bit_offset: 3
+    bit_size: 1
+  - name: VBUS_VALID_3V
+    description: VBUS_VALID_3V Detector Status.
+    bit_offset: 4
+    bit_size: 1
+  - name: EXT_ID
+    description: OTG ID External Override Status.
+    bit_offset: 5
+    bit_size: 1
+fieldset/USB1_VBUS_DET_STAT_SET:
+  description: VBUS Detect Status.
+  fields:
+  - name: SESSEND
+    description: Session End Indicator.
+    bit_offset: 0
+    bit_size: 1
+  - name: BVALID
+    description: B-Device Session Valid Status.
+    bit_offset: 1
+    bit_size: 1
+  - name: AVALID
+    description: A-Device Session Valid Status.
+    bit_offset: 2
+    bit_size: 1
+  - name: VBUS_VALID
+    description: VBUS Voltage Status.
+    bit_offset: 3
+    bit_size: 1
+  - name: VBUS_VALID_3V
+    description: VBUS_VALID_3V Detector Status.
+    bit_offset: 4
+    bit_size: 1
+  - name: EXT_ID
+    description: OTG ID External Override Status.
+    bit_offset: 5
+    bit_size: 1
+fieldset/USB1_VBUS_DET_STAT_TOG:
+  description: VBUS Detect Status.
+  fields:
+  - name: SESSEND
+    description: Session End Indicator.
+    bit_offset: 0
+    bit_size: 1
+  - name: BVALID
+    description: B-Device Session Valid Status.
+    bit_offset: 1
+    bit_size: 1
+  - name: AVALID
+    description: A-Device Session Valid Status.
+    bit_offset: 2
+    bit_size: 1
+  - name: VBUS_VALID
+    description: VBUS Voltage Status.
+    bit_offset: 3
+    bit_size: 1
+  - name: VBUS_VALID_3V
+    description: VBUS_VALID_3V Detector Status.
+    bit_offset: 4
+    bit_size: 1
+  - name: EXT_ID
+    description: OTG ID External Override Status.
+    bit_offset: 5
+    bit_size: 1
+fieldset/VERSION:
+  description: Version.
+  fields:
+  - name: STEP
+    description: Step.
+    bit_offset: 0
+    bit_size: 16
+  - name: MINOR
+    description: Minor.
+    bit_offset: 16
+    bit_size: 8
+  - name: MAJOR
+    description: Major.
+    bit_offset: 24
+    bit_size: 8
+enum/AUTORESUME_EN:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/AVALID:
+  bit_size: 1
+  variants:
+  - name: AVALID_LO
+    description: Below threshold.
+    value: 0
+  - name: AVALID_HI
+    description: Above threshold.
+    value: 1
+enum/BVALID:
+  bit_size: 1
+  variants:
+  - name: BVALID_LO
+    description: Below threshold.
+    value: 0
+  - name: BVALID_HI
+    description: Above threshold.
+    value: 1
+enum/CHK_CHRG_B:
+  bit_size: 1
+  variants:
+  - name: BC_CHRGDET_ENABLE
+    description: Enable.
+    value: 0
+  - name: BC_CHRGDET_DISABLE
+    description: Disable.
+    value: 1
+enum/CHK_CONTACT:
+  bit_size: 1
+  variants:
+  - name: BC_DCD_DISABLE
+    description: Disable.
+    value: 0
+  - name: BC_DCD_ENABLE
+    description: Enable.
+    value: 1
+enum/CHRG_DETECTED:
+  bit_size: 1
+  variants:
+  - name: SDP_DETECT
+    description: SDP detected.
+    value: 0
+  - name: CHRG_PORT_DETECT
+    description: Charging port detected.
+    value: 1
+enum/CLKGATE:
+  bit_size: 1
+  variants:
+  - name: RUN_CLOCKS
+    description: Run clocks.
+    value: 0
+  - name: GATE_CLOCKS
+    description: Gate clocks.
+    value: 1
+enum/DCDSEL:
+  bit_size: 1
+  variants:
+  - name: CHRGDET_CTRL
+    description: Fields in USB1_CHRG_DETECT.
+    value: 0
+  - name: USBHSDCD_CTRL
+    description: Fields and state machines in the USBHSDCD module.
+    value: 1
+enum/DETECT_SEC:
+  bit_size: 1
+  variants:
+  - name: BC_SECDET_DISABLE
+    description: Disable.
+    value: 0
+  - name: BC_SECDET_ENABLE
+    description: Enable.
+    value: 1
+enum/DEVPLUGIN_POLARITY:
+  bit_size: 1
+  variants:
+  - name: PLUGGED_IN
+    description: Plugged in.
+    value: 0
+  - name: UNPLUGGED
+    description: Unplugged.
+    value: 1
+enum/DEVPLUGIN_STATUS:
+  bit_size: 1
+  variants:
+  - name: NO_CABLE
+    description: No attachment detected.
+    value: 0
+  - name: CABLE_ATTACH
+    description: Cable attachment detected.
+    value: 1
+enum/DEV_PULLDOWN:
+  bit_size: 1
+  variants:
+  - name: DEV_PULLDOWN_DIS
+    description: Disable.
+    value: 0
+  - name: DEV_PULLDOWN_EN
+    description: Enable.
+    value: 1
+enum/DISCHARGE_VBUS:
+  bit_size: 1
+  variants:
+  - name: VBUS_DCHG_OFF
+    description: Disable.
+    value: 0
+  - name: VBUS_DCHG_ON
+    description: Enable.
+    value: 1
+enum/DISCONADJ:
+  bit_size: 3
+  variants:
+  - name: DISCON_TRIM_NOM
+    description: 0.56875 V.
+    value: 0
+  - name: DISCON_TRIM_LO
+    description: 0.55000 V.
+    value: 1
+  - name: DISCON_TRIM_MEDHI
+    description: 0.58125 V.
+    value: 2
+  - name: DISCON_TRIM_HI
+    description: 0.60000 V.
+    value: 3
+enum/DIV_SEL_OVERRIDE:
+  bit_size: 1
+  variants:
+  - name: USE_TRIM0_PLLDIV
+    description: TRIM_OVERRIDE_EN.
+    value: 0
+  - name: USE_PLL_SIC_PLLDIV
+    description: PLL_SIC.
+    value: 1
+enum/DM_STATE:
+  bit_size: 1
+  variants:
+  - name: DM_SERX_LO
+    description: USB_DM pin voltage is <= 0.8 V.
+    value: 0
+  - name: DM_SERX_HI
+    description: USB_DM pin voltage is >= 2.0 V.
+    value: 1
+enum/DP_STATE:
+  bit_size: 1
+  variants:
+  - name: DP_SERX_LO
+    description: USB_DP pin voltage is <= 0.8 V.
+    value: 0
+  - name: DP_SERX_HI
+    description: USB_DP pin voltage is >= 2.0 V.
+    value: 1
+enum/D_CAL:
+  bit_size: 4
+  variants:
+  - name: MAX_CURRENT
+    description: Maximum current, approximately 19% above nominal.
+    value: 0
+  - name: NOMINAL
+    description: Nominal.
+    value: 7
+  - name: MIN_CURRENT
+    description: Minimum current, approximately 19% below nominal.
+    value: 15
+enum/ENAUTOCLR_CLKGATE:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENAUTOCLR_PHY_PWD:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENDEVPLUGINDETECT:
+  bit_size: 1
+  variants:
+  - name: PLUGIN_DISABLE
+    description: Disable.
+    value: 0
+  - name: PLUGIN_ENABLE
+    description: Enable.
+    value: 1
+enum/ENHOSTDISCONDETECT:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENHSTPULLDOWN:
+  bit_size: 2
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENIRQDEVPLUGIN:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENIRQHOSTDISCON:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENIRQRESUMEDETECT:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENIRQWAKEUP:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENOTGIDDETECT:
+  bit_size: 1
+  variants:
+  - name: ID_DET_DISABLE
+    description: Disable.
+    value: 0
+  - name: ID_DET_ENABLE
+    description: Enable.
+    value: 1
+enum/ENOTG_ID_CHG_IRQ:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENUTMILEVEL2:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENUTMILEVEL3:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: Disable.
+    value: 0
+  - name: ENABLE
+    description: Enable.
+    value: 1
+enum/ENVADJ:
+  bit_size: 3
+  variants:
+  - name: ENV_TRIM_NOM
+    description: 0.1000 V.
+    value: 0
+  - name: ENV_TRIM_MEDHI
+    description: 0.1125 V.
+    value: 1
+  - name: ENV_TRIM_HI
+    description: 0.1250 V.
+    value: 2
+  - name: ENV_TRIM_LO
+    description: 0.0875 V.
+    value: 3
+enum/EN_B:
+  bit_size: 1
+  variants:
+  - name: BC_ENABLE
+    description: Enable.
+    value: 0
+  - name: BC_DISABLE
+    description: Disable.
+    value: 1
+enum/EXT_ID_OVERRIDE_EN:
+  bit_size: 1
+  variants:
+  - name: USE_PHY_ID
+    description: Internal detector or local override.
+    value: 0
+  - name: USE_EXT_ID
+    description: External ID signal value.
+    value: 1
+enum/EXT_VBUS_OVERRIDE_EN:
+  bit_size: 1
+  variants:
+  - name: USE_PHY_VBUS
+    description: Internal detector or local override.
+    value: 0
+  - name: USB_EXT_VBUS
+    description: External VBUS_VALID value.
+    value: 1
+enum/HOSTDISCONDETECT_IRQ:
+  bit_size: 1
+  variants:
+  - name: CONNECTED
+    description: Connected.
+    value: 0
+  - name: DISCONNECTED
+    description: Disconnected.
+    value: 1
+enum/HOSTDISCONDETECT_STATUS:
+  bit_size: 1
+  variants:
+  - name: NO_DISCONNECT
+    description: Not detected.
+    value: 0
+  - name: DISCONNECT
+    description: Detected.
+    value: 1
+enum/HSTPULLDOWN:
+  bit_size: 2
+  variants:
+  - name: DISCONNECT
+    description: Disconnect.
+    value: 0
+  - name: CONNECT
+    description: Connect.
+    value: 1
+enum/ID_OVERRIDE_EN:
+  bit_size: 1
+  variants:
+  - name: NO_PHY_ID_OVERRIDE
+    description: Use ID pin detector or external override.
+    value: 0
+  - name: USE_PHY_ID_OVERRIDE
+    description: Allow local override of ID pin detection status.
+    value: 1
+enum/LVI_EN:
+  bit_size: 1
+  variants:
+  - name: LVI_3V_DISABLE
+    description: Disable.
+    value: 0
+  - name: LVI_3V_ENABLE
+    description: Enable.
+    value: 1
+enum/MISC2_CONTROL0:
+  bit_size: 1
+  variants:
+  - name: PLL_ON_SUSPEND
+    description: Power up PLL.
+    value: 0
+  - name: PLL_OFF_SUSPEND
+    description: Power down PLL.
+    value: 1
+enum/OK_STATUS_3V:
+  bit_size: 1
+  variants:
+  - name: POWER_3_1P8_OK
+    description: Not powered.
+    value: 0
+  - name: POWER_3_1P8_BAD
+    description: Powered.
+    value: 1
+enum/OTGID_STATUS:
+  bit_size: 1
+  variants:
+  - name: ID_HOST
+    description: Host.
+    value: 0
+  - name: ID_DEVICE
+    description: Device.
+    value: 1
+enum/OTG_ID_CHG_IRQ:
+  bit_size: 1
+  variants:
+  - name: No_ID_CHG_IRQ
+    description: No ID change interrupt.
+    value: 0
+  - name: ID_CHG_IRQ
+    description: ID change interrupt.
+    value: 1
+enum/OTG_ID_VALUE:
+  bit_size: 1
+  variants:
+  - name: ID_HOST
+    description: Host.
+    value: 0
+  - name: ID_DEVICE
+    description: Device.
+    value: 1
+enum/PFD0_CLKGATE:
+  bit_size: 1
+  variants:
+  - name: PFD0_CLK_EN
+    description: Enable.
+    value: 0
+  - name: PFD0_CLK_DIS
+    description: Disable.
+    value: 1
+enum/PFD0_STABLE:
+  bit_size: 1
+  variants:
+  - name: NOT_STABLE
+    description: Not stable.
+    value: 0
+  - name: STABLE
+    description: Stable.
+    value: 1
+enum/PFD_CLK_SEL:
+  bit_size: 2
+  variants:
+  - name: PFD_CLK_BYPASS
+    description: USB1PFDCLK = USB PLL reference clock.
+    value: 0
+  - name: PFD_CLK_DIV_4
+    description: USB1PFDCLK = pfd_clk / 4.
+    value: 1
+  - name: PFD_CLK_DIV_2
+    description: USB1PFDCLK frequency = pfd_clk / 2.
+    value: 2
+  - name: PFD_CLK_DIV_1
+    description: USB1PFDCLK = pfd_clk.
+    value: 3
+enum/PLL_BYPASS:
+  bit_size: 1
+  variants:
+  - name: PLL_NO_BYPASS
+    description: 480 MHz output clock.
+    value: 0
+  - name: PLL_BYPASS
+    description: Input reference clock.
+    value: 1
+enum/PLL_DIV_SEL:
+  bit_size: 3
+  variants:
+  - name: PLL_DIV_15
+    description: Configure for a 32 MHz input clock (divide by 15).
+    value: 0
+  - name: PLL_DIV_16
+    description: Configure for a 30 MHz input clock (divide by 16).
+    value: 1
+  - name: PLL_DIV_20
+    description: Configure for a 24 MHz input clock (divide by 20).
+    value: 2
+  - name: PLL_DIV_24
+    description: Configure for a 20 MHz input clock (divide by 24).
+    value: 4
+  - name: PLL_DIV_25
+    description: Configure for a 19.2 MHz input clock (divide by 25).
+    value: 5
+  - name: PLL_DIV_30
+    description: Configure for a 16 MHz input clock (divide by 30).
+    value: 6
+  - name: PLL_DIV_32
+    description: Configure for a 12 MHz input clock (divide by 40).
+    value: 7
+enum/PLL_ENABLE:
+  bit_size: 1
+  variants:
+  - name: PLL_OUT_DISABLE
+    description: Disable.
+    value: 0
+  - name: PLL_OUT_ENABLE
+    description: Enable.
+    value: 1
+enum/PLL_EN_USB_CLKS:
+  bit_size: 1
+  variants:
+  - name: PLL_MP_DISABLE
+    description: Disable.
+    value: 0
+  - name: PLL_MP_ENABLE
+    description: Enable.
+    value: 1
+enum/PLL_LOCK:
+  bit_size: 1
+  variants:
+  - name: PLL_NOT_LOCKED
+    description: Not locked.
+    value: 0
+  - name: PLL_LOCKED
+    description: Locked.
+    value: 1
+enum/PLL_POWER:
+  bit_size: 1
+  variants:
+  - name: PLL_FORCE_PWD
+    description: Power down.
+    value: 0
+  - name: PLL_ALLOW_POWERUP
+    description: Allow powerup.
+    value: 1
+enum/PLL_PREDIV:
+  bit_size: 1
+  variants:
+  - name: PREDIV_1
+    description: Uses the undivided reference clock for PLL loop.
+    value: 0
+  - name: PREDIV_2
+    description: Divides the reference clock by two for PLL loop.
+    value: 1
+enum/PLL_REG_ENABLE:
+  bit_size: 1
+  variants:
+  - name: PLL_REG_DISABLE
+    description: Disable.
+    value: 0
+  - name: PLL_REG_ENABLE
+    description: Enable.
+    value: 1
+enum/PLUG_CONTACT:
+  bit_size: 1
+  variants:
+  - name: NO_DC_DETECTED
+    description: Not detected.
+    value: 0
+  - name: DC_DETECED
+    description: Detected.
+    value: 1
+enum/PULLUP_DP:
+  bit_size: 1
+  variants:
+  - name: DP_PUE_NORMAL
+    description: Disable.
+    value: 0
+  - name: DP_PUE_OVERRIDE
+    description: Enable.
+    value: 1
+enum/REFBIAS_PWD:
+  bit_size: 1
+  variants:
+  - name: REFBIAS_ENABLED
+    description: Enable.
+    value: 0
+  - name: REFBIAS_PWD
+    description: Disable or power down.
+    value: 1
+enum/REFBIAS_PWD_SEL:
+  bit_size: 1
+  variants:
+  - name: BIAS_PLLPOWER
+    description: PLL_POWER internal state signal.
+    value: 0
+  - name: BIAS_REFBIAS_PWD
+    description: REFBIAS_PWD.
+    value: 1
+enum/RESUMEIRQSTICKY:
+  bit_size: 1
+  variants:
+  - name: DISABLE
+    description: During the resume or reset state signaling period.
+    value: 0
+  - name: ENABLE
+    description: Until you write 0 to it.
+    value: 1
+enum/RESUME_IRQ:
+  bit_size: 1
+  variants:
+  - name: NORESIRQ
+    description: No resume interrupt.
+    value: 0
+  - name: RESIRQ
+    description: Resume interrupt.
+    value: 1
+enum/RXPWD1PT1:
+  bit_size: 1
+  variants:
+  - name: FS_RXDIFF_ENABLE
+    description: Enable.
+    value: 0
+  - name: FS_RXDIFF_PWD
+    description: Disable or power down.
+    value: 1
+enum/RXPWDDIFF:
+  bit_size: 1
+  variants:
+  - name: HS_RXDIFF_ENABLE
+    description: Enable.
+    value: 0
+  - name: HS_RXDIFF_PWD
+    description: Disable or power down.
+    value: 1
+enum/RXPWDENV:
+  bit_size: 1
+  variants:
+  - name: RX_ENVHD_ENABLE
+    description: Enable.
+    value: 0
+  - name: RX_ENVHD_PWD
+    description: Disable or power down.
+    value: 1
+enum/RXPWDRX:
+  bit_size: 1
+  variants:
+  - name: RX_BIAS_ENABLE
+    description: Enable.
+    value: 0
+  - name: RX_BIAS_PWD
+    description: Disable or power down.
+    value: 1
+enum/SECDET_DCP:
+  bit_size: 1
+  variants:
+  - name: SECDET_CDP
+    description: CDP detected.
+    value: 0
+  - name: SECDET_DCP
+    description: DCP detected.
+    value: 1
+enum/SESSEND:
+  bit_size: 1
+  variants:
+  - name: SESSEND_LO
+    description: Above threshold.
+    value: 0
+  - name: SESSEND_HI
+    description: Below threshold.
+    value: 1
+enum/SFTRST:
+  bit_size: 1
+  variants:
+  - name: RELEASE_RESET
+    description: Release from reset.
+    value: 0
+  - name: SOFT_RESET
+    description: Soft-reset.
+    value: 1
+enum/TXPWDFS:
+  bit_size: 1
+  variants:
+  - name: FSTX_BIAS_ENABLE
+    description: Provide bias to enable.
+    value: 0
+  - name: FSTX_BIAS_PWD
+    description: Disable or power down.
+    value: 1
+enum/TXPWDIBIAS:
+  bit_size: 1
+  variants:
+  - name: IBIAS_ENABLE
+    description: Enable.
+    value: 0
+  - name: IBIAS_PWD
+    description: Disable or power down.
+    value: 1
+enum/TXPWDV2I:
+  bit_size: 1
+  variants:
+  - name: V2I_BIAS_ENABLE
+    description: Enable.
+    value: 0
+  - name: V2I_BIAS_PWD
+    description: Disable or power down.
+    value: 1
+enum/TX_CAL45DM_OVERRIDE:
+  bit_size: 1
+  variants:
+  - name: USE_TRIM0_CAL45DN
+    description: TRIM_OVERRIDE_EN.
+    value: 0
+  - name: USE_TX_CAL45DN
+    description: TX.
+    value: 1
+enum/TX_CAL45DP_OVERRIDE:
+  bit_size: 1
+  variants:
+  - name: USE_TRIM0_CAL45DP
+    description: TRIM_OVERRIDE_EN.
+    value: 0
+  - name: USE_TX_CAL45DP
+    description: TX.
+    value: 1
+enum/TX_D_CAL_OVERRIDE:
+  bit_size: 1
+  variants:
+  - name: USE_TRIM0_DCAL
+    description: TRIM_OVERRIDE_EN.
+    value: 0
+  - name: USE_TX_DCAL
+    description: TX.
+    value: 1
+enum/USBPHY_TX_D_CAL:
+  bit_size: 4
+  variants:
+  - name: MAX_CURRENT
+    description: Maximum current, approximately 19% above nominal.
+    value: 0
+  - name: NOMINAL
+    description: Nominal.
+    value: 7
+  - name: MIN_CURRENT
+    description: Minimum current, approximately 19% below nominal.
+    value: 15
+enum/UTMI_SUSPENDM:
+  bit_size: 1
+  variants:
+  - name: NOT_SUSPENDED
+    description: Not suspended.
+    value: 0
+  - name: SUSPENDED
+    description: Suspended.
+    value: 1
+enum/VBUSVALID_PWRUP_CMPS:
+  bit_size: 3
+  variants:
+  - name: SESS_VLD_DISABLE
+    description: Disable or power down the session valid detector.
+    value: 0
+  - name: V3V_DISABLE
+    description: Disable or power down the VBUS_VALID_3V detector.
+    value: 0
+  - name: VBUS_VALID_DISABLE
+    description: Disable or power down the VBUS_VALID comparator.
+    value: 0
+  - name: VBUS_VALID_ENABLE
+    description: Enable the VBUS_VALID comparator.
+    value: 1
+  - name: SESS_VLD_ENABLE
+    description: Enable the session valid detector.
+    value: 2
+  - name: V3V_ENABLE
+    description: Enable the VBUS_VALID_3V detector.
+    value: 4
+enum/VBUSVALID_SEL:
+  bit_size: 1
+  variants:
+  - name: VBUS_VLD_OUT
+    description: VBUS_VALID comparator result.
+    value: 0
+  - name: VBUS_VLD_3V_OUT
+    description: VBUS_VALID_3V comparator result.
+    value: 1
+enum/VBUSVALID_THRESH:
+  bit_size: 3
+  variants:
+  - name: VBUS_VLD_4P0
+    description: 4.0 V.
+    value: 0
+  - name: VBUS_VLD_4P1
+    description: 4.1 V.
+    value: 1
+  - name: VBUS_VLD_4P2
+    description: 4.2 V.
+    value: 2
+  - name: VBUS_VLD_4P3
+    description: 4.3 V.
+    value: 3
+  - name: VBUS_VLD_4P4
+    description: 4.4 V.
+    value: 4
+  - name: VBUS_VLD_4P5
+    description: 4.5 V.
+    value: 5
+  - name: VBUS_VLD_4P6
+    description: 4.6 V.
+    value: 6
+  - name: VBUS_VLD_4P7
+    description: 4.7 V.
+    value: 7
+enum/VBUSVALID_TO_B:
+  bit_size: 1
+  variants:
+  - name: USE_VBUS_VLD
+    description: VBUS_VALID comparator.
+    value: 0
+  - name: USE_SESS_VLD
+    description: Session valid detector.
+    value: 1
+enum/VBUS_OVERRIDE_EN:
+  bit_size: 1
+  variants:
+  - name: VBUS_NO_OVERRIDE
+    description: Results of VBUS_VALID and session valid comparators for VBUS_VALID, AVALID, BVALID, and SESSEND.
+    value: 0
+  - name: VBUS_OVERRIDE
+    description: Override values for VBUS_VALID, AVALID, BVALID, and SESSEND.
+    value: 1
+enum/VBUS_SOURCE_SEL:
+  bit_size: 2
+  variants:
+  - name: USE_VBUS_VLD
+    description: VBUS_VALID comparator result.
+    value: 0
+  - name: USE_ASESS_VLD
+    description: Session valid comparator result.
+    value: 1
+  - name: USE_BSESS_VLD
+    description: Session valid comparator result.
+    value: 2
+enum/VBUS_VALID:
+  bit_size: 1
+  variants:
+  - name: VBUS_LO
+    description: Below threshold.
+    value: 0
+  - name: VBUS_HI
+    description: Above threshold.
+    value: 1
+enum/VBUS_VALID_3V:
+  bit_size: 1
+  variants:
+  - name: VBUS_VLD3V_LO
+    description: Below threshold.
+    value: 0
+  - name: VBUS_VLD3V_HI
+    description: Above threshold.
+    value: 1
+enum/VDM_SRC_ENABLE:
+  bit_size: 1
+  variants:
+  - name: DCD_VDM_SRC_DISABLE
+    description: Disable.
+    value: 0
+  - name: DCD_VDM_SRC_ENABLE
+    description: Enable.
+    value: 1

--- a/nxp-pac/src/chips/mcxa577/metadata.rs
+++ b/nxp-pac/src/chips/mcxa577/metadata.rs
@@ -12245,8 +12245,8 @@ pub const PERIPHERALS: &[Peripheral] = &[
     },
     Peripheral {
         name: "USB1",
-        address: 0,
-        driver_name: "",
+        address: 0x4002E000,
+        driver_name: "mcxa/USBHS",
         signals: &[
             Signal {
                 name: "OTGn_ID",
@@ -12297,9 +12297,18 @@ pub const PERIPHERALS: &[Peripheral] = &[
         gate: None,
     },
     Peripheral {
+        name: "USBNC",
+        address: 0x4002E200,
+        driver_name: "mcxa/USBNC",
+        signals: &[],
+        flexcomm: None,
+        dma_muxing: &[],
+        gate: None,
+    },
+    Peripheral {
         name: "USB1_HS_PHY",
-        address: 0,
-        driver_name: "",
+        address: 0x4002F000,
+        driver_name: "mcxa/USBPHY",
         signals: &[],
         flexcomm: None,
         dma_muxing: &[],

--- a/nxp-pac/src/chips/mcxa577/mod.rs
+++ b/nxp-pac/src/chips/mcxa577/mod.rs
@@ -282,6 +282,9 @@ pub const SGI0: sgi::Sgi = unsafe { sgi::Sgi::from_ptr(0x400EB000 as _) };
 pub const SPC0: spc::Spc = unsafe { spc::Spc::from_ptr(0x400CB000 as _) };
 pub const SYSCON: syscon::Syscon = unsafe { syscon::Syscon::from_ptr(0x40091000 as _) };
 pub const TRNG0: trng::Trng = unsafe { trng::Trng::from_ptr(0x400EC000 as _) };
+pub const USB1: usbhs::Usbhs = unsafe { usbhs::Usbhs::from_ptr(0x4002E000 as _) };
+pub const USBNC: usbnc::Usbnc = unsafe { usbnc::Usbnc::from_ptr(0x4002E200 as _) };
+pub const USB1_HS_PHY: usbphy::Usbphy = unsafe { usbphy::Usbphy::from_ptr(0x4002F000 as _) };
 pub const VBAT0: vbat::Vbat = unsafe { vbat::Vbat::from_ptr(0x40093000 as _) };
 pub const WWDT0: wwdt::Wwdt = unsafe { wwdt::Wwdt::from_ptr(0x4000C000 as _) };
 pub const WWDT1: wwdt::Wwdt = unsafe { wwdt::Wwdt::from_ptr(0x4000D000 as _) };
@@ -343,6 +346,12 @@ pub mod spc;
 pub mod syscon;
 #[path = "../../meta_peripherals/mcxa/TRNG.rs"]
 pub mod trng;
+#[path = "../../meta_peripherals/mcxa/USBHS.rs"]
+pub mod usbhs;
+#[path = "../../meta_peripherals/mcxa/USBNC.rs"]
+pub mod usbnc;
+#[path = "../../meta_peripherals/mcxa/USBPHY.rs"]
+pub mod usbphy;
 #[path = "../../meta_peripherals/mcxa/VBAT.rs"]
 pub mod vbat;
 #[path = "../../meta_peripherals/mcxa/WWDT.rs"]

--- a/nxp-pac/src/meta_peripherals/_peripherals.rs
+++ b/nxp-pac/src/meta_peripherals/_peripherals.rs
@@ -34,6 +34,9 @@ pub const META_PERIPHERALS: &[&str] = &[
     "mcxa/SYSCON5xx",
     "mcxa/TRNG",
     "mcxa/USB",
+    "mcxa/USBHS",
+    "mcxa/USBNC",
+    "mcxa/USBPHY",
     "mcxa/VBAT",
     "mcxa/WWDT",
 ];

--- a/nxp-pac/src/meta_peripherals/mcxa/USBHS.rs
+++ b/nxp-pac/src/meta_peripherals/mcxa/USBHS.rs
@@ -1,0 +1,10934 @@
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e5ab29f 2026-04-30))"]
+#[doc = "USBC."]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct Usbhs {
+    ptr: *mut u8,
+}
+unsafe impl Send for Usbhs {}
+unsafe impl Sync for Usbhs {}
+impl Usbhs {
+    #[inline(always)]
+    pub const unsafe fn from_ptr(ptr: *mut ()) -> Self {
+        Self { ptr: ptr as _ }
+    }
+    #[inline(always)]
+    pub const fn as_ptr(&self) -> *mut () {
+        self.ptr as _
+    }
+    #[doc = "Identification."]
+    #[inline(always)]
+    pub const fn ID(self) -> crate::pac::common::Reg<ID, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+    }
+    #[doc = "Hardware General."]
+    #[inline(always)]
+    pub const fn HWGENERAL(self) -> crate::pac::common::Reg<HWGENERAL, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
+    }
+    #[doc = "Host Hardware Parameters."]
+    #[inline(always)]
+    pub const fn HWHOST(self) -> crate::pac::common::Reg<HWHOST, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x08usize) as _) }
+    }
+    #[doc = "Device Hardware Parameters."]
+    #[inline(always)]
+    pub const fn HWDEVICE(self) -> crate::pac::common::Reg<HWDEVICE, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0cusize) as _) }
+    }
+    #[doc = "TX Buffer Hardware Parameters."]
+    #[inline(always)]
+    pub const fn HWTXBUF(self) -> crate::pac::common::Reg<HWTXBUF, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x10usize) as _) }
+    }
+    #[doc = "RX Buffer Hardware Parameters."]
+    #[inline(always)]
+    pub const fn HWRXBUF(self) -> crate::pac::common::Reg<HWRXBUF, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x14usize) as _) }
+    }
+    #[doc = "General Purpose Timer 0 Load."]
+    #[inline(always)]
+    pub const fn GPTIMER0LD(self) -> crate::pac::common::Reg<GPTIMER0LD, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x80usize) as _) }
+    }
+    #[doc = "General Purpose Timer 0 Controller."]
+    #[inline(always)]
+    pub const fn GPTIMER0CTRL(
+        self,
+    ) -> crate::pac::common::Reg<GPTIMER0CTRL, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x84usize) as _) }
+    }
+    #[doc = "General Purpose Timer 1 Load."]
+    #[inline(always)]
+    pub const fn GPTIMER1LD(self) -> crate::pac::common::Reg<GPTIMER1LD, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x88usize) as _) }
+    }
+    #[doc = "General Purpose Timer 1 Controller."]
+    #[inline(always)]
+    pub const fn GPTIMER1CTRL(
+        self,
+    ) -> crate::pac::common::Reg<GPTIMER1CTRL, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x8cusize) as _) }
+    }
+    #[doc = "System Bus Configuration."]
+    #[inline(always)]
+    pub const fn SBUSCFG(self) -> crate::pac::common::Reg<SBUSCFG, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x90usize) as _) }
+    }
+    #[doc = "Capability Registers Length."]
+    #[inline(always)]
+    pub const fn CAPLENGTH(self) -> crate::pac::common::Reg<CAPLENGTH, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0100usize) as _) }
+    }
+    #[doc = "Host Controller Interface Version."]
+    #[inline(always)]
+    pub const fn HCIVERSION(self) -> crate::pac::common::Reg<HCIVERSION, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0102usize) as _) }
+    }
+    #[doc = "Host Controller Structural Parameters."]
+    #[inline(always)]
+    pub const fn HCSPARAMS(self) -> crate::pac::common::Reg<HCSPARAMS, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0104usize) as _) }
+    }
+    #[doc = "Host Controller Capability Parameters."]
+    #[inline(always)]
+    pub const fn HCCPARAMS(self) -> crate::pac::common::Reg<HCCPARAMS, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0108usize) as _) }
+    }
+    #[doc = "Device Controller Interface Version."]
+    #[inline(always)]
+    pub const fn DCIVERSION(self) -> crate::pac::common::Reg<DCIVERSION, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0120usize) as _) }
+    }
+    #[doc = "Device Controller Capability Parameters."]
+    #[inline(always)]
+    pub const fn DCCPARAMS(self) -> crate::pac::common::Reg<DCCPARAMS, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0124usize) as _) }
+    }
+    #[doc = "USB Command."]
+    #[inline(always)]
+    pub const fn USBCMD(self) -> crate::pac::common::Reg<USBCMD, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0140usize) as _) }
+    }
+    #[doc = "USB Status."]
+    #[inline(always)]
+    pub const fn USBSTS(self) -> crate::pac::common::Reg<USBSTS, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0144usize) as _) }
+    }
+    #[doc = "Interrupt Enable."]
+    #[inline(always)]
+    pub const fn USBINTR(self) -> crate::pac::common::Reg<USBINTR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0148usize) as _) }
+    }
+    #[doc = "USB Frame Index."]
+    #[inline(always)]
+    pub const fn FRINDEX(self) -> crate::pac::common::Reg<FRINDEX, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x014cusize) as _) }
+    }
+    #[doc = "Device Address."]
+    #[inline(always)]
+    pub const fn DEVICEADDR(self) -> crate::pac::common::Reg<DEVICEADDR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0154usize) as _) }
+    }
+    #[doc = "Frame List Base Address."]
+    #[inline(always)]
+    pub const fn PERIODICLISTBASE(
+        self,
+    ) -> crate::pac::common::Reg<PERIODICLISTBASE, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0154usize) as _) }
+    }
+    #[doc = "Next Asynchronous Address."]
+    #[inline(always)]
+    pub const fn ASYNCLISTADDR(
+        self,
+    ) -> crate::pac::common::Reg<ASYNCLISTADDR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0158usize) as _) }
+    }
+    #[doc = "Endpoint List Address."]
+    #[inline(always)]
+    pub const fn ENDPTLISTADDR(
+        self,
+    ) -> crate::pac::common::Reg<ENDPTLISTADDR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0158usize) as _) }
+    }
+    #[doc = "Programmable Burst Size."]
+    #[inline(always)]
+    pub const fn BURSTSIZE(self) -> crate::pac::common::Reg<BURSTSIZE, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0160usize) as _) }
+    }
+    #[doc = "TX FIFO Fill Tuning."]
+    #[inline(always)]
+    pub const fn TXFILLTUNING(
+        self,
+    ) -> crate::pac::common::Reg<TXFILLTUNING, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0164usize) as _) }
+    }
+    #[doc = "Endpoint NAK."]
+    #[inline(always)]
+    pub const fn ENDPTNAK(self) -> crate::pac::common::Reg<ENDPTNAK, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0178usize) as _) }
+    }
+    #[doc = "Endpoint NAK Enable."]
+    #[inline(always)]
+    pub const fn ENDPTNAKEN(self) -> crate::pac::common::Reg<ENDPTNAKEN, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x017cusize) as _) }
+    }
+    #[doc = "Configure Flag."]
+    #[inline(always)]
+    pub const fn CONFIGFLAG(self) -> crate::pac::common::Reg<CONFIGFLAG, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0180usize) as _) }
+    }
+    #[doc = "Port Status and Control."]
+    #[inline(always)]
+    pub const fn PORTSC1(self) -> crate::pac::common::Reg<PORTSC1, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0184usize) as _) }
+    }
+    #[doc = "On-The-Go Status and Control."]
+    #[inline(always)]
+    pub const fn OTGSC(self) -> crate::pac::common::Reg<OTGSC, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01a4usize) as _) }
+    }
+    #[doc = "USB Device Mode."]
+    #[inline(always)]
+    pub const fn USBMODE(self) -> crate::pac::common::Reg<USBMODE, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01a8usize) as _) }
+    }
+    #[doc = "Endpoint Setup Status."]
+    #[inline(always)]
+    pub const fn ENDPTSETUPSTAT(
+        self,
+    ) -> crate::pac::common::Reg<ENDPTSETUPSTAT, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01acusize) as _) }
+    }
+    #[doc = "Endpoint Prime."]
+    #[inline(always)]
+    pub const fn ENDPTPRIME(self) -> crate::pac::common::Reg<ENDPTPRIME, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01b0usize) as _) }
+    }
+    #[doc = "Endpoint Flush."]
+    #[inline(always)]
+    pub const fn ENDPTFLUSH(self) -> crate::pac::common::Reg<ENDPTFLUSH, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01b4usize) as _) }
+    }
+    #[doc = "Endpoint Status."]
+    #[inline(always)]
+    pub const fn ENDPTSTAT(self) -> crate::pac::common::Reg<ENDPTSTAT, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01b8usize) as _) }
+    }
+    #[doc = "Endpoint Complete."]
+    #[inline(always)]
+    pub const fn ENDPTCOMPLETE(
+        self,
+    ) -> crate::pac::common::Reg<ENDPTCOMPLETE, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01bcusize) as _) }
+    }
+    #[doc = "Endpoint Control 0."]
+    #[inline(always)]
+    pub const fn ENDPTCTRL0(self) -> crate::pac::common::Reg<ENDPTCTRL0, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01c0usize) as _) }
+    }
+    #[doc = "Endpoint Control 1."]
+    #[inline(always)]
+    pub const fn ENDPTCTRL1(self) -> crate::pac::common::Reg<ENDPTCTRL1, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01c4usize) as _) }
+    }
+    #[doc = "Endpoint Control 2."]
+    #[inline(always)]
+    pub const fn ENDPTCTRL2(self) -> crate::pac::common::Reg<ENDPTCTRL2, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01c8usize) as _) }
+    }
+    #[doc = "Endpoint Control 3."]
+    #[inline(always)]
+    pub const fn ENDPTCTRL3(self) -> crate::pac::common::Reg<ENDPTCTRL3, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01ccusize) as _) }
+    }
+    #[doc = "Endpoint Control 4."]
+    #[inline(always)]
+    pub const fn ENDPTCTRL4(self) -> crate::pac::common::Reg<ENDPTCTRL4, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01d0usize) as _) }
+    }
+    #[doc = "Endpoint Control 5."]
+    #[inline(always)]
+    pub const fn ENDPTCTRL5(self) -> crate::pac::common::Reg<ENDPTCTRL5, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01d4usize) as _) }
+    }
+    #[doc = "Endpoint Control 6."]
+    #[inline(always)]
+    pub const fn ENDPTCTRL6(self) -> crate::pac::common::Reg<ENDPTCTRL6, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01d8usize) as _) }
+    }
+    #[doc = "Endpoint Control 7."]
+    #[inline(always)]
+    pub const fn ENDPTCTRL7(self) -> crate::pac::common::Reg<ENDPTCTRL7, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x01dcusize) as _) }
+    }
+}
+#[doc = "Next Asynchronous Address."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ASYNCLISTADDR(pub u32);
+impl ASYNCLISTADDR {
+    #[doc = "Link Pointer Low (LPL)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ASYBASE(&self) -> u32 {
+        let val = (self.0 >> 5usize) & 0x07ff_ffff;
+        val as u32
+    }
+    #[doc = "Link Pointer Low (LPL)."]
+    #[inline(always)]
+    pub const fn set_ASYBASE(&mut self, val: u32) {
+        self.0 = (self.0 & !(0x07ff_ffff << 5usize)) | (((val as u32) & 0x07ff_ffff) << 5usize);
+    }
+}
+impl Default for ASYNCLISTADDR {
+    #[inline(always)]
+    fn default() -> ASYNCLISTADDR {
+        ASYNCLISTADDR(0)
+    }
+}
+impl core::fmt::Debug for ASYNCLISTADDR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ASYNCLISTADDR")
+            .field("ASYBASE", &self.ASYBASE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ASYNCLISTADDR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "ASYNCLISTADDR {{ ASYBASE: {=u32:?} }}", self.ASYBASE())
+    }
+}
+#[doc = "Programmable Burst Size."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct BURSTSIZE(pub u32);
+impl BURSTSIZE {
+    #[doc = "Programmable RX Burst Size."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPBURST(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0xff;
+        val as u8
+    }
+    #[doc = "Programmable RX Burst Size."]
+    #[inline(always)]
+    pub const fn set_RXPBURST(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 0usize)) | (((val as u32) & 0xff) << 0usize);
+    }
+    #[doc = "Programmable TX Burst Size."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXPBURST(&self) -> u8 {
+        let val = (self.0 >> 8usize) & 0xff;
+        val as u8
+    }
+    #[doc = "Programmable TX Burst Size."]
+    #[inline(always)]
+    pub const fn set_TXPBURST(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 8usize)) | (((val as u32) & 0xff) << 8usize);
+    }
+}
+impl Default for BURSTSIZE {
+    #[inline(always)]
+    fn default() -> BURSTSIZE {
+        BURSTSIZE(0)
+    }
+}
+impl core::fmt::Debug for BURSTSIZE {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BURSTSIZE")
+            .field("RXPBURST", &self.RXPBURST())
+            .field("TXPBURST", &self.TXPBURST())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BURSTSIZE {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "BURSTSIZE {{ RXPBURST: {=u8:?}, TXPBURST: {=u8:?} }}",
+            self.RXPBURST(),
+            self.TXPBURST()
+        )
+    }
+}
+#[doc = "Capability Registers Length."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct CAPLENGTH(pub u8);
+impl CAPLENGTH {
+    #[doc = "Capability Length."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CAPLENGTH(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0xff;
+        val as u8
+    }
+    #[doc = "Capability Length."]
+    #[inline(always)]
+    pub const fn set_CAPLENGTH(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 0usize)) | (((val as u8) & 0xff) << 0usize);
+    }
+}
+impl Default for CAPLENGTH {
+    #[inline(always)]
+    fn default() -> CAPLENGTH {
+        CAPLENGTH(0)
+    }
+}
+impl core::fmt::Debug for CAPLENGTH {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CAPLENGTH")
+            .field("CAPLENGTH", &self.CAPLENGTH())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CAPLENGTH {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "CAPLENGTH {{ CAPLENGTH: {=u8:?} }}", self.CAPLENGTH())
+    }
+}
+#[doc = "Configure Flag."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct CONFIGFLAG(pub u32);
+impl CONFIGFLAG {
+    #[doc = "Configure Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CF(&self) -> CF {
+        let val = (self.0 >> 0usize) & 0x01;
+        CF::from_bits(val as u8)
+    }
+    #[doc = "Configure Flag."]
+    #[inline(always)]
+    pub const fn set_CF(&mut self, val: CF) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+}
+impl Default for CONFIGFLAG {
+    #[inline(always)]
+    fn default() -> CONFIGFLAG {
+        CONFIGFLAG(0)
+    }
+}
+impl core::fmt::Debug for CONFIGFLAG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CONFIGFLAG")
+            .field("CF", &self.CF())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CONFIGFLAG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "CONFIGFLAG {{ CF: {:?} }}", self.CF())
+    }
+}
+#[doc = "Device Controller Capability Parameters."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct DCCPARAMS(pub u32);
+impl DCCPARAMS {
+    #[doc = "Device Endpoint Number."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEN(&self) -> DEN {
+        let val = (self.0 >> 0usize) & 0x1f;
+        DEN::from_bits(val as u8)
+    }
+    #[doc = "Device Endpoint Number."]
+    #[inline(always)]
+    pub const fn set_DEN(&mut self, val: DEN) {
+        self.0 = (self.0 & !(0x1f << 0usize)) | (((val.to_bits() as u32) & 0x1f) << 0usize);
+    }
+    #[doc = "Device Capable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DC(&self) -> DCCPARAMS_DC {
+        let val = (self.0 >> 7usize) & 0x01;
+        DCCPARAMS_DC::from_bits(val as u8)
+    }
+    #[doc = "Device Capable."]
+    #[inline(always)]
+    pub const fn set_DC(&mut self, val: DCCPARAMS_DC) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "Host Capable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HC(&self) -> DCCPARAMS_HC {
+        let val = (self.0 >> 8usize) & 0x01;
+        DCCPARAMS_HC::from_bits(val as u8)
+    }
+    #[doc = "Host Capable."]
+    #[inline(always)]
+    pub const fn set_HC(&mut self, val: DCCPARAMS_HC) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val.to_bits() as u32) & 0x01) << 8usize);
+    }
+}
+impl Default for DCCPARAMS {
+    #[inline(always)]
+    fn default() -> DCCPARAMS {
+        DCCPARAMS(0)
+    }
+}
+impl core::fmt::Debug for DCCPARAMS {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DCCPARAMS")
+            .field("DEN", &self.DEN())
+            .field("DC", &self.DC())
+            .field("HC", &self.HC())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DCCPARAMS {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "DCCPARAMS {{ DEN: {:?}, DC: {:?}, HC: {:?} }}",
+            self.DEN(),
+            self.DC(),
+            self.HC()
+        )
+    }
+}
+#[doc = "Device Controller Interface Version."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct DCIVERSION(pub u16);
+impl DCIVERSION {
+    #[doc = "Device Controller Interface Version Number."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DCIVERSION(&self) -> u16 {
+        let val = (self.0 >> 0usize) & 0xffff;
+        val as u16
+    }
+    #[doc = "Device Controller Interface Version Number."]
+    #[inline(always)]
+    pub const fn set_DCIVERSION(&mut self, val: u16) {
+        self.0 = (self.0 & !(0xffff << 0usize)) | (((val as u16) & 0xffff) << 0usize);
+    }
+}
+impl Default for DCIVERSION {
+    #[inline(always)]
+    fn default() -> DCIVERSION {
+        DCIVERSION(0)
+    }
+}
+impl core::fmt::Debug for DCIVERSION {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DCIVERSION")
+            .field("DCIVERSION", &self.DCIVERSION())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DCIVERSION {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "DCIVERSION {{ DCIVERSION: {=u16:?} }}",
+            self.DCIVERSION()
+        )
+    }
+}
+#[doc = "Device Address."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct DEVICEADDR(pub u32);
+impl DEVICEADDR {
+    #[doc = "Device Address Advance."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBADRA(&self) -> bool {
+        let val = (self.0 >> 24usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Device Address Advance."]
+    #[inline(always)]
+    pub const fn set_USBADRA(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 24usize)) | (((val as u32) & 0x01) << 24usize);
+    }
+    #[doc = "Device Address."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBADR(&self) -> u8 {
+        let val = (self.0 >> 25usize) & 0x7f;
+        val as u8
+    }
+    #[doc = "Device Address."]
+    #[inline(always)]
+    pub const fn set_USBADR(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x7f << 25usize)) | (((val as u32) & 0x7f) << 25usize);
+    }
+}
+impl Default for DEVICEADDR {
+    #[inline(always)]
+    fn default() -> DEVICEADDR {
+        DEVICEADDR(0)
+    }
+}
+impl core::fmt::Debug for DEVICEADDR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DEVICEADDR")
+            .field("USBADRA", &self.USBADRA())
+            .field("USBADR", &self.USBADR())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DEVICEADDR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "DEVICEADDR {{ USBADRA: {=bool:?}, USBADR: {=u8:?} }}",
+            self.USBADRA(),
+            self.USBADR()
+        )
+    }
+}
+#[doc = "Endpoint Complete."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTCOMPLETE(pub u32);
+impl ENDPTCOMPLETE {
+    #[doc = "Endpoint Receive Complete Event."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ERCE(&self) -> ERCE {
+        let val = (self.0 >> 0usize) & 0xff;
+        ERCE::from_bits(val as u8)
+    }
+    #[doc = "Endpoint Receive Complete Event."]
+    #[inline(always)]
+    pub const fn set_ERCE(&mut self, val: ERCE) {
+        self.0 = (self.0 & !(0xff << 0usize)) | (((val.to_bits() as u32) & 0xff) << 0usize);
+    }
+    #[doc = "Endpoint Transmit Complete Event."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ETCE(&self) -> ETCE {
+        let val = (self.0 >> 16usize) & 0xff;
+        ETCE::from_bits(val as u8)
+    }
+    #[doc = "Endpoint Transmit Complete Event."]
+    #[inline(always)]
+    pub const fn set_ETCE(&mut self, val: ETCE) {
+        self.0 = (self.0 & !(0xff << 16usize)) | (((val.to_bits() as u32) & 0xff) << 16usize);
+    }
+}
+impl Default for ENDPTCOMPLETE {
+    #[inline(always)]
+    fn default() -> ENDPTCOMPLETE {
+        ENDPTCOMPLETE(0)
+    }
+}
+impl core::fmt::Debug for ENDPTCOMPLETE {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTCOMPLETE")
+            .field("ERCE", &self.ERCE())
+            .field("ETCE", &self.ETCE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTCOMPLETE {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTCOMPLETE {{ ERCE: {:?}, ETCE: {:?} }}",
+            self.ERCE(),
+            self.ETCE()
+        )
+    }
+}
+#[doc = "Endpoint Control 0."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTCTRL0(pub u32);
+impl ENDPTCTRL0 {
+    #[doc = "RX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXS(&self) -> ENDPTCTRL0_RXS {
+        let val = (self.0 >> 0usize) & 0x01;
+        ENDPTCTRL0_RXS::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_RXS(&mut self, val: ENDPTCTRL0_RXS) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "RX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXT(&self) -> u8 {
+        let val = (self.0 >> 2usize) & 0x03;
+        val as u8
+    }
+    #[doc = "RX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_RXT(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val as u32) & 0x03) << 2usize);
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXE(&self) -> ENDPTCTRL0_RXE {
+        let val = (self.0 >> 7usize) & 0x01;
+        ENDPTCTRL0_RXE::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_RXE(&mut self, val: ENDPTCTRL0_RXE) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXS(&self) -> ENDPTCTRL0_TXS {
+        let val = (self.0 >> 16usize) & 0x01;
+        ENDPTCTRL0_TXS::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_TXS(&mut self, val: ENDPTCTRL0_TXS) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val.to_bits() as u32) & 0x01) << 16usize);
+    }
+    #[doc = "TX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXT(&self) -> u8 {
+        let val = (self.0 >> 18usize) & 0x03;
+        val as u8
+    }
+    #[doc = "TX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_TXT(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 18usize)) | (((val as u32) & 0x03) << 18usize);
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXE(&self) -> ENDPTCTRL0_TXE {
+        let val = (self.0 >> 23usize) & 0x01;
+        ENDPTCTRL0_TXE::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_TXE(&mut self, val: ENDPTCTRL0_TXE) {
+        self.0 = (self.0 & !(0x01 << 23usize)) | (((val.to_bits() as u32) & 0x01) << 23usize);
+    }
+}
+impl Default for ENDPTCTRL0 {
+    #[inline(always)]
+    fn default() -> ENDPTCTRL0 {
+        ENDPTCTRL0(0)
+    }
+}
+impl core::fmt::Debug for ENDPTCTRL0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTCTRL0")
+            .field("RXS", &self.RXS())
+            .field("RXT", &self.RXT())
+            .field("RXE", &self.RXE())
+            .field("TXS", &self.TXS())
+            .field("TXT", &self.TXT())
+            .field("TXE", &self.TXE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTCTRL0 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTCTRL0 {{ RXS: {:?}, RXT: {=u8:?}, RXE: {:?}, TXS: {:?}, TXT: {=u8:?}, TXE: {:?} }}",
+            self.RXS(),
+            self.RXT(),
+            self.RXE(),
+            self.TXS(),
+            self.TXT(),
+            self.TXE()
+        )
+    }
+}
+#[doc = "Endpoint Control 1."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTCTRL1(pub u32);
+impl ENDPTCTRL1 {
+    #[doc = "RX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXS(&self) -> ENDPTCTRL1_RXS {
+        let val = (self.0 >> 0usize) & 0x01;
+        ENDPTCTRL1_RXS::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_RXS(&mut self, val: ENDPTCTRL1_RXS) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXD(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[inline(always)]
+    pub const fn set_RXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "RX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXT(&self) -> ENDPTCTRL1_RXT {
+        let val = (self.0 >> 2usize) & 0x03;
+        ENDPTCTRL1_RXT::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_RXT(&mut self, val: ENDPTCTRL1_RXT) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val.to_bits() as u32) & 0x03) << 2usize);
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXI(&self) -> ENDPTCTRL1_RXI {
+        let val = (self.0 >> 5usize) & 0x01;
+        ENDPTCTRL1_RXI::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_RXI(&mut self, val: ENDPTCTRL1_RXI) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXR(&self) -> ENDPTCTRL1_RXR {
+        let val = (self.0 >> 6usize) & 0x01;
+        ENDPTCTRL1_RXR::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_RXR(&mut self, val: ENDPTCTRL1_RXR) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXE(&self) -> ENDPTCTRL1_RXE {
+        let val = (self.0 >> 7usize) & 0x01;
+        ENDPTCTRL1_RXE::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_RXE(&mut self, val: ENDPTCTRL1_RXE) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXS(&self) -> ENDPTCTRL1_TXS {
+        let val = (self.0 >> 16usize) & 0x01;
+        ENDPTCTRL1_TXS::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_TXS(&mut self, val: ENDPTCTRL1_TXS) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val.to_bits() as u32) & 0x01) << 16usize);
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXD(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[inline(always)]
+    pub const fn set_TXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "TX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXT(&self) -> ENDPTCTRL1_TXT {
+        let val = (self.0 >> 18usize) & 0x03;
+        ENDPTCTRL1_TXT::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_TXT(&mut self, val: ENDPTCTRL1_TXT) {
+        self.0 = (self.0 & !(0x03 << 18usize)) | (((val.to_bits() as u32) & 0x03) << 18usize);
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXI(&self) -> ENDPTCTRL1_TXI {
+        let val = (self.0 >> 21usize) & 0x01;
+        ENDPTCTRL1_TXI::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_TXI(&mut self, val: ENDPTCTRL1_TXI) {
+        self.0 = (self.0 & !(0x01 << 21usize)) | (((val.to_bits() as u32) & 0x01) << 21usize);
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXR(&self) -> ENDPTCTRL1_TXR {
+        let val = (self.0 >> 22usize) & 0x01;
+        ENDPTCTRL1_TXR::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_TXR(&mut self, val: ENDPTCTRL1_TXR) {
+        self.0 = (self.0 & !(0x01 << 22usize)) | (((val.to_bits() as u32) & 0x01) << 22usize);
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXE(&self) -> ENDPTCTRL1_TXE {
+        let val = (self.0 >> 23usize) & 0x01;
+        ENDPTCTRL1_TXE::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_TXE(&mut self, val: ENDPTCTRL1_TXE) {
+        self.0 = (self.0 & !(0x01 << 23usize)) | (((val.to_bits() as u32) & 0x01) << 23usize);
+    }
+}
+impl Default for ENDPTCTRL1 {
+    #[inline(always)]
+    fn default() -> ENDPTCTRL1 {
+        ENDPTCTRL1(0)
+    }
+}
+impl core::fmt::Debug for ENDPTCTRL1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTCTRL1")
+            .field("RXS", &self.RXS())
+            .field("RXD", &self.RXD())
+            .field("RXT", &self.RXT())
+            .field("RXI", &self.RXI())
+            .field("RXR", &self.RXR())
+            .field("RXE", &self.RXE())
+            .field("TXS", &self.TXS())
+            .field("TXD", &self.TXD())
+            .field("TXT", &self.TXT())
+            .field("TXI", &self.TXI())
+            .field("TXR", &self.TXR())
+            .field("TXE", &self.TXE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTCTRL1 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTCTRL1 {{ RXS: {:?}, RXD: {=bool:?}, RXT: {:?}, RXI: {:?}, RXR: {:?}, RXE: {:?}, TXS: {:?}, TXD: {=bool:?}, TXT: {:?}, TXI: {:?}, TXR: {:?}, TXE: {:?} }}",
+            self.RXS(),
+            self.RXD(),
+            self.RXT(),
+            self.RXI(),
+            self.RXR(),
+            self.RXE(),
+            self.TXS(),
+            self.TXD(),
+            self.TXT(),
+            self.TXI(),
+            self.TXR(),
+            self.TXE()
+        )
+    }
+}
+#[doc = "Endpoint Control 2."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTCTRL2(pub u32);
+impl ENDPTCTRL2 {
+    #[doc = "RX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXS(&self) -> ENDPTCTRL2_RXS {
+        let val = (self.0 >> 0usize) & 0x01;
+        ENDPTCTRL2_RXS::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_RXS(&mut self, val: ENDPTCTRL2_RXS) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXD(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[inline(always)]
+    pub const fn set_RXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "RX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXT(&self) -> ENDPTCTRL2_RXT {
+        let val = (self.0 >> 2usize) & 0x03;
+        ENDPTCTRL2_RXT::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_RXT(&mut self, val: ENDPTCTRL2_RXT) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val.to_bits() as u32) & 0x03) << 2usize);
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXI(&self) -> ENDPTCTRL2_RXI {
+        let val = (self.0 >> 5usize) & 0x01;
+        ENDPTCTRL2_RXI::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_RXI(&mut self, val: ENDPTCTRL2_RXI) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXR(&self) -> ENDPTCTRL2_RXR {
+        let val = (self.0 >> 6usize) & 0x01;
+        ENDPTCTRL2_RXR::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_RXR(&mut self, val: ENDPTCTRL2_RXR) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXE(&self) -> ENDPTCTRL2_RXE {
+        let val = (self.0 >> 7usize) & 0x01;
+        ENDPTCTRL2_RXE::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_RXE(&mut self, val: ENDPTCTRL2_RXE) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXS(&self) -> ENDPTCTRL2_TXS {
+        let val = (self.0 >> 16usize) & 0x01;
+        ENDPTCTRL2_TXS::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_TXS(&mut self, val: ENDPTCTRL2_TXS) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val.to_bits() as u32) & 0x01) << 16usize);
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXD(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[inline(always)]
+    pub const fn set_TXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "TX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXT(&self) -> ENDPTCTRL2_TXT {
+        let val = (self.0 >> 18usize) & 0x03;
+        ENDPTCTRL2_TXT::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_TXT(&mut self, val: ENDPTCTRL2_TXT) {
+        self.0 = (self.0 & !(0x03 << 18usize)) | (((val.to_bits() as u32) & 0x03) << 18usize);
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXI(&self) -> ENDPTCTRL2_TXI {
+        let val = (self.0 >> 21usize) & 0x01;
+        ENDPTCTRL2_TXI::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_TXI(&mut self, val: ENDPTCTRL2_TXI) {
+        self.0 = (self.0 & !(0x01 << 21usize)) | (((val.to_bits() as u32) & 0x01) << 21usize);
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXR(&self) -> ENDPTCTRL2_TXR {
+        let val = (self.0 >> 22usize) & 0x01;
+        ENDPTCTRL2_TXR::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_TXR(&mut self, val: ENDPTCTRL2_TXR) {
+        self.0 = (self.0 & !(0x01 << 22usize)) | (((val.to_bits() as u32) & 0x01) << 22usize);
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXE(&self) -> ENDPTCTRL2_TXE {
+        let val = (self.0 >> 23usize) & 0x01;
+        ENDPTCTRL2_TXE::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_TXE(&mut self, val: ENDPTCTRL2_TXE) {
+        self.0 = (self.0 & !(0x01 << 23usize)) | (((val.to_bits() as u32) & 0x01) << 23usize);
+    }
+}
+impl Default for ENDPTCTRL2 {
+    #[inline(always)]
+    fn default() -> ENDPTCTRL2 {
+        ENDPTCTRL2(0)
+    }
+}
+impl core::fmt::Debug for ENDPTCTRL2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTCTRL2")
+            .field("RXS", &self.RXS())
+            .field("RXD", &self.RXD())
+            .field("RXT", &self.RXT())
+            .field("RXI", &self.RXI())
+            .field("RXR", &self.RXR())
+            .field("RXE", &self.RXE())
+            .field("TXS", &self.TXS())
+            .field("TXD", &self.TXD())
+            .field("TXT", &self.TXT())
+            .field("TXI", &self.TXI())
+            .field("TXR", &self.TXR())
+            .field("TXE", &self.TXE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTCTRL2 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTCTRL2 {{ RXS: {:?}, RXD: {=bool:?}, RXT: {:?}, RXI: {:?}, RXR: {:?}, RXE: {:?}, TXS: {:?}, TXD: {=bool:?}, TXT: {:?}, TXI: {:?}, TXR: {:?}, TXE: {:?} }}",
+            self.RXS(),
+            self.RXD(),
+            self.RXT(),
+            self.RXI(),
+            self.RXR(),
+            self.RXE(),
+            self.TXS(),
+            self.TXD(),
+            self.TXT(),
+            self.TXI(),
+            self.TXR(),
+            self.TXE()
+        )
+    }
+}
+#[doc = "Endpoint Control 3."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTCTRL3(pub u32);
+impl ENDPTCTRL3 {
+    #[doc = "RX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXS(&self) -> ENDPTCTRL3_RXS {
+        let val = (self.0 >> 0usize) & 0x01;
+        ENDPTCTRL3_RXS::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_RXS(&mut self, val: ENDPTCTRL3_RXS) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXD(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[inline(always)]
+    pub const fn set_RXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "RX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXT(&self) -> ENDPTCTRL3_RXT {
+        let val = (self.0 >> 2usize) & 0x03;
+        ENDPTCTRL3_RXT::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_RXT(&mut self, val: ENDPTCTRL3_RXT) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val.to_bits() as u32) & 0x03) << 2usize);
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXI(&self) -> ENDPTCTRL3_RXI {
+        let val = (self.0 >> 5usize) & 0x01;
+        ENDPTCTRL3_RXI::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_RXI(&mut self, val: ENDPTCTRL3_RXI) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXR(&self) -> ENDPTCTRL3_RXR {
+        let val = (self.0 >> 6usize) & 0x01;
+        ENDPTCTRL3_RXR::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_RXR(&mut self, val: ENDPTCTRL3_RXR) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXE(&self) -> ENDPTCTRL3_RXE {
+        let val = (self.0 >> 7usize) & 0x01;
+        ENDPTCTRL3_RXE::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_RXE(&mut self, val: ENDPTCTRL3_RXE) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXS(&self) -> ENDPTCTRL3_TXS {
+        let val = (self.0 >> 16usize) & 0x01;
+        ENDPTCTRL3_TXS::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_TXS(&mut self, val: ENDPTCTRL3_TXS) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val.to_bits() as u32) & 0x01) << 16usize);
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXD(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[inline(always)]
+    pub const fn set_TXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "TX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXT(&self) -> ENDPTCTRL3_TXT {
+        let val = (self.0 >> 18usize) & 0x03;
+        ENDPTCTRL3_TXT::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_TXT(&mut self, val: ENDPTCTRL3_TXT) {
+        self.0 = (self.0 & !(0x03 << 18usize)) | (((val.to_bits() as u32) & 0x03) << 18usize);
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXI(&self) -> ENDPTCTRL3_TXI {
+        let val = (self.0 >> 21usize) & 0x01;
+        ENDPTCTRL3_TXI::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_TXI(&mut self, val: ENDPTCTRL3_TXI) {
+        self.0 = (self.0 & !(0x01 << 21usize)) | (((val.to_bits() as u32) & 0x01) << 21usize);
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXR(&self) -> ENDPTCTRL3_TXR {
+        let val = (self.0 >> 22usize) & 0x01;
+        ENDPTCTRL3_TXR::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_TXR(&mut self, val: ENDPTCTRL3_TXR) {
+        self.0 = (self.0 & !(0x01 << 22usize)) | (((val.to_bits() as u32) & 0x01) << 22usize);
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXE(&self) -> ENDPTCTRL3_TXE {
+        let val = (self.0 >> 23usize) & 0x01;
+        ENDPTCTRL3_TXE::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_TXE(&mut self, val: ENDPTCTRL3_TXE) {
+        self.0 = (self.0 & !(0x01 << 23usize)) | (((val.to_bits() as u32) & 0x01) << 23usize);
+    }
+}
+impl Default for ENDPTCTRL3 {
+    #[inline(always)]
+    fn default() -> ENDPTCTRL3 {
+        ENDPTCTRL3(0)
+    }
+}
+impl core::fmt::Debug for ENDPTCTRL3 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTCTRL3")
+            .field("RXS", &self.RXS())
+            .field("RXD", &self.RXD())
+            .field("RXT", &self.RXT())
+            .field("RXI", &self.RXI())
+            .field("RXR", &self.RXR())
+            .field("RXE", &self.RXE())
+            .field("TXS", &self.TXS())
+            .field("TXD", &self.TXD())
+            .field("TXT", &self.TXT())
+            .field("TXI", &self.TXI())
+            .field("TXR", &self.TXR())
+            .field("TXE", &self.TXE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTCTRL3 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTCTRL3 {{ RXS: {:?}, RXD: {=bool:?}, RXT: {:?}, RXI: {:?}, RXR: {:?}, RXE: {:?}, TXS: {:?}, TXD: {=bool:?}, TXT: {:?}, TXI: {:?}, TXR: {:?}, TXE: {:?} }}",
+            self.RXS(),
+            self.RXD(),
+            self.RXT(),
+            self.RXI(),
+            self.RXR(),
+            self.RXE(),
+            self.TXS(),
+            self.TXD(),
+            self.TXT(),
+            self.TXI(),
+            self.TXR(),
+            self.TXE()
+        )
+    }
+}
+#[doc = "Endpoint Control 4."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTCTRL4(pub u32);
+impl ENDPTCTRL4 {
+    #[doc = "RX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXS(&self) -> ENDPTCTRL4_RXS {
+        let val = (self.0 >> 0usize) & 0x01;
+        ENDPTCTRL4_RXS::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_RXS(&mut self, val: ENDPTCTRL4_RXS) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXD(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[inline(always)]
+    pub const fn set_RXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "RX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXT(&self) -> ENDPTCTRL4_RXT {
+        let val = (self.0 >> 2usize) & 0x03;
+        ENDPTCTRL4_RXT::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_RXT(&mut self, val: ENDPTCTRL4_RXT) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val.to_bits() as u32) & 0x03) << 2usize);
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXI(&self) -> ENDPTCTRL4_RXI {
+        let val = (self.0 >> 5usize) & 0x01;
+        ENDPTCTRL4_RXI::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_RXI(&mut self, val: ENDPTCTRL4_RXI) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXR(&self) -> ENDPTCTRL4_RXR {
+        let val = (self.0 >> 6usize) & 0x01;
+        ENDPTCTRL4_RXR::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_RXR(&mut self, val: ENDPTCTRL4_RXR) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXE(&self) -> ENDPTCTRL4_RXE {
+        let val = (self.0 >> 7usize) & 0x01;
+        ENDPTCTRL4_RXE::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_RXE(&mut self, val: ENDPTCTRL4_RXE) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXS(&self) -> ENDPTCTRL4_TXS {
+        let val = (self.0 >> 16usize) & 0x01;
+        ENDPTCTRL4_TXS::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_TXS(&mut self, val: ENDPTCTRL4_TXS) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val.to_bits() as u32) & 0x01) << 16usize);
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXD(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[inline(always)]
+    pub const fn set_TXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "TX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXT(&self) -> ENDPTCTRL4_TXT {
+        let val = (self.0 >> 18usize) & 0x03;
+        ENDPTCTRL4_TXT::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_TXT(&mut self, val: ENDPTCTRL4_TXT) {
+        self.0 = (self.0 & !(0x03 << 18usize)) | (((val.to_bits() as u32) & 0x03) << 18usize);
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXI(&self) -> ENDPTCTRL4_TXI {
+        let val = (self.0 >> 21usize) & 0x01;
+        ENDPTCTRL4_TXI::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_TXI(&mut self, val: ENDPTCTRL4_TXI) {
+        self.0 = (self.0 & !(0x01 << 21usize)) | (((val.to_bits() as u32) & 0x01) << 21usize);
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXR(&self) -> ENDPTCTRL4_TXR {
+        let val = (self.0 >> 22usize) & 0x01;
+        ENDPTCTRL4_TXR::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_TXR(&mut self, val: ENDPTCTRL4_TXR) {
+        self.0 = (self.0 & !(0x01 << 22usize)) | (((val.to_bits() as u32) & 0x01) << 22usize);
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXE(&self) -> ENDPTCTRL4_TXE {
+        let val = (self.0 >> 23usize) & 0x01;
+        ENDPTCTRL4_TXE::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_TXE(&mut self, val: ENDPTCTRL4_TXE) {
+        self.0 = (self.0 & !(0x01 << 23usize)) | (((val.to_bits() as u32) & 0x01) << 23usize);
+    }
+}
+impl Default for ENDPTCTRL4 {
+    #[inline(always)]
+    fn default() -> ENDPTCTRL4 {
+        ENDPTCTRL4(0)
+    }
+}
+impl core::fmt::Debug for ENDPTCTRL4 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTCTRL4")
+            .field("RXS", &self.RXS())
+            .field("RXD", &self.RXD())
+            .field("RXT", &self.RXT())
+            .field("RXI", &self.RXI())
+            .field("RXR", &self.RXR())
+            .field("RXE", &self.RXE())
+            .field("TXS", &self.TXS())
+            .field("TXD", &self.TXD())
+            .field("TXT", &self.TXT())
+            .field("TXI", &self.TXI())
+            .field("TXR", &self.TXR())
+            .field("TXE", &self.TXE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTCTRL4 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTCTRL4 {{ RXS: {:?}, RXD: {=bool:?}, RXT: {:?}, RXI: {:?}, RXR: {:?}, RXE: {:?}, TXS: {:?}, TXD: {=bool:?}, TXT: {:?}, TXI: {:?}, TXR: {:?}, TXE: {:?} }}",
+            self.RXS(),
+            self.RXD(),
+            self.RXT(),
+            self.RXI(),
+            self.RXR(),
+            self.RXE(),
+            self.TXS(),
+            self.TXD(),
+            self.TXT(),
+            self.TXI(),
+            self.TXR(),
+            self.TXE()
+        )
+    }
+}
+#[doc = "Endpoint Control 5."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTCTRL5(pub u32);
+impl ENDPTCTRL5 {
+    #[doc = "RX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXS(&self) -> ENDPTCTRL5_RXS {
+        let val = (self.0 >> 0usize) & 0x01;
+        ENDPTCTRL5_RXS::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_RXS(&mut self, val: ENDPTCTRL5_RXS) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXD(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[inline(always)]
+    pub const fn set_RXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "RX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXT(&self) -> ENDPTCTRL5_RXT {
+        let val = (self.0 >> 2usize) & 0x03;
+        ENDPTCTRL5_RXT::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_RXT(&mut self, val: ENDPTCTRL5_RXT) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val.to_bits() as u32) & 0x03) << 2usize);
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXI(&self) -> ENDPTCTRL5_RXI {
+        let val = (self.0 >> 5usize) & 0x01;
+        ENDPTCTRL5_RXI::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_RXI(&mut self, val: ENDPTCTRL5_RXI) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXR(&self) -> ENDPTCTRL5_RXR {
+        let val = (self.0 >> 6usize) & 0x01;
+        ENDPTCTRL5_RXR::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_RXR(&mut self, val: ENDPTCTRL5_RXR) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXE(&self) -> ENDPTCTRL5_RXE {
+        let val = (self.0 >> 7usize) & 0x01;
+        ENDPTCTRL5_RXE::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_RXE(&mut self, val: ENDPTCTRL5_RXE) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXS(&self) -> ENDPTCTRL5_TXS {
+        let val = (self.0 >> 16usize) & 0x01;
+        ENDPTCTRL5_TXS::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_TXS(&mut self, val: ENDPTCTRL5_TXS) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val.to_bits() as u32) & 0x01) << 16usize);
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXD(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[inline(always)]
+    pub const fn set_TXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "TX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXT(&self) -> ENDPTCTRL5_TXT {
+        let val = (self.0 >> 18usize) & 0x03;
+        ENDPTCTRL5_TXT::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_TXT(&mut self, val: ENDPTCTRL5_TXT) {
+        self.0 = (self.0 & !(0x03 << 18usize)) | (((val.to_bits() as u32) & 0x03) << 18usize);
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXI(&self) -> ENDPTCTRL5_TXI {
+        let val = (self.0 >> 21usize) & 0x01;
+        ENDPTCTRL5_TXI::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_TXI(&mut self, val: ENDPTCTRL5_TXI) {
+        self.0 = (self.0 & !(0x01 << 21usize)) | (((val.to_bits() as u32) & 0x01) << 21usize);
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXR(&self) -> ENDPTCTRL5_TXR {
+        let val = (self.0 >> 22usize) & 0x01;
+        ENDPTCTRL5_TXR::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_TXR(&mut self, val: ENDPTCTRL5_TXR) {
+        self.0 = (self.0 & !(0x01 << 22usize)) | (((val.to_bits() as u32) & 0x01) << 22usize);
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXE(&self) -> ENDPTCTRL5_TXE {
+        let val = (self.0 >> 23usize) & 0x01;
+        ENDPTCTRL5_TXE::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_TXE(&mut self, val: ENDPTCTRL5_TXE) {
+        self.0 = (self.0 & !(0x01 << 23usize)) | (((val.to_bits() as u32) & 0x01) << 23usize);
+    }
+}
+impl Default for ENDPTCTRL5 {
+    #[inline(always)]
+    fn default() -> ENDPTCTRL5 {
+        ENDPTCTRL5(0)
+    }
+}
+impl core::fmt::Debug for ENDPTCTRL5 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTCTRL5")
+            .field("RXS", &self.RXS())
+            .field("RXD", &self.RXD())
+            .field("RXT", &self.RXT())
+            .field("RXI", &self.RXI())
+            .field("RXR", &self.RXR())
+            .field("RXE", &self.RXE())
+            .field("TXS", &self.TXS())
+            .field("TXD", &self.TXD())
+            .field("TXT", &self.TXT())
+            .field("TXI", &self.TXI())
+            .field("TXR", &self.TXR())
+            .field("TXE", &self.TXE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTCTRL5 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTCTRL5 {{ RXS: {:?}, RXD: {=bool:?}, RXT: {:?}, RXI: {:?}, RXR: {:?}, RXE: {:?}, TXS: {:?}, TXD: {=bool:?}, TXT: {:?}, TXI: {:?}, TXR: {:?}, TXE: {:?} }}",
+            self.RXS(),
+            self.RXD(),
+            self.RXT(),
+            self.RXI(),
+            self.RXR(),
+            self.RXE(),
+            self.TXS(),
+            self.TXD(),
+            self.TXT(),
+            self.TXI(),
+            self.TXR(),
+            self.TXE()
+        )
+    }
+}
+#[doc = "Endpoint Control 6."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTCTRL6(pub u32);
+impl ENDPTCTRL6 {
+    #[doc = "RX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXS(&self) -> ENDPTCTRL6_RXS {
+        let val = (self.0 >> 0usize) & 0x01;
+        ENDPTCTRL6_RXS::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_RXS(&mut self, val: ENDPTCTRL6_RXS) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXD(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[inline(always)]
+    pub const fn set_RXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "RX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXT(&self) -> ENDPTCTRL6_RXT {
+        let val = (self.0 >> 2usize) & 0x03;
+        ENDPTCTRL6_RXT::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_RXT(&mut self, val: ENDPTCTRL6_RXT) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val.to_bits() as u32) & 0x03) << 2usize);
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXI(&self) -> ENDPTCTRL6_RXI {
+        let val = (self.0 >> 5usize) & 0x01;
+        ENDPTCTRL6_RXI::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_RXI(&mut self, val: ENDPTCTRL6_RXI) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXR(&self) -> ENDPTCTRL6_RXR {
+        let val = (self.0 >> 6usize) & 0x01;
+        ENDPTCTRL6_RXR::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_RXR(&mut self, val: ENDPTCTRL6_RXR) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXE(&self) -> ENDPTCTRL6_RXE {
+        let val = (self.0 >> 7usize) & 0x01;
+        ENDPTCTRL6_RXE::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_RXE(&mut self, val: ENDPTCTRL6_RXE) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXS(&self) -> ENDPTCTRL6_TXS {
+        let val = (self.0 >> 16usize) & 0x01;
+        ENDPTCTRL6_TXS::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_TXS(&mut self, val: ENDPTCTRL6_TXS) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val.to_bits() as u32) & 0x01) << 16usize);
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXD(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[inline(always)]
+    pub const fn set_TXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "TX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXT(&self) -> ENDPTCTRL6_TXT {
+        let val = (self.0 >> 18usize) & 0x03;
+        ENDPTCTRL6_TXT::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_TXT(&mut self, val: ENDPTCTRL6_TXT) {
+        self.0 = (self.0 & !(0x03 << 18usize)) | (((val.to_bits() as u32) & 0x03) << 18usize);
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXI(&self) -> ENDPTCTRL6_TXI {
+        let val = (self.0 >> 21usize) & 0x01;
+        ENDPTCTRL6_TXI::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_TXI(&mut self, val: ENDPTCTRL6_TXI) {
+        self.0 = (self.0 & !(0x01 << 21usize)) | (((val.to_bits() as u32) & 0x01) << 21usize);
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXR(&self) -> ENDPTCTRL6_TXR {
+        let val = (self.0 >> 22usize) & 0x01;
+        ENDPTCTRL6_TXR::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_TXR(&mut self, val: ENDPTCTRL6_TXR) {
+        self.0 = (self.0 & !(0x01 << 22usize)) | (((val.to_bits() as u32) & 0x01) << 22usize);
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXE(&self) -> ENDPTCTRL6_TXE {
+        let val = (self.0 >> 23usize) & 0x01;
+        ENDPTCTRL6_TXE::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_TXE(&mut self, val: ENDPTCTRL6_TXE) {
+        self.0 = (self.0 & !(0x01 << 23usize)) | (((val.to_bits() as u32) & 0x01) << 23usize);
+    }
+}
+impl Default for ENDPTCTRL6 {
+    #[inline(always)]
+    fn default() -> ENDPTCTRL6 {
+        ENDPTCTRL6(0)
+    }
+}
+impl core::fmt::Debug for ENDPTCTRL6 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTCTRL6")
+            .field("RXS", &self.RXS())
+            .field("RXD", &self.RXD())
+            .field("RXT", &self.RXT())
+            .field("RXI", &self.RXI())
+            .field("RXR", &self.RXR())
+            .field("RXE", &self.RXE())
+            .field("TXS", &self.TXS())
+            .field("TXD", &self.TXD())
+            .field("TXT", &self.TXT())
+            .field("TXI", &self.TXI())
+            .field("TXR", &self.TXR())
+            .field("TXE", &self.TXE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTCTRL6 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTCTRL6 {{ RXS: {:?}, RXD: {=bool:?}, RXT: {:?}, RXI: {:?}, RXR: {:?}, RXE: {:?}, TXS: {:?}, TXD: {=bool:?}, TXT: {:?}, TXI: {:?}, TXR: {:?}, TXE: {:?} }}",
+            self.RXS(),
+            self.RXD(),
+            self.RXT(),
+            self.RXI(),
+            self.RXR(),
+            self.RXE(),
+            self.TXS(),
+            self.TXD(),
+            self.TXT(),
+            self.TXI(),
+            self.TXR(),
+            self.TXE()
+        )
+    }
+}
+#[doc = "Endpoint Control 7."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTCTRL7(pub u32);
+impl ENDPTCTRL7 {
+    #[doc = "RX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXS(&self) -> ENDPTCTRL7_RXS {
+        let val = (self.0 >> 0usize) & 0x01;
+        ENDPTCTRL7_RXS::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_RXS(&mut self, val: ENDPTCTRL7_RXS) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXD(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "RX Endpoint Data Sink."]
+    #[inline(always)]
+    pub const fn set_RXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "RX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXT(&self) -> ENDPTCTRL7_RXT {
+        let val = (self.0 >> 2usize) & 0x03;
+        ENDPTCTRL7_RXT::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_RXT(&mut self, val: ENDPTCTRL7_RXT) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val.to_bits() as u32) & 0x03) << 2usize);
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXI(&self) -> ENDPTCTRL7_RXI {
+        let val = (self.0 >> 5usize) & 0x01;
+        ENDPTCTRL7_RXI::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_RXI(&mut self, val: ENDPTCTRL7_RXI) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXR(&self) -> ENDPTCTRL7_RXR {
+        let val = (self.0 >> 6usize) & 0x01;
+        ENDPTCTRL7_RXR::from_bits(val as u8)
+    }
+    #[doc = "RX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_RXR(&mut self, val: ENDPTCTRL7_RXR) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXE(&self) -> ENDPTCTRL7_RXE {
+        let val = (self.0 >> 7usize) & 0x01;
+        ENDPTCTRL7_RXE::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_RXE(&mut self, val: ENDPTCTRL7_RXE) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXS(&self) -> ENDPTCTRL7_TXS {
+        let val = (self.0 >> 16usize) & 0x01;
+        ENDPTCTRL7_TXS::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Stall."]
+    #[inline(always)]
+    pub const fn set_TXS(&mut self, val: ENDPTCTRL7_TXS) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val.to_bits() as u32) & 0x01) << 16usize);
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXD(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "TX Endpoint Data Source."]
+    #[inline(always)]
+    pub const fn set_TXD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "TX Endpoint Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXT(&self) -> ENDPTCTRL7_TXT {
+        let val = (self.0 >> 18usize) & 0x03;
+        ENDPTCTRL7_TXT::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Type."]
+    #[inline(always)]
+    pub const fn set_TXT(&mut self, val: ENDPTCTRL7_TXT) {
+        self.0 = (self.0 & !(0x03 << 18usize)) | (((val.to_bits() as u32) & 0x03) << 18usize);
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXI(&self) -> ENDPTCTRL7_TXI {
+        let val = (self.0 >> 21usize) & 0x01;
+        ENDPTCTRL7_TXI::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Inhibit."]
+    #[inline(always)]
+    pub const fn set_TXI(&mut self, val: ENDPTCTRL7_TXI) {
+        self.0 = (self.0 & !(0x01 << 21usize)) | (((val.to_bits() as u32) & 0x01) << 21usize);
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXR(&self) -> ENDPTCTRL7_TXR {
+        let val = (self.0 >> 22usize) & 0x01;
+        ENDPTCTRL7_TXR::from_bits(val as u8)
+    }
+    #[doc = "TX Data Toggle Reset."]
+    #[inline(always)]
+    pub const fn set_TXR(&mut self, val: ENDPTCTRL7_TXR) {
+        self.0 = (self.0 & !(0x01 << 22usize)) | (((val.to_bits() as u32) & 0x01) << 22usize);
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXE(&self) -> ENDPTCTRL7_TXE {
+        let val = (self.0 >> 23usize) & 0x01;
+        ENDPTCTRL7_TXE::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint Enable."]
+    #[inline(always)]
+    pub const fn set_TXE(&mut self, val: ENDPTCTRL7_TXE) {
+        self.0 = (self.0 & !(0x01 << 23usize)) | (((val.to_bits() as u32) & 0x01) << 23usize);
+    }
+}
+impl Default for ENDPTCTRL7 {
+    #[inline(always)]
+    fn default() -> ENDPTCTRL7 {
+        ENDPTCTRL7(0)
+    }
+}
+impl core::fmt::Debug for ENDPTCTRL7 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTCTRL7")
+            .field("RXS", &self.RXS())
+            .field("RXD", &self.RXD())
+            .field("RXT", &self.RXT())
+            .field("RXI", &self.RXI())
+            .field("RXR", &self.RXR())
+            .field("RXE", &self.RXE())
+            .field("TXS", &self.TXS())
+            .field("TXD", &self.TXD())
+            .field("TXT", &self.TXT())
+            .field("TXI", &self.TXI())
+            .field("TXR", &self.TXR())
+            .field("TXE", &self.TXE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTCTRL7 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTCTRL7 {{ RXS: {:?}, RXD: {=bool:?}, RXT: {:?}, RXI: {:?}, RXR: {:?}, RXE: {:?}, TXS: {:?}, TXD: {=bool:?}, TXT: {:?}, TXI: {:?}, TXR: {:?}, TXE: {:?} }}",
+            self.RXS(),
+            self.RXD(),
+            self.RXT(),
+            self.RXI(),
+            self.RXR(),
+            self.RXE(),
+            self.TXS(),
+            self.TXD(),
+            self.TXT(),
+            self.TXI(),
+            self.TXR(),
+            self.TXE()
+        )
+    }
+}
+#[doc = "Endpoint Flush."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTFLUSH(pub u32);
+impl ENDPTFLUSH {
+    #[doc = "Flush Endpoint Receive Buffer."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn FERB(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0xff;
+        val as u8
+    }
+    #[doc = "Flush Endpoint Receive Buffer."]
+    #[inline(always)]
+    pub const fn set_FERB(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 0usize)) | (((val as u32) & 0xff) << 0usize);
+    }
+    #[doc = "Flush Endpoint Transmit Buffer."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn FETB(&self) -> u8 {
+        let val = (self.0 >> 16usize) & 0xff;
+        val as u8
+    }
+    #[doc = "Flush Endpoint Transmit Buffer."]
+    #[inline(always)]
+    pub const fn set_FETB(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 16usize)) | (((val as u32) & 0xff) << 16usize);
+    }
+}
+impl Default for ENDPTFLUSH {
+    #[inline(always)]
+    fn default() -> ENDPTFLUSH {
+        ENDPTFLUSH(0)
+    }
+}
+impl core::fmt::Debug for ENDPTFLUSH {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTFLUSH")
+            .field("FERB", &self.FERB())
+            .field("FETB", &self.FETB())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTFLUSH {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTFLUSH {{ FERB: {=u8:?}, FETB: {=u8:?} }}",
+            self.FERB(),
+            self.FETB()
+        )
+    }
+}
+#[doc = "Endpoint List Address."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTLISTADDR(pub u32);
+impl ENDPTLISTADDR {
+    #[doc = "Endpoint List Pointer (Low)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EPBASE(&self) -> u32 {
+        let val = (self.0 >> 11usize) & 0x001f_ffff;
+        val as u32
+    }
+    #[doc = "Endpoint List Pointer (Low)."]
+    #[inline(always)]
+    pub const fn set_EPBASE(&mut self, val: u32) {
+        self.0 = (self.0 & !(0x001f_ffff << 11usize)) | (((val as u32) & 0x001f_ffff) << 11usize);
+    }
+}
+impl Default for ENDPTLISTADDR {
+    #[inline(always)]
+    fn default() -> ENDPTLISTADDR {
+        ENDPTLISTADDR(0)
+    }
+}
+impl core::fmt::Debug for ENDPTLISTADDR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTLISTADDR")
+            .field("EPBASE", &self.EPBASE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTLISTADDR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "ENDPTLISTADDR {{ EPBASE: {=u32:?} }}", self.EPBASE())
+    }
+}
+#[doc = "Endpoint NAK."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTNAK(pub u32);
+impl ENDPTNAK {
+    #[doc = "RX Endpoint NAK Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EPRN(&self) -> EPRN {
+        let val = (self.0 >> 0usize) & 0xff;
+        EPRN::from_bits(val as u8)
+    }
+    #[doc = "RX Endpoint NAK Flag."]
+    #[inline(always)]
+    pub const fn set_EPRN(&mut self, val: EPRN) {
+        self.0 = (self.0 & !(0xff << 0usize)) | (((val.to_bits() as u32) & 0xff) << 0usize);
+    }
+    #[doc = "TX Endpoint NAK Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EPTN(&self) -> EPTN {
+        let val = (self.0 >> 16usize) & 0xff;
+        EPTN::from_bits(val as u8)
+    }
+    #[doc = "TX Endpoint NAK Flag."]
+    #[inline(always)]
+    pub const fn set_EPTN(&mut self, val: EPTN) {
+        self.0 = (self.0 & !(0xff << 16usize)) | (((val.to_bits() as u32) & 0xff) << 16usize);
+    }
+}
+impl Default for ENDPTNAK {
+    #[inline(always)]
+    fn default() -> ENDPTNAK {
+        ENDPTNAK(0)
+    }
+}
+impl core::fmt::Debug for ENDPTNAK {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTNAK")
+            .field("EPRN", &self.EPRN())
+            .field("EPTN", &self.EPTN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTNAK {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTNAK {{ EPRN: {:?}, EPTN: {:?} }}",
+            self.EPRN(),
+            self.EPTN()
+        )
+    }
+}
+#[doc = "Endpoint NAK Enable."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTNAKEN(pub u32);
+impl ENDPTNAKEN {
+    #[doc = "RX Endpoint NAK Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EPRNE(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0xff;
+        val as u8
+    }
+    #[doc = "RX Endpoint NAK Enable."]
+    #[inline(always)]
+    pub const fn set_EPRNE(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 0usize)) | (((val as u32) & 0xff) << 0usize);
+    }
+    #[doc = "TX Endpoint NAK Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EPTNE(&self) -> u8 {
+        let val = (self.0 >> 16usize) & 0xff;
+        val as u8
+    }
+    #[doc = "TX Endpoint NAK Enable."]
+    #[inline(always)]
+    pub const fn set_EPTNE(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 16usize)) | (((val as u32) & 0xff) << 16usize);
+    }
+}
+impl Default for ENDPTNAKEN {
+    #[inline(always)]
+    fn default() -> ENDPTNAKEN {
+        ENDPTNAKEN(0)
+    }
+}
+impl core::fmt::Debug for ENDPTNAKEN {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTNAKEN")
+            .field("EPRNE", &self.EPRNE())
+            .field("EPTNE", &self.EPTNE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTNAKEN {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTNAKEN {{ EPRNE: {=u8:?}, EPTNE: {=u8:?} }}",
+            self.EPRNE(),
+            self.EPTNE()
+        )
+    }
+}
+#[doc = "Endpoint Prime."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTPRIME(pub u32);
+impl ENDPTPRIME {
+    #[doc = "Prime Endpoint Receive Buffer."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PERB(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0xff;
+        val as u8
+    }
+    #[doc = "Prime Endpoint Receive Buffer."]
+    #[inline(always)]
+    pub const fn set_PERB(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 0usize)) | (((val as u32) & 0xff) << 0usize);
+    }
+    #[doc = "Prime Endpoint Transmit Buffer."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PETB(&self) -> u8 {
+        let val = (self.0 >> 16usize) & 0xff;
+        val as u8
+    }
+    #[doc = "Prime Endpoint Transmit Buffer."]
+    #[inline(always)]
+    pub const fn set_PETB(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 16usize)) | (((val as u32) & 0xff) << 16usize);
+    }
+}
+impl Default for ENDPTPRIME {
+    #[inline(always)]
+    fn default() -> ENDPTPRIME {
+        ENDPTPRIME(0)
+    }
+}
+impl core::fmt::Debug for ENDPTPRIME {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTPRIME")
+            .field("PERB", &self.PERB())
+            .field("PETB", &self.PETB())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTPRIME {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTPRIME {{ PERB: {=u8:?}, PETB: {=u8:?} }}",
+            self.PERB(),
+            self.PETB()
+        )
+    }
+}
+#[doc = "Endpoint Setup Status."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTSETUPSTAT(pub u32);
+impl ENDPTSETUPSTAT {
+    #[doc = "Endpoint Setup Status Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENDPTSETUPSTAT(&self) -> ENDPTSETUPSTAT_FLAG {
+        let val = (self.0 >> 0usize) & 0xffff;
+        ENDPTSETUPSTAT_FLAG::from_bits(val as u16)
+    }
+    #[doc = "Endpoint Setup Status Flag."]
+    #[inline(always)]
+    pub const fn set_ENDPTSETUPSTAT(&mut self, val: ENDPTSETUPSTAT_FLAG) {
+        self.0 = (self.0 & !(0xffff << 0usize)) | (((val.to_bits() as u32) & 0xffff) << 0usize);
+    }
+}
+impl Default for ENDPTSETUPSTAT {
+    #[inline(always)]
+    fn default() -> ENDPTSETUPSTAT {
+        ENDPTSETUPSTAT(0)
+    }
+}
+impl core::fmt::Debug for ENDPTSETUPSTAT {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTSETUPSTAT")
+            .field("ENDPTSETUPSTAT", &self.ENDPTSETUPSTAT())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTSETUPSTAT {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTSETUPSTAT {{ ENDPTSETUPSTAT: {:?} }}",
+            self.ENDPTSETUPSTAT()
+        )
+    }
+}
+#[doc = "Endpoint Status."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ENDPTSTAT(pub u32);
+impl ENDPTSTAT {
+    #[doc = "Endpoint Receive Buffer Ready."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ERBR(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0xff;
+        val as u8
+    }
+    #[doc = "Endpoint Receive Buffer Ready."]
+    #[inline(always)]
+    pub const fn set_ERBR(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 0usize)) | (((val as u32) & 0xff) << 0usize);
+    }
+    #[doc = "Endpoint Transmit Buffer Ready."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ETBR(&self) -> u8 {
+        let val = (self.0 >> 16usize) & 0xff;
+        val as u8
+    }
+    #[doc = "Endpoint Transmit Buffer Ready."]
+    #[inline(always)]
+    pub const fn set_ETBR(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 16usize)) | (((val as u32) & 0xff) << 16usize);
+    }
+}
+impl Default for ENDPTSTAT {
+    #[inline(always)]
+    fn default() -> ENDPTSTAT {
+        ENDPTSTAT(0)
+    }
+}
+impl core::fmt::Debug for ENDPTSTAT {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ENDPTSTAT")
+            .field("ERBR", &self.ERBR())
+            .field("ETBR", &self.ETBR())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTSTAT {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ENDPTSTAT {{ ERBR: {=u8:?}, ETBR: {=u8:?} }}",
+            self.ERBR(),
+            self.ETBR()
+        )
+    }
+}
+#[doc = "USB Frame Index."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct FRINDEX(pub u32);
+impl FRINDEX {
+    #[doc = "Frame Index."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn FRINDEX(&self) -> FRINDEX_VALUE {
+        let val = (self.0 >> 0usize) & 0x3fff;
+        FRINDEX_VALUE::from_bits(val as u16)
+    }
+    #[doc = "Frame Index."]
+    #[inline(always)]
+    pub const fn set_FRINDEX(&mut self, val: FRINDEX_VALUE) {
+        self.0 = (self.0 & !(0x3fff << 0usize)) | (((val.to_bits() as u32) & 0x3fff) << 0usize);
+    }
+}
+impl Default for FRINDEX {
+    #[inline(always)]
+    fn default() -> FRINDEX {
+        FRINDEX(0)
+    }
+}
+impl core::fmt::Debug for FRINDEX {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FRINDEX")
+            .field("FRINDEX", &self.FRINDEX())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FRINDEX {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "FRINDEX {{ FRINDEX: {:?} }}", self.FRINDEX())
+    }
+}
+#[doc = "General Purpose Timer 0 Controller."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct GPTIMER0CTRL(pub u32);
+impl GPTIMER0CTRL {
+    #[doc = "General Purpose Timer Counter."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn GPTCNT(&self) -> u32 {
+        let val = (self.0 >> 0usize) & 0x00ff_ffff;
+        val as u32
+    }
+    #[doc = "General Purpose Timer Counter."]
+    #[inline(always)]
+    pub const fn set_GPTCNT(&mut self, val: u32) {
+        self.0 = (self.0 & !(0x00ff_ffff << 0usize)) | (((val as u32) & 0x00ff_ffff) << 0usize);
+    }
+    #[doc = "General Purpose Timer Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn GPTMODE(&self) -> GPTIMER0CTRL_GPTMODE {
+        let val = (self.0 >> 24usize) & 0x01;
+        GPTIMER0CTRL_GPTMODE::from_bits(val as u8)
+    }
+    #[doc = "General Purpose Timer Mode."]
+    #[inline(always)]
+    pub const fn set_GPTMODE(&mut self, val: GPTIMER0CTRL_GPTMODE) {
+        self.0 = (self.0 & !(0x01 << 24usize)) | (((val.to_bits() as u32) & 0x01) << 24usize);
+    }
+    #[doc = "General Purpose Timer Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn GPTRST(&self) -> GPTIMER0CTRL_GPTRST {
+        let val = (self.0 >> 30usize) & 0x01;
+        GPTIMER0CTRL_GPTRST::from_bits(val as u8)
+    }
+    #[doc = "General Purpose Timer Reset."]
+    #[inline(always)]
+    pub const fn set_GPTRST(&mut self, val: GPTIMER0CTRL_GPTRST) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val.to_bits() as u32) & 0x01) << 30usize);
+    }
+    #[doc = "General Purpose Timer Run."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn GPTRUN(&self) -> GPTIMER0CTRL_GPTRUN {
+        let val = (self.0 >> 31usize) & 0x01;
+        GPTIMER0CTRL_GPTRUN::from_bits(val as u8)
+    }
+    #[doc = "General Purpose Timer Run."]
+    #[inline(always)]
+    pub const fn set_GPTRUN(&mut self, val: GPTIMER0CTRL_GPTRUN) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val.to_bits() as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for GPTIMER0CTRL {
+    #[inline(always)]
+    fn default() -> GPTIMER0CTRL {
+        GPTIMER0CTRL(0)
+    }
+}
+impl core::fmt::Debug for GPTIMER0CTRL {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("GPTIMER0CTRL")
+            .field("GPTCNT", &self.GPTCNT())
+            .field("GPTMODE", &self.GPTMODE())
+            .field("GPTRST", &self.GPTRST())
+            .field("GPTRUN", &self.GPTRUN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for GPTIMER0CTRL {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "GPTIMER0CTRL {{ GPTCNT: {=u32:?}, GPTMODE: {:?}, GPTRST: {:?}, GPTRUN: {:?} }}",
+            self.GPTCNT(),
+            self.GPTMODE(),
+            self.GPTRST(),
+            self.GPTRUN()
+        )
+    }
+}
+#[doc = "General Purpose Timer 0 Load."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct GPTIMER0LD(pub u32);
+impl GPTIMER0LD {
+    #[doc = "General Purpose Timer Load Value."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn GPTLD(&self) -> u32 {
+        let val = (self.0 >> 0usize) & 0x00ff_ffff;
+        val as u32
+    }
+    #[doc = "General Purpose Timer Load Value."]
+    #[inline(always)]
+    pub const fn set_GPTLD(&mut self, val: u32) {
+        self.0 = (self.0 & !(0x00ff_ffff << 0usize)) | (((val as u32) & 0x00ff_ffff) << 0usize);
+    }
+}
+impl Default for GPTIMER0LD {
+    #[inline(always)]
+    fn default() -> GPTIMER0LD {
+        GPTIMER0LD(0)
+    }
+}
+impl core::fmt::Debug for GPTIMER0LD {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("GPTIMER0LD")
+            .field("GPTLD", &self.GPTLD())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for GPTIMER0LD {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "GPTIMER0LD {{ GPTLD: {=u32:?} }}", self.GPTLD())
+    }
+}
+#[doc = "General Purpose Timer 1 Controller."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct GPTIMER1CTRL(pub u32);
+impl GPTIMER1CTRL {
+    #[doc = "General Purpose Timer Counter."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn GPTCNT(&self) -> u32 {
+        let val = (self.0 >> 0usize) & 0x00ff_ffff;
+        val as u32
+    }
+    #[doc = "General Purpose Timer Counter."]
+    #[inline(always)]
+    pub const fn set_GPTCNT(&mut self, val: u32) {
+        self.0 = (self.0 & !(0x00ff_ffff << 0usize)) | (((val as u32) & 0x00ff_ffff) << 0usize);
+    }
+    #[doc = "General Purpose Timer Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn GPTMODE(&self) -> GPTIMER1CTRL_GPTMODE {
+        let val = (self.0 >> 24usize) & 0x01;
+        GPTIMER1CTRL_GPTMODE::from_bits(val as u8)
+    }
+    #[doc = "General Purpose Timer Mode."]
+    #[inline(always)]
+    pub const fn set_GPTMODE(&mut self, val: GPTIMER1CTRL_GPTMODE) {
+        self.0 = (self.0 & !(0x01 << 24usize)) | (((val.to_bits() as u32) & 0x01) << 24usize);
+    }
+    #[doc = "General Purpose Timer Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn GPTRST(&self) -> GPTIMER1CTRL_GPTRST {
+        let val = (self.0 >> 30usize) & 0x01;
+        GPTIMER1CTRL_GPTRST::from_bits(val as u8)
+    }
+    #[doc = "General Purpose Timer Reset."]
+    #[inline(always)]
+    pub const fn set_GPTRST(&mut self, val: GPTIMER1CTRL_GPTRST) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val.to_bits() as u32) & 0x01) << 30usize);
+    }
+    #[doc = "General Purpose Timer Run."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn GPTRUN(&self) -> GPTIMER1CTRL_GPTRUN {
+        let val = (self.0 >> 31usize) & 0x01;
+        GPTIMER1CTRL_GPTRUN::from_bits(val as u8)
+    }
+    #[doc = "General Purpose Timer Run."]
+    #[inline(always)]
+    pub const fn set_GPTRUN(&mut self, val: GPTIMER1CTRL_GPTRUN) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val.to_bits() as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for GPTIMER1CTRL {
+    #[inline(always)]
+    fn default() -> GPTIMER1CTRL {
+        GPTIMER1CTRL(0)
+    }
+}
+impl core::fmt::Debug for GPTIMER1CTRL {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("GPTIMER1CTRL")
+            .field("GPTCNT", &self.GPTCNT())
+            .field("GPTMODE", &self.GPTMODE())
+            .field("GPTRST", &self.GPTRST())
+            .field("GPTRUN", &self.GPTRUN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for GPTIMER1CTRL {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "GPTIMER1CTRL {{ GPTCNT: {=u32:?}, GPTMODE: {:?}, GPTRST: {:?}, GPTRUN: {:?} }}",
+            self.GPTCNT(),
+            self.GPTMODE(),
+            self.GPTRST(),
+            self.GPTRUN()
+        )
+    }
+}
+#[doc = "General Purpose Timer 1 Load."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct GPTIMER1LD(pub u32);
+impl GPTIMER1LD {
+    #[doc = "General Purpose Timer Load Value."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn GPTLD(&self) -> u32 {
+        let val = (self.0 >> 0usize) & 0x00ff_ffff;
+        val as u32
+    }
+    #[doc = "General Purpose Timer Load Value."]
+    #[inline(always)]
+    pub const fn set_GPTLD(&mut self, val: u32) {
+        self.0 = (self.0 & !(0x00ff_ffff << 0usize)) | (((val as u32) & 0x00ff_ffff) << 0usize);
+    }
+}
+impl Default for GPTIMER1LD {
+    #[inline(always)]
+    fn default() -> GPTIMER1LD {
+        GPTIMER1LD(0)
+    }
+}
+impl core::fmt::Debug for GPTIMER1LD {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("GPTIMER1LD")
+            .field("GPTLD", &self.GPTLD())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for GPTIMER1LD {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "GPTIMER1LD {{ GPTLD: {=u32:?} }}", self.GPTLD())
+    }
+}
+#[doc = "Host Controller Capability Parameters."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct HCCPARAMS(pub u32);
+impl HCCPARAMS {
+    #[doc = "Addressing Capability."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ADC(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Addressing Capability."]
+    #[inline(always)]
+    pub const fn set_ADC(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Programmable Frame List Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFL(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Programmable Frame List Flag."]
+    #[inline(always)]
+    pub const fn set_PFL(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "Asynchronous Schedule Park Capability."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ASP(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Asynchronous Schedule Park Capability."]
+    #[inline(always)]
+    pub const fn set_ASP(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "Isochronous Scheduling Threshold."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn IST(&self) -> u8 {
+        let val = (self.0 >> 4usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "Isochronous Scheduling Threshold."]
+    #[inline(always)]
+    pub const fn set_IST(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 4usize)) | (((val as u32) & 0x0f) << 4usize);
+    }
+    #[doc = "EHCI Extended Capabilities Pointer."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EECP(&self) -> u8 {
+        let val = (self.0 >> 8usize) & 0xff;
+        val as u8
+    }
+    #[doc = "EHCI Extended Capabilities Pointer."]
+    #[inline(always)]
+    pub const fn set_EECP(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 8usize)) | (((val as u32) & 0xff) << 8usize);
+    }
+}
+impl Default for HCCPARAMS {
+    #[inline(always)]
+    fn default() -> HCCPARAMS {
+        HCCPARAMS(0)
+    }
+}
+impl core::fmt::Debug for HCCPARAMS {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HCCPARAMS")
+            .field("ADC", &self.ADC())
+            .field("PFL", &self.PFL())
+            .field("ASP", &self.ASP())
+            .field("IST", &self.IST())
+            .field("EECP", &self.EECP())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for HCCPARAMS {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "HCCPARAMS {{ ADC: {=bool:?}, PFL: {=bool:?}, ASP: {=bool:?}, IST: {=u8:?}, EECP: {=u8:?} }}",
+            self.ADC(),
+            self.PFL(),
+            self.ASP(),
+            self.IST(),
+            self.EECP()
+        )
+    }
+}
+#[doc = "Host Controller Interface Version."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct HCIVERSION(pub u16);
+impl HCIVERSION {
+    #[doc = "Host Controller Interface Version Number."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HCIVERSION(&self) -> u16 {
+        let val = (self.0 >> 0usize) & 0xffff;
+        val as u16
+    }
+    #[doc = "Host Controller Interface Version Number."]
+    #[inline(always)]
+    pub const fn set_HCIVERSION(&mut self, val: u16) {
+        self.0 = (self.0 & !(0xffff << 0usize)) | (((val as u16) & 0xffff) << 0usize);
+    }
+}
+impl Default for HCIVERSION {
+    #[inline(always)]
+    fn default() -> HCIVERSION {
+        HCIVERSION(0)
+    }
+}
+impl core::fmt::Debug for HCIVERSION {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HCIVERSION")
+            .field("HCIVERSION", &self.HCIVERSION())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for HCIVERSION {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "HCIVERSION {{ HCIVERSION: {=u16:?} }}",
+            self.HCIVERSION()
+        )
+    }
+}
+#[doc = "Host Controller Structural Parameters."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct HCSPARAMS(pub u32);
+impl HCSPARAMS {
+    #[doc = "Number of Ports."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn N_PORTS(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "Number of Ports."]
+    #[inline(always)]
+    pub const fn set_N_PORTS(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 0usize)) | (((val as u32) & 0x0f) << 0usize);
+    }
+    #[doc = "Port Power Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PPC(&self) -> PPC {
+        let val = (self.0 >> 4usize) & 0x01;
+        PPC::from_bits(val as u8)
+    }
+    #[doc = "Port Power Control."]
+    #[inline(always)]
+    pub const fn set_PPC(&mut self, val: PPC) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u32) & 0x01) << 4usize);
+    }
+    #[doc = "Number of Ports per Companion Controller."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn N_PCC(&self) -> u8 {
+        let val = (self.0 >> 8usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "Number of Ports per Companion Controller."]
+    #[inline(always)]
+    pub const fn set_N_PCC(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 8usize)) | (((val as u32) & 0x0f) << 8usize);
+    }
+    #[doc = "Number of Companion Controller (N_CC)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn N_CC(&self) -> N_CC {
+        let val = (self.0 >> 12usize) & 0x0f;
+        N_CC::from_bits(val as u8)
+    }
+    #[doc = "Number of Companion Controller (N_CC)."]
+    #[inline(always)]
+    pub const fn set_N_CC(&mut self, val: N_CC) {
+        self.0 = (self.0 & !(0x0f << 12usize)) | (((val.to_bits() as u32) & 0x0f) << 12usize);
+    }
+    #[doc = "Port Indicators (P_INDICATOR)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PI(&self) -> bool {
+        let val = (self.0 >> 16usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Port Indicators (P_INDICATOR)."]
+    #[inline(always)]
+    pub const fn set_PI(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val as u32) & 0x01) << 16usize);
+    }
+    #[doc = "Number of Ports per Transaction Translator (N_PTT)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn N_PTT(&self) -> u8 {
+        let val = (self.0 >> 20usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "Number of Ports per Transaction Translator (N_PTT)."]
+    #[inline(always)]
+    pub const fn set_N_PTT(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 20usize)) | (((val as u32) & 0x0f) << 20usize);
+    }
+    #[doc = "Number of Transaction Translators (N_TT)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn N_TT(&self) -> u8 {
+        let val = (self.0 >> 24usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "Number of Transaction Translators (N_TT)."]
+    #[inline(always)]
+    pub const fn set_N_TT(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 24usize)) | (((val as u32) & 0x0f) << 24usize);
+    }
+}
+impl Default for HCSPARAMS {
+    #[inline(always)]
+    fn default() -> HCSPARAMS {
+        HCSPARAMS(0)
+    }
+}
+impl core::fmt::Debug for HCSPARAMS {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HCSPARAMS")
+            .field("N_PORTS", &self.N_PORTS())
+            .field("PPC", &self.PPC())
+            .field("N_PCC", &self.N_PCC())
+            .field("N_CC", &self.N_CC())
+            .field("PI", &self.PI())
+            .field("N_PTT", &self.N_PTT())
+            .field("N_TT", &self.N_TT())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for HCSPARAMS {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "HCSPARAMS {{ N_PORTS: {=u8:?}, PPC: {:?}, N_PCC: {=u8:?}, N_CC: {:?}, PI: {=bool:?}, N_PTT: {=u8:?}, N_TT: {=u8:?} }}",
+            self.N_PORTS(),
+            self.PPC(),
+            self.N_PCC(),
+            self.N_CC(),
+            self.PI(),
+            self.N_PTT(),
+            self.N_TT()
+        )
+    }
+}
+#[doc = "Device Hardware Parameters."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct HWDEVICE(pub u32);
+impl HWDEVICE {
+    #[doc = "Device Capable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DC(&self) -> HWDEVICE_DC {
+        let val = (self.0 >> 0usize) & 0x01;
+        HWDEVICE_DC::from_bits(val as u8)
+    }
+    #[doc = "Device Capable."]
+    #[inline(always)]
+    pub const fn set_DC(&mut self, val: HWDEVICE_DC) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Device Endpoint Number."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEVEP(&self) -> u8 {
+        let val = (self.0 >> 1usize) & 0x1f;
+        val as u8
+    }
+    #[doc = "Device Endpoint Number."]
+    #[inline(always)]
+    pub const fn set_DEVEP(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x1f << 1usize)) | (((val as u32) & 0x1f) << 1usize);
+    }
+}
+impl Default for HWDEVICE {
+    #[inline(always)]
+    fn default() -> HWDEVICE {
+        HWDEVICE(0)
+    }
+}
+impl core::fmt::Debug for HWDEVICE {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HWDEVICE")
+            .field("DC", &self.DC())
+            .field("DEVEP", &self.DEVEP())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for HWDEVICE {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "HWDEVICE {{ DC: {:?}, DEVEP: {=u8:?} }}",
+            self.DC(),
+            self.DEVEP()
+        )
+    }
+}
+#[doc = "Hardware General."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct HWGENERAL(pub u32);
+impl HWGENERAL {
+    #[doc = "PHY Width."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PHYW(&self) -> PHYW {
+        let val = (self.0 >> 4usize) & 0x03;
+        PHYW::from_bits(val as u8)
+    }
+    #[doc = "PHY Width."]
+    #[inline(always)]
+    pub const fn set_PHYW(&mut self, val: PHYW) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+    }
+    #[doc = "Transceiver Type."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PHYM(&self) -> PHYM {
+        let val = (self.0 >> 6usize) & 0x0f;
+        PHYM::from_bits(val as u8)
+    }
+    #[doc = "Transceiver Type."]
+    #[inline(always)]
+    pub const fn set_PHYM(&mut self, val: PHYM) {
+        self.0 = (self.0 & !(0x0f << 6usize)) | (((val.to_bits() as u32) & 0x0f) << 6usize);
+    }
+    #[doc = "Serial Interface Mode Capability."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SM(&self) -> SM {
+        let val = (self.0 >> 10usize) & 0x03;
+        SM::from_bits(val as u8)
+    }
+    #[doc = "Serial Interface Mode Capability."]
+    #[inline(always)]
+    pub const fn set_SM(&mut self, val: SM) {
+        self.0 = (self.0 & !(0x03 << 10usize)) | (((val.to_bits() as u32) & 0x03) << 10usize);
+    }
+    #[doc = "Link Power Management Capability."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM(&self) -> LPM {
+        let val = (self.0 >> 12usize) & 0x01;
+        LPM::from_bits(val as u8)
+    }
+    #[doc = "Link Power Management Capability."]
+    #[inline(always)]
+    pub const fn set_LPM(&mut self, val: LPM) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val.to_bits() as u32) & 0x01) << 12usize);
+    }
+}
+impl Default for HWGENERAL {
+    #[inline(always)]
+    fn default() -> HWGENERAL {
+        HWGENERAL(0)
+    }
+}
+impl core::fmt::Debug for HWGENERAL {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HWGENERAL")
+            .field("PHYW", &self.PHYW())
+            .field("PHYM", &self.PHYM())
+            .field("SM", &self.SM())
+            .field("LPM", &self.LPM())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for HWGENERAL {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "HWGENERAL {{ PHYW: {:?}, PHYM: {:?}, SM: {:?}, LPM: {:?} }}",
+            self.PHYW(),
+            self.PHYM(),
+            self.SM(),
+            self.LPM()
+        )
+    }
+}
+#[doc = "Host Hardware Parameters."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct HWHOST(pub u32);
+impl HWHOST {
+    #[doc = "Host Capable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HC(&self) -> HWHOST_HC {
+        let val = (self.0 >> 0usize) & 0x01;
+        HWHOST_HC::from_bits(val as u8)
+    }
+    #[doc = "Host Capable."]
+    #[inline(always)]
+    pub const fn set_HC(&mut self, val: HWHOST_HC) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Number of Ports."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn NPORT(&self) -> u8 {
+        let val = (self.0 >> 1usize) & 0x07;
+        val as u8
+    }
+    #[doc = "Number of Ports."]
+    #[inline(always)]
+    pub const fn set_NPORT(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 1usize)) | (((val as u32) & 0x07) << 1usize);
+    }
+}
+impl Default for HWHOST {
+    #[inline(always)]
+    fn default() -> HWHOST {
+        HWHOST(0)
+    }
+}
+impl core::fmt::Debug for HWHOST {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HWHOST")
+            .field("HC", &self.HC())
+            .field("NPORT", &self.NPORT())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for HWHOST {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "HWHOST {{ HC: {:?}, NPORT: {=u8:?} }}",
+            self.HC(),
+            self.NPORT()
+        )
+    }
+}
+#[doc = "RX Buffer Hardware Parameters."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct HWRXBUF(pub u32);
+impl HWRXBUF {
+    #[doc = "RX Burst."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXBURST(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0xff;
+        val as u8
+    }
+    #[doc = "RX Burst."]
+    #[inline(always)]
+    pub const fn set_RXBURST(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 0usize)) | (((val as u32) & 0xff) << 0usize);
+    }
+    #[doc = "RX Add."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXADD(&self) -> u8 {
+        let val = (self.0 >> 8usize) & 0xff;
+        val as u8
+    }
+    #[doc = "RX Add."]
+    #[inline(always)]
+    pub const fn set_RXADD(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 8usize)) | (((val as u32) & 0xff) << 8usize);
+    }
+}
+impl Default for HWRXBUF {
+    #[inline(always)]
+    fn default() -> HWRXBUF {
+        HWRXBUF(0)
+    }
+}
+impl core::fmt::Debug for HWRXBUF {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HWRXBUF")
+            .field("RXBURST", &self.RXBURST())
+            .field("RXADD", &self.RXADD())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for HWRXBUF {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "HWRXBUF {{ RXBURST: {=u8:?}, RXADD: {=u8:?} }}",
+            self.RXBURST(),
+            self.RXADD()
+        )
+    }
+}
+#[doc = "TX Buffer Hardware Parameters."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct HWTXBUF(pub u32);
+impl HWTXBUF {
+    #[doc = "TX Burst."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXBURST(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0xff;
+        val as u8
+    }
+    #[doc = "TX Burst."]
+    #[inline(always)]
+    pub const fn set_TXBURST(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 0usize)) | (((val as u32) & 0xff) << 0usize);
+    }
+    #[doc = "TX Channel Add."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXCHANADD(&self) -> u8 {
+        let val = (self.0 >> 16usize) & 0xff;
+        val as u8
+    }
+    #[doc = "TX Channel Add."]
+    #[inline(always)]
+    pub const fn set_TXCHANADD(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 16usize)) | (((val as u32) & 0xff) << 16usize);
+    }
+}
+impl Default for HWTXBUF {
+    #[inline(always)]
+    fn default() -> HWTXBUF {
+        HWTXBUF(0)
+    }
+}
+impl core::fmt::Debug for HWTXBUF {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HWTXBUF")
+            .field("TXBURST", &self.TXBURST())
+            .field("TXCHANADD", &self.TXCHANADD())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for HWTXBUF {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "HWTXBUF {{ TXBURST: {=u8:?}, TXCHANADD: {=u8:?} }}",
+            self.TXBURST(),
+            self.TXCHANADD()
+        )
+    }
+}
+#[doc = "Identification."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ID(pub u32);
+impl ID {
+    #[doc = "Configuration Number."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ID(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0x3f;
+        val as u8
+    }
+    #[doc = "Configuration Number."]
+    #[inline(always)]
+    pub const fn set_ID(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x3f << 0usize)) | (((val as u32) & 0x3f) << 0usize);
+    }
+    #[doc = "Complement Version."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn NID(&self) -> u8 {
+        let val = (self.0 >> 8usize) & 0x3f;
+        val as u8
+    }
+    #[doc = "Complement Version."]
+    #[inline(always)]
+    pub const fn set_NID(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x3f << 8usize)) | (((val as u32) & 0x3f) << 8usize);
+    }
+    #[doc = "Revision Number."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn REVISION(&self) -> u8 {
+        let val = (self.0 >> 16usize) & 0xff;
+        val as u8
+    }
+    #[doc = "Revision Number."]
+    #[inline(always)]
+    pub const fn set_REVISION(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 16usize)) | (((val as u32) & 0xff) << 16usize);
+    }
+}
+impl Default for ID {
+    #[inline(always)]
+    fn default() -> ID {
+        ID(0)
+    }
+}
+impl core::fmt::Debug for ID {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ID")
+            .field("ID", &self.ID())
+            .field("NID", &self.NID())
+            .field("REVISION", &self.REVISION())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ID {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ID {{ ID: {=u8:?}, NID: {=u8:?}, REVISION: {=u8:?} }}",
+            self.ID(),
+            self.NID(),
+            self.REVISION()
+        )
+    }
+}
+#[doc = "On-The-Go Status and Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct OTGSC(pub u32);
+impl OTGSC {
+    #[doc = "VBUS Discharge."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VD(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS Discharge."]
+    #[inline(always)]
+    pub const fn set_VD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "VBUS Charge."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VC(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS Charge."]
+    #[inline(always)]
+    pub const fn set_VC(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "Hardware Assist Auto Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HAAR(&self) -> HAAR {
+        let val = (self.0 >> 2usize) & 0x01;
+        HAAR::from_bits(val as u8)
+    }
+    #[doc = "Hardware Assist Auto Reset."]
+    #[inline(always)]
+    pub const fn set_HAAR(&mut self, val: HAAR) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val.to_bits() as u32) & 0x01) << 2usize);
+    }
+    #[doc = "OTG Termination."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OT(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG Termination."]
+    #[inline(always)]
+    pub const fn set_OT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Data Pulsing."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DP(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Data Pulsing."]
+    #[inline(always)]
+    pub const fn set_DP(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "ID Pullup."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn IDPU(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "ID Pullup."]
+    #[inline(always)]
+    pub const fn set_IDPU(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+    #[doc = "Hardware Assist Data Pulse."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HADP(&self) -> HADP {
+        let val = (self.0 >> 6usize) & 0x01;
+        HADP::from_bits(val as u8)
+    }
+    #[doc = "Hardware Assist Data Pulse."]
+    #[inline(always)]
+    pub const fn set_HADP(&mut self, val: HADP) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "Hardware Assist B-Disconnect to A-connect."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HABA(&self) -> HABA {
+        let val = (self.0 >> 7usize) & 0x01;
+        HABA::from_bits(val as u8)
+    }
+    #[doc = "Hardware Assist B-Disconnect to A-connect."]
+    #[inline(always)]
+    pub const fn set_HABA(&mut self, val: HABA) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "USB ID."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ID(&self) -> OTG_ID {
+        let val = (self.0 >> 8usize) & 0x01;
+        OTG_ID::from_bits(val as u8)
+    }
+    #[doc = "USB ID."]
+    #[inline(always)]
+    pub const fn set_ID(&mut self, val: OTG_ID) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val.to_bits() as u32) & 0x01) << 8usize);
+    }
+    #[doc = "A VBUS Valid."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AVV(&self) -> bool {
+        let val = (self.0 >> 9usize) & 0x01;
+        val != 0
+    }
+    #[doc = "A VBUS Valid."]
+    #[inline(always)]
+    pub const fn set_AVV(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 9usize)) | (((val as u32) & 0x01) << 9usize);
+    }
+    #[doc = "A Session Valid."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ASV(&self) -> bool {
+        let val = (self.0 >> 10usize) & 0x01;
+        val != 0
+    }
+    #[doc = "A Session Valid."]
+    #[inline(always)]
+    pub const fn set_ASV(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val as u32) & 0x01) << 10usize);
+    }
+    #[doc = "B Session Valid."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BSV(&self) -> bool {
+        let val = (self.0 >> 11usize) & 0x01;
+        val != 0
+    }
+    #[doc = "B Session Valid."]
+    #[inline(always)]
+    pub const fn set_BSV(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val as u32) & 0x01) << 11usize);
+    }
+    #[doc = "B Session End."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BSE(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "B Session End."]
+    #[inline(always)]
+    pub const fn set_BSE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "1 Millisecond Timer Toggle."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TOG_1MS(&self) -> bool {
+        let val = (self.0 >> 13usize) & 0x01;
+        val != 0
+    }
+    #[doc = "1 Millisecond Timer Toggle."]
+    #[inline(always)]
+    pub const fn set_TOG_1MS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val as u32) & 0x01) << 13usize);
+    }
+    #[doc = "Data Bus Pulsing Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DPS(&self) -> bool {
+        let val = (self.0 >> 14usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Data Bus Pulsing Status."]
+    #[inline(always)]
+    pub const fn set_DPS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 14usize)) | (((val as u32) & 0x01) << 14usize);
+    }
+    #[doc = "USB ID Interrupt Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn IDIS(&self) -> bool {
+        let val = (self.0 >> 16usize) & 0x01;
+        val != 0
+    }
+    #[doc = "USB ID Interrupt Status."]
+    #[inline(always)]
+    pub const fn set_IDIS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val as u32) & 0x01) << 16usize);
+    }
+    #[doc = "A VBUS Valid Interrupt Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AVVIS(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "A VBUS Valid Interrupt Status."]
+    #[inline(always)]
+    pub const fn set_AVVIS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "A Session Valid Interrupt Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ASVIS(&self) -> bool {
+        let val = (self.0 >> 18usize) & 0x01;
+        val != 0
+    }
+    #[doc = "A Session Valid Interrupt Status."]
+    #[inline(always)]
+    pub const fn set_ASVIS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    }
+    #[doc = "B Session Valid Interrupt Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BSVIS(&self) -> bool {
+        let val = (self.0 >> 19usize) & 0x01;
+        val != 0
+    }
+    #[doc = "B Session Valid Interrupt Status."]
+    #[inline(always)]
+    pub const fn set_BSVIS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val as u32) & 0x01) << 19usize);
+    }
+    #[doc = "B Session End Interrupt Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BSEIS(&self) -> bool {
+        let val = (self.0 >> 20usize) & 0x01;
+        val != 0
+    }
+    #[doc = "B Session End Interrupt Status."]
+    #[inline(always)]
+    pub const fn set_BSEIS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val as u32) & 0x01) << 20usize);
+    }
+    #[doc = "1 Millisecond Timer Interrupt Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn STATUS_1MS(&self) -> bool {
+        let val = (self.0 >> 21usize) & 0x01;
+        val != 0
+    }
+    #[doc = "1 Millisecond Timer Interrupt Status."]
+    #[inline(always)]
+    pub const fn set_STATUS_1MS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 21usize)) | (((val as u32) & 0x01) << 21usize);
+    }
+    #[doc = "Data Pulse Interrupt Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DPIS(&self) -> bool {
+        let val = (self.0 >> 22usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Data Pulse Interrupt Status."]
+    #[inline(always)]
+    pub const fn set_DPIS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 22usize)) | (((val as u32) & 0x01) << 22usize);
+    }
+    #[doc = "USB ID Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn IDIE(&self) -> bool {
+        let val = (self.0 >> 24usize) & 0x01;
+        val != 0
+    }
+    #[doc = "USB ID Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_IDIE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 24usize)) | (((val as u32) & 0x01) << 24usize);
+    }
+    #[doc = "A VBUS Valid Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AVVIE(&self) -> bool {
+        let val = (self.0 >> 25usize) & 0x01;
+        val != 0
+    }
+    #[doc = "A VBUS Valid Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_AVVIE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 25usize)) | (((val as u32) & 0x01) << 25usize);
+    }
+    #[doc = "A Session Valid Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ASVIE(&self) -> bool {
+        let val = (self.0 >> 26usize) & 0x01;
+        val != 0
+    }
+    #[doc = "A Session Valid Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_ASVIE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 26usize)) | (((val as u32) & 0x01) << 26usize);
+    }
+    #[doc = "B Session Valid Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BSVIE(&self) -> bool {
+        let val = (self.0 >> 27usize) & 0x01;
+        val != 0
+    }
+    #[doc = "B Session Valid Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_BSVIE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 27usize)) | (((val as u32) & 0x01) << 27usize);
+    }
+    #[doc = "B Session End Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BSEIE(&self) -> bool {
+        let val = (self.0 >> 28usize) & 0x01;
+        val != 0
+    }
+    #[doc = "B Session End Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_BSEIE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 28usize)) | (((val as u32) & 0x01) << 28usize);
+    }
+    #[doc = "1 Millisecond Timer Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EN_1MS(&self) -> bool {
+        let val = (self.0 >> 29usize) & 0x01;
+        val != 0
+    }
+    #[doc = "1 Millisecond Timer Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_EN_1MS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 29usize)) | (((val as u32) & 0x01) << 29usize);
+    }
+    #[doc = "Data Pulse Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DPIE(&self) -> bool {
+        let val = (self.0 >> 30usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Data Pulse Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_DPIE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val as u32) & 0x01) << 30usize);
+    }
+}
+impl Default for OTGSC {
+    #[inline(always)]
+    fn default() -> OTGSC {
+        OTGSC(0)
+    }
+}
+impl core::fmt::Debug for OTGSC {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("OTGSC")
+            .field("VD", &self.VD())
+            .field("VC", &self.VC())
+            .field("HAAR", &self.HAAR())
+            .field("OT", &self.OT())
+            .field("DP", &self.DP())
+            .field("IDPU", &self.IDPU())
+            .field("HADP", &self.HADP())
+            .field("HABA", &self.HABA())
+            .field("ID", &self.ID())
+            .field("AVV", &self.AVV())
+            .field("ASV", &self.ASV())
+            .field("BSV", &self.BSV())
+            .field("BSE", &self.BSE())
+            .field("TOG_1MS", &self.TOG_1MS())
+            .field("DPS", &self.DPS())
+            .field("IDIS", &self.IDIS())
+            .field("AVVIS", &self.AVVIS())
+            .field("ASVIS", &self.ASVIS())
+            .field("BSVIS", &self.BSVIS())
+            .field("BSEIS", &self.BSEIS())
+            .field("STATUS_1MS", &self.STATUS_1MS())
+            .field("DPIS", &self.DPIS())
+            .field("IDIE", &self.IDIE())
+            .field("AVVIE", &self.AVVIE())
+            .field("ASVIE", &self.ASVIE())
+            .field("BSVIE", &self.BSVIE())
+            .field("BSEIE", &self.BSEIE())
+            .field("EN_1MS", &self.EN_1MS())
+            .field("DPIE", &self.DPIE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for OTGSC {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "OTGSC {{ VD: {=bool:?}, VC: {=bool:?}, HAAR: {:?}, OT: {=bool:?}, DP: {=bool:?}, IDPU: {=bool:?}, HADP: {:?}, HABA: {:?}, ID: {:?}, AVV: {=bool:?}, ASV: {=bool:?}, BSV: {=bool:?}, BSE: {=bool:?}, TOG_1MS: {=bool:?}, DPS: {=bool:?}, IDIS: {=bool:?}, AVVIS: {=bool:?}, ASVIS: {=bool:?}, BSVIS: {=bool:?}, BSEIS: {=bool:?}, STATUS_1MS: {=bool:?}, DPIS: {=bool:?}, IDIE: {=bool:?}, AVVIE: {=bool:?}, ASVIE: {=bool:?}, BSVIE: {=bool:?}, BSEIE: {=bool:?}, EN_1MS: {=bool:?}, DPIE: {=bool:?} }}",
+            self.VD(),
+            self.VC(),
+            self.HAAR(),
+            self.OT(),
+            self.DP(),
+            self.IDPU(),
+            self.HADP(),
+            self.HABA(),
+            self.ID(),
+            self.AVV(),
+            self.ASV(),
+            self.BSV(),
+            self.BSE(),
+            self.TOG_1MS(),
+            self.DPS(),
+            self.IDIS(),
+            self.AVVIS(),
+            self.ASVIS(),
+            self.BSVIS(),
+            self.BSEIS(),
+            self.STATUS_1MS(),
+            self.DPIS(),
+            self.IDIE(),
+            self.AVVIE(),
+            self.ASVIE(),
+            self.BSVIE(),
+            self.BSEIE(),
+            self.EN_1MS(),
+            self.DPIE()
+        )
+    }
+}
+#[doc = "Frame List Base Address."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PERIODICLISTBASE(pub u32);
+impl PERIODICLISTBASE {
+    #[doc = "Base Address (Low)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BASEADR(&self) -> u32 {
+        let val = (self.0 >> 12usize) & 0x000f_ffff;
+        val as u32
+    }
+    #[doc = "Base Address (Low)."]
+    #[inline(always)]
+    pub const fn set_BASEADR(&mut self, val: u32) {
+        self.0 = (self.0 & !(0x000f_ffff << 12usize)) | (((val as u32) & 0x000f_ffff) << 12usize);
+    }
+}
+impl Default for PERIODICLISTBASE {
+    #[inline(always)]
+    fn default() -> PERIODICLISTBASE {
+        PERIODICLISTBASE(0)
+    }
+}
+impl core::fmt::Debug for PERIODICLISTBASE {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PERIODICLISTBASE")
+            .field("BASEADR", &self.BASEADR())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PERIODICLISTBASE {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PERIODICLISTBASE {{ BASEADR: {=u32:?} }}",
+            self.BASEADR()
+        )
+    }
+}
+#[doc = "Port Status and Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PORTSC1(pub u32);
+impl PORTSC1 {
+    #[doc = "Current Connect Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CCS(&self) -> CCS {
+        let val = (self.0 >> 0usize) & 0x01;
+        CCS::from_bits(val as u8)
+    }
+    #[doc = "Current Connect Status."]
+    #[inline(always)]
+    pub const fn set_CCS(&mut self, val: CCS) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Connect Status Change Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CSC(&self) -> CSC {
+        let val = (self.0 >> 1usize) & 0x01;
+        CSC::from_bits(val as u8)
+    }
+    #[doc = "Connect Status Change Flag."]
+    #[inline(always)]
+    pub const fn set_CSC(&mut self, val: CSC) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val.to_bits() as u32) & 0x01) << 1usize);
+    }
+    #[doc = "Port Enable and Disable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PE(&self) -> PE {
+        let val = (self.0 >> 2usize) & 0x01;
+        PE::from_bits(val as u8)
+    }
+    #[doc = "Port Enable and Disable."]
+    #[inline(always)]
+    pub const fn set_PE(&mut self, val: PE) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val.to_bits() as u32) & 0x01) << 2usize);
+    }
+    #[doc = "Port Enable and Disable Change Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PEC(&self) -> PEC {
+        let val = (self.0 >> 3usize) & 0x01;
+        PEC::from_bits(val as u8)
+    }
+    #[doc = "Port Enable and Disable Change Flag."]
+    #[inline(always)]
+    pub const fn set_PEC(&mut self, val: PEC) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val.to_bits() as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Overcurrent Active."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OCA(&self) -> OCA {
+        let val = (self.0 >> 4usize) & 0x01;
+        OCA::from_bits(val as u8)
+    }
+    #[doc = "Overcurrent Active."]
+    #[inline(always)]
+    pub const fn set_OCA(&mut self, val: OCA) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u32) & 0x01) << 4usize);
+    }
+    #[doc = "Overcurrent Change Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OCC(&self) -> OCC {
+        let val = (self.0 >> 5usize) & 0x01;
+        OCC::from_bits(val as u8)
+    }
+    #[doc = "Overcurrent Change Flag."]
+    #[inline(always)]
+    pub const fn set_OCC(&mut self, val: OCC) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "Force Port Resume."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn FPR(&self) -> FPR {
+        let val = (self.0 >> 6usize) & 0x01;
+        FPR::from_bits(val as u8)
+    }
+    #[doc = "Force Port Resume."]
+    #[inline(always)]
+    pub const fn set_FPR(&mut self, val: FPR) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "Suspend."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SUSP(&self) -> SUSP {
+        let val = (self.0 >> 7usize) & 0x01;
+        SUSP::from_bits(val as u8)
+    }
+    #[doc = "Suspend."]
+    #[inline(always)]
+    pub const fn set_SUSP(&mut self, val: SUSP) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "Port Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PR(&self) -> PR {
+        let val = (self.0 >> 8usize) & 0x01;
+        PR::from_bits(val as u8)
+    }
+    #[doc = "Port Reset."]
+    #[inline(always)]
+    pub const fn set_PR(&mut self, val: PR) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val.to_bits() as u32) & 0x01) << 8usize);
+    }
+    #[doc = "High-Speed Port."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HSP(&self) -> HSP {
+        let val = (self.0 >> 9usize) & 0x01;
+        HSP::from_bits(val as u8)
+    }
+    #[doc = "High-Speed Port."]
+    #[inline(always)]
+    pub const fn set_HSP(&mut self, val: HSP) {
+        self.0 = (self.0 & !(0x01 << 9usize)) | (((val.to_bits() as u32) & 0x01) << 9usize);
+    }
+    #[doc = "Line Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LS(&self) -> LS {
+        let val = (self.0 >> 10usize) & 0x03;
+        LS::from_bits(val as u8)
+    }
+    #[doc = "Line Status."]
+    #[inline(always)]
+    pub const fn set_LS(&mut self, val: LS) {
+        self.0 = (self.0 & !(0x03 << 10usize)) | (((val.to_bits() as u32) & 0x03) << 10usize);
+    }
+    #[doc = "Port Power (PP)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PP(&self) -> PP {
+        let val = (self.0 >> 12usize) & 0x01;
+        PP::from_bits(val as u8)
+    }
+    #[doc = "Port Power (PP)."]
+    #[inline(always)]
+    pub const fn set_PP(&mut self, val: PP) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val.to_bits() as u32) & 0x01) << 12usize);
+    }
+    #[doc = "Port Owner."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PO(&self) -> bool {
+        let val = (self.0 >> 13usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Port Owner."]
+    #[inline(always)]
+    pub const fn set_PO(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val as u32) & 0x01) << 13usize);
+    }
+    #[doc = "Port Indicator Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PIC(&self) -> PIC {
+        let val = (self.0 >> 14usize) & 0x03;
+        PIC::from_bits(val as u8)
+    }
+    #[doc = "Port Indicator Control."]
+    #[inline(always)]
+    pub const fn set_PIC(&mut self, val: PIC) {
+        self.0 = (self.0 & !(0x03 << 14usize)) | (((val.to_bits() as u32) & 0x03) << 14usize);
+    }
+    #[doc = "Port Test Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PTC(&self) -> PTC {
+        let val = (self.0 >> 16usize) & 0x0f;
+        PTC::from_bits(val as u8)
+    }
+    #[doc = "Port Test Control."]
+    #[inline(always)]
+    pub const fn set_PTC(&mut self, val: PTC) {
+        self.0 = (self.0 & !(0x0f << 16usize)) | (((val.to_bits() as u32) & 0x0f) << 16usize);
+    }
+    #[doc = "Wake on Connect Enable (WKCNNT_E)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WKCN(&self) -> WKCN {
+        let val = (self.0 >> 20usize) & 0x01;
+        WKCN::from_bits(val as u8)
+    }
+    #[doc = "Wake on Connect Enable (WKCNNT_E)."]
+    #[inline(always)]
+    pub const fn set_WKCN(&mut self, val: WKCN) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val.to_bits() as u32) & 0x01) << 20usize);
+    }
+    #[doc = "Wake on Disconnect Enable (WKDSCNNT_E)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WKDC(&self) -> WKDC {
+        let val = (self.0 >> 21usize) & 0x01;
+        WKDC::from_bits(val as u8)
+    }
+    #[doc = "Wake on Disconnect Enable (WKDSCNNT_E)."]
+    #[inline(always)]
+    pub const fn set_WKDC(&mut self, val: WKDC) {
+        self.0 = (self.0 & !(0x01 << 21usize)) | (((val.to_bits() as u32) & 0x01) << 21usize);
+    }
+    #[doc = "Wake on Overcurrent Enable (WKOC)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WKOC(&self) -> bool {
+        let val = (self.0 >> 22usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Wake on Overcurrent Enable (WKOC)."]
+    #[inline(always)]
+    pub const fn set_WKOC(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 22usize)) | (((val as u32) & 0x01) << 22usize);
+    }
+    #[doc = "PHY Low-Power Suspend - Clock Disable (PLPSCD)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PHCD(&self) -> PHCD {
+        let val = (self.0 >> 23usize) & 0x01;
+        PHCD::from_bits(val as u8)
+    }
+    #[doc = "PHY Low-Power Suspend - Clock Disable (PLPSCD)."]
+    #[inline(always)]
+    pub const fn set_PHCD(&mut self, val: PHCD) {
+        self.0 = (self.0 & !(0x01 << 23usize)) | (((val.to_bits() as u32) & 0x01) << 23usize);
+    }
+    #[doc = "Port Force Full Speed Connect."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFSC(&self) -> PFSC {
+        let val = (self.0 >> 24usize) & 0x01;
+        PFSC::from_bits(val as u8)
+    }
+    #[doc = "Port Force Full Speed Connect."]
+    #[inline(always)]
+    pub const fn set_PFSC(&mut self, val: PFSC) {
+        self.0 = (self.0 & !(0x01 << 24usize)) | (((val.to_bits() as u32) & 0x01) << 24usize);
+    }
+    #[doc = "Parallel Transceiver Select 2."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PTS_2(&self) -> bool {
+        let val = (self.0 >> 25usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Parallel Transceiver Select 2."]
+    #[inline(always)]
+    pub const fn set_PTS_2(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 25usize)) | (((val as u32) & 0x01) << 25usize);
+    }
+    #[doc = "Port Speed."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PSPD(&self) -> PSPD {
+        let val = (self.0 >> 26usize) & 0x03;
+        PSPD::from_bits(val as u8)
+    }
+    #[doc = "Port Speed."]
+    #[inline(always)]
+    pub const fn set_PSPD(&mut self, val: PSPD) {
+        self.0 = (self.0 & !(0x03 << 26usize)) | (((val.to_bits() as u32) & 0x03) << 26usize);
+    }
+    #[doc = "Parallel Transceiver Width."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PTW(&self) -> PTW {
+        let val = (self.0 >> 28usize) & 0x01;
+        PTW::from_bits(val as u8)
+    }
+    #[doc = "Parallel Transceiver Width."]
+    #[inline(always)]
+    pub const fn set_PTW(&mut self, val: PTW) {
+        self.0 = (self.0 & !(0x01 << 28usize)) | (((val.to_bits() as u32) & 0x01) << 28usize);
+    }
+    #[doc = "Serial Transceiver Select."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn STS(&self) -> STS {
+        let val = (self.0 >> 29usize) & 0x01;
+        STS::from_bits(val as u8)
+    }
+    #[doc = "Serial Transceiver Select."]
+    #[inline(always)]
+    pub const fn set_STS(&mut self, val: STS) {
+        self.0 = (self.0 & !(0x01 << 29usize)) | (((val.to_bits() as u32) & 0x01) << 29usize);
+    }
+    #[doc = "Parallel Transceiver Select 1."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PTS_1(&self) -> u8 {
+        let val = (self.0 >> 30usize) & 0x03;
+        val as u8
+    }
+    #[doc = "Parallel Transceiver Select 1."]
+    #[inline(always)]
+    pub const fn set_PTS_1(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 30usize)) | (((val as u32) & 0x03) << 30usize);
+    }
+}
+impl Default for PORTSC1 {
+    #[inline(always)]
+    fn default() -> PORTSC1 {
+        PORTSC1(0)
+    }
+}
+impl core::fmt::Debug for PORTSC1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PORTSC1")
+            .field("CCS", &self.CCS())
+            .field("CSC", &self.CSC())
+            .field("PE", &self.PE())
+            .field("PEC", &self.PEC())
+            .field("OCA", &self.OCA())
+            .field("OCC", &self.OCC())
+            .field("FPR", &self.FPR())
+            .field("SUSP", &self.SUSP())
+            .field("PR", &self.PR())
+            .field("HSP", &self.HSP())
+            .field("LS", &self.LS())
+            .field("PP", &self.PP())
+            .field("PO", &self.PO())
+            .field("PIC", &self.PIC())
+            .field("PTC", &self.PTC())
+            .field("WKCN", &self.WKCN())
+            .field("WKDC", &self.WKDC())
+            .field("WKOC", &self.WKOC())
+            .field("PHCD", &self.PHCD())
+            .field("PFSC", &self.PFSC())
+            .field("PTS_2", &self.PTS_2())
+            .field("PSPD", &self.PSPD())
+            .field("PTW", &self.PTW())
+            .field("STS", &self.STS())
+            .field("PTS_1", &self.PTS_1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PORTSC1 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PORTSC1 {{ CCS: {:?}, CSC: {:?}, PE: {:?}, PEC: {:?}, OCA: {:?}, OCC: {:?}, FPR: {:?}, SUSP: {:?}, PR: {:?}, HSP: {:?}, LS: {:?}, PP: {:?}, PO: {=bool:?}, PIC: {:?}, PTC: {:?}, WKCN: {:?}, WKDC: {:?}, WKOC: {=bool:?}, PHCD: {:?}, PFSC: {:?}, PTS_2: {=bool:?}, PSPD: {:?}, PTW: {:?}, STS: {:?}, PTS_1: {=u8:?} }}",
+            self.CCS(),
+            self.CSC(),
+            self.PE(),
+            self.PEC(),
+            self.OCA(),
+            self.OCC(),
+            self.FPR(),
+            self.SUSP(),
+            self.PR(),
+            self.HSP(),
+            self.LS(),
+            self.PP(),
+            self.PO(),
+            self.PIC(),
+            self.PTC(),
+            self.WKCN(),
+            self.WKDC(),
+            self.WKOC(),
+            self.PHCD(),
+            self.PFSC(),
+            self.PTS_2(),
+            self.PSPD(),
+            self.PTW(),
+            self.STS(),
+            self.PTS_1()
+        )
+    }
+}
+#[doc = "System Bus Configuration."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct SBUSCFG(pub u32);
+impl SBUSCFG {
+    #[doc = "AHB Manager Interface Burst Configuration."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AHBBRST(&self) -> AHBBRST {
+        let val = (self.0 >> 0usize) & 0x07;
+        AHBBRST::from_bits(val as u8)
+    }
+    #[doc = "AHB Manager Interface Burst Configuration."]
+    #[inline(always)]
+    pub const fn set_AHBBRST(&mut self, val: AHBBRST) {
+        self.0 = (self.0 & !(0x07 << 0usize)) | (((val.to_bits() as u32) & 0x07) << 0usize);
+    }
+}
+impl Default for SBUSCFG {
+    #[inline(always)]
+    fn default() -> SBUSCFG {
+        SBUSCFG(0)
+    }
+}
+impl core::fmt::Debug for SBUSCFG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SBUSCFG")
+            .field("AHBBRST", &self.AHBBRST())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SBUSCFG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "SBUSCFG {{ AHBBRST: {:?} }}", self.AHBBRST())
+    }
+}
+#[doc = "TX FIFO Fill Tuning."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct TXFILLTUNING(pub u32);
+impl TXFILLTUNING {
+    #[doc = "Scheduler Overhead."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXSCHOH(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0x7f;
+        val as u8
+    }
+    #[doc = "Scheduler Overhead."]
+    #[inline(always)]
+    pub const fn set_TXSCHOH(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x7f << 0usize)) | (((val as u32) & 0x7f) << 0usize);
+    }
+    #[doc = "Scheduler Health Counter."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXSCHHEALTH(&self) -> u8 {
+        let val = (self.0 >> 8usize) & 0x1f;
+        val as u8
+    }
+    #[doc = "Scheduler Health Counter."]
+    #[inline(always)]
+    pub const fn set_TXSCHHEALTH(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x1f << 8usize)) | (((val as u32) & 0x1f) << 8usize);
+    }
+    #[doc = "FIFO Burst Threshold."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXFIFOTHRES(&self) -> u8 {
+        let val = (self.0 >> 16usize) & 0x3f;
+        val as u8
+    }
+    #[doc = "FIFO Burst Threshold."]
+    #[inline(always)]
+    pub const fn set_TXFIFOTHRES(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x3f << 16usize)) | (((val as u32) & 0x3f) << 16usize);
+    }
+}
+impl Default for TXFILLTUNING {
+    #[inline(always)]
+    fn default() -> TXFILLTUNING {
+        TXFILLTUNING(0)
+    }
+}
+impl core::fmt::Debug for TXFILLTUNING {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TXFILLTUNING")
+            .field("TXSCHOH", &self.TXSCHOH())
+            .field("TXSCHHEALTH", &self.TXSCHHEALTH())
+            .field("TXFIFOTHRES", &self.TXFIFOTHRES())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TXFILLTUNING {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "TXFILLTUNING {{ TXSCHOH: {=u8:?}, TXSCHHEALTH: {=u8:?}, TXFIFOTHRES: {=u8:?} }}",
+            self.TXSCHOH(),
+            self.TXSCHHEALTH(),
+            self.TXFIFOTHRES()
+        )
+    }
+}
+#[doc = "USB Command."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USBCMD(pub u32);
+impl USBCMD {
+    #[doc = "Run/Stop."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RS(&self) -> RS {
+        let val = (self.0 >> 0usize) & 0x01;
+        RS::from_bits(val as u8)
+    }
+    #[doc = "Run/Stop."]
+    #[inline(always)]
+    pub const fn set_RS(&mut self, val: RS) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Controller Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RST(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Controller Reset."]
+    #[inline(always)]
+    pub const fn set_RST(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "Frame List Size 1."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn FS_1(&self) -> u8 {
+        let val = (self.0 >> 2usize) & 0x03;
+        val as u8
+    }
+    #[doc = "Frame List Size 1."]
+    #[inline(always)]
+    pub const fn set_FS_1(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val as u32) & 0x03) << 2usize);
+    }
+    #[doc = "Periodic Schedule Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PSE(&self) -> PSE {
+        let val = (self.0 >> 4usize) & 0x01;
+        PSE::from_bits(val as u8)
+    }
+    #[doc = "Periodic Schedule Enable."]
+    #[inline(always)]
+    pub const fn set_PSE(&mut self, val: PSE) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u32) & 0x01) << 4usize);
+    }
+    #[doc = "Asynchronous Schedule Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ASE(&self) -> ASE {
+        let val = (self.0 >> 5usize) & 0x01;
+        ASE::from_bits(val as u8)
+    }
+    #[doc = "Asynchronous Schedule Enable."]
+    #[inline(always)]
+    pub const fn set_ASE(&mut self, val: ASE) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "Interrupt on Async Advance Doorbell."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn IAA(&self) -> bool {
+        let val = (self.0 >> 6usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Interrupt on Async Advance Doorbell."]
+    #[inline(always)]
+    pub const fn set_IAA(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val as u32) & 0x01) << 6usize);
+    }
+    #[doc = "Asynchronous Schedule Park Mode Count."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ASP(&self) -> u8 {
+        let val = (self.0 >> 8usize) & 0x03;
+        val as u8
+    }
+    #[doc = "Asynchronous Schedule Park Mode Count."]
+    #[inline(always)]
+    pub const fn set_ASP(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 8usize)) | (((val as u32) & 0x03) << 8usize);
+    }
+    #[doc = "Asynchronous Schedule Park Mode Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ASPE(&self) -> ASPE {
+        let val = (self.0 >> 11usize) & 0x01;
+        ASPE::from_bits(val as u8)
+    }
+    #[doc = "Asynchronous Schedule Park Mode Enable."]
+    #[inline(always)]
+    pub const fn set_ASPE(&mut self, val: ASPE) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val.to_bits() as u32) & 0x01) << 11usize);
+    }
+    #[doc = "Setup Trip Wire (Device mode only)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SUTW(&self) -> bool {
+        let val = (self.0 >> 13usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Setup Trip Wire (Device mode only)."]
+    #[inline(always)]
+    pub const fn set_SUTW(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val as u32) & 0x01) << 13usize);
+    }
+    #[doc = "Add dTD Trip Wire (Device mode only)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ATDTW(&self) -> bool {
+        let val = (self.0 >> 14usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Add dTD Trip Wire (Device mode only)."]
+    #[inline(always)]
+    pub const fn set_ATDTW(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 14usize)) | (((val as u32) & 0x01) << 14usize);
+    }
+    #[doc = "Frame List Size 2 (Host mode only)."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn FS_2(&self) -> bool {
+        let val = (self.0 >> 15usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Frame List Size 2 (Host mode only)."]
+    #[inline(always)]
+    pub const fn set_FS_2(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 15usize)) | (((val as u32) & 0x01) << 15usize);
+    }
+    #[doc = "Interrupt Threshold Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ITC(&self) -> ITC {
+        let val = (self.0 >> 16usize) & 0xff;
+        ITC::from_bits(val as u8)
+    }
+    #[doc = "Interrupt Threshold Control."]
+    #[inline(always)]
+    pub const fn set_ITC(&mut self, val: ITC) {
+        self.0 = (self.0 & !(0xff << 16usize)) | (((val.to_bits() as u32) & 0xff) << 16usize);
+    }
+}
+impl Default for USBCMD {
+    #[inline(always)]
+    fn default() -> USBCMD {
+        USBCMD(0)
+    }
+}
+impl core::fmt::Debug for USBCMD {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USBCMD")
+            .field("RS", &self.RS())
+            .field("RST", &self.RST())
+            .field("FS_1", &self.FS_1())
+            .field("PSE", &self.PSE())
+            .field("ASE", &self.ASE())
+            .field("IAA", &self.IAA())
+            .field("ASP", &self.ASP())
+            .field("ASPE", &self.ASPE())
+            .field("SUTW", &self.SUTW())
+            .field("ATDTW", &self.ATDTW())
+            .field("FS_2", &self.FS_2())
+            .field("ITC", &self.ITC())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USBCMD {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USBCMD {{ RS: {:?}, RST: {=bool:?}, FS_1: {=u8:?}, PSE: {:?}, ASE: {:?}, IAA: {=bool:?}, ASP: {=u8:?}, ASPE: {:?}, SUTW: {=bool:?}, ATDTW: {=bool:?}, FS_2: {=bool:?}, ITC: {:?} }}",
+            self.RS(),
+            self.RST(),
+            self.FS_1(),
+            self.PSE(),
+            self.ASE(),
+            self.IAA(),
+            self.ASP(),
+            self.ASPE(),
+            self.SUTW(),
+            self.ATDTW(),
+            self.FS_2(),
+            self.ITC()
+        )
+    }
+}
+#[doc = "Interrupt Enable."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USBINTR(pub u32);
+impl USBINTR {
+    #[doc = "USB Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn UE(&self) -> UE {
+        let val = (self.0 >> 0usize) & 0x01;
+        UE::from_bits(val as u8)
+    }
+    #[doc = "USB Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_UE(&mut self, val: UE) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "USB Error Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn UEE(&self) -> UEE {
+        let val = (self.0 >> 1usize) & 0x01;
+        UEE::from_bits(val as u8)
+    }
+    #[doc = "USB Error Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_UEE(&mut self, val: UEE) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val.to_bits() as u32) & 0x01) << 1usize);
+    }
+    #[doc = "Port Change Detect Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PCE(&self) -> PCE {
+        let val = (self.0 >> 2usize) & 0x01;
+        PCE::from_bits(val as u8)
+    }
+    #[doc = "Port Change Detect Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_PCE(&mut self, val: PCE) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val.to_bits() as u32) & 0x01) << 2usize);
+    }
+    #[doc = "Frame List Rollover Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn FRE(&self) -> FRE {
+        let val = (self.0 >> 3usize) & 0x01;
+        FRE::from_bits(val as u8)
+    }
+    #[doc = "Frame List Rollover Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_FRE(&mut self, val: FRE) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val.to_bits() as u32) & 0x01) << 3usize);
+    }
+    #[doc = "System Error Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SEE(&self) -> SEE {
+        let val = (self.0 >> 4usize) & 0x01;
+        SEE::from_bits(val as u8)
+    }
+    #[doc = "System Error Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_SEE(&mut self, val: SEE) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u32) & 0x01) << 4usize);
+    }
+    #[doc = "Asynchronous Advance Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AAE(&self) -> AAE {
+        let val = (self.0 >> 5usize) & 0x01;
+        AAE::from_bits(val as u8)
+    }
+    #[doc = "Asynchronous Advance Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_AAE(&mut self, val: AAE) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "USB Reset Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn URE(&self) -> URE {
+        let val = (self.0 >> 6usize) & 0x01;
+        URE::from_bits(val as u8)
+    }
+    #[doc = "USB Reset Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_URE(&mut self, val: URE) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "SOF Received Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SRE(&self) -> SRE {
+        let val = (self.0 >> 7usize) & 0x01;
+        SRE::from_bits(val as u8)
+    }
+    #[doc = "SOF Received Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_SRE(&mut self, val: SRE) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "Sleep Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SLE(&self) -> SLE {
+        let val = (self.0 >> 8usize) & 0x01;
+        SLE::from_bits(val as u8)
+    }
+    #[doc = "Sleep Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_SLE(&mut self, val: SLE) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val.to_bits() as u32) & 0x01) << 8usize);
+    }
+    #[doc = "NAK Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn NAKE(&self) -> NAKE {
+        let val = (self.0 >> 16usize) & 0x01;
+        NAKE::from_bits(val as u8)
+    }
+    #[doc = "NAK Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_NAKE(&mut self, val: NAKE) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val.to_bits() as u32) & 0x01) << 16usize);
+    }
+    #[doc = "USB Host Asynchronous Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn UAIE(&self) -> UAIE {
+        let val = (self.0 >> 18usize) & 0x01;
+        UAIE::from_bits(val as u8)
+    }
+    #[doc = "USB Host Asynchronous Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_UAIE(&mut self, val: UAIE) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val.to_bits() as u32) & 0x01) << 18usize);
+    }
+    #[doc = "USB Host Periodic Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn UPIE(&self) -> UPIE {
+        let val = (self.0 >> 19usize) & 0x01;
+        UPIE::from_bits(val as u8)
+    }
+    #[doc = "USB Host Periodic Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_UPIE(&mut self, val: UPIE) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val.to_bits() as u32) & 0x01) << 19usize);
+    }
+    #[doc = "General Purpose Timer 0 Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TIE0(&self) -> TIE0 {
+        let val = (self.0 >> 24usize) & 0x01;
+        TIE0::from_bits(val as u8)
+    }
+    #[doc = "General Purpose Timer 0 Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_TIE0(&mut self, val: TIE0) {
+        self.0 = (self.0 & !(0x01 << 24usize)) | (((val.to_bits() as u32) & 0x01) << 24usize);
+    }
+    #[doc = "General Purpose Timer 1 Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TIE1(&self) -> TIE1 {
+        let val = (self.0 >> 25usize) & 0x01;
+        TIE1::from_bits(val as u8)
+    }
+    #[doc = "General Purpose Timer 1 Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_TIE1(&mut self, val: TIE1) {
+        self.0 = (self.0 & !(0x01 << 25usize)) | (((val.to_bits() as u32) & 0x01) << 25usize);
+    }
+    #[doc = "L1 Exit Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_L1_EXITIE(&self) -> LPM_L1_EXITIE {
+        let val = (self.0 >> 28usize) & 0x01;
+        LPM_L1_EXITIE::from_bits(val as u8)
+    }
+    #[doc = "L1 Exit Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_LPM_L1_EXITIE(&mut self, val: LPM_L1_EXITIE) {
+        self.0 = (self.0 & !(0x01 << 28usize)) | (((val.to_bits() as u32) & 0x01) << 28usize);
+    }
+    #[doc = "L1 Entry Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_L1_ENTRYIE(&self) -> LPM_L1_ENTRYIE {
+        let val = (self.0 >> 29usize) & 0x01;
+        LPM_L1_ENTRYIE::from_bits(val as u8)
+    }
+    #[doc = "L1 Entry Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_LPM_L1_ENTRYIE(&mut self, val: LPM_L1_ENTRYIE) {
+        self.0 = (self.0 & !(0x01 << 29usize)) | (((val.to_bits() as u32) & 0x01) << 29usize);
+    }
+    #[doc = "Device Received Extension Token Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_DEV_RCVDIE(&self) -> LPM_DEV_RCVDIE {
+        let val = (self.0 >> 30usize) & 0x01;
+        LPM_DEV_RCVDIE::from_bits(val as u8)
+    }
+    #[doc = "Device Received Extension Token Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_LPM_DEV_RCVDIE(&mut self, val: LPM_DEV_RCVDIE) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val.to_bits() as u32) & 0x01) << 30usize);
+    }
+    #[doc = "Host Completed LPM Transaction Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_HST_COMPIE(&self) -> LPM_HST_COMPIE {
+        let val = (self.0 >> 31usize) & 0x01;
+        LPM_HST_COMPIE::from_bits(val as u8)
+    }
+    #[doc = "Host Completed LPM Transaction Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_LPM_HST_COMPIE(&mut self, val: LPM_HST_COMPIE) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val.to_bits() as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for USBINTR {
+    #[inline(always)]
+    fn default() -> USBINTR {
+        USBINTR(0)
+    }
+}
+impl core::fmt::Debug for USBINTR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USBINTR")
+            .field("UE", &self.UE())
+            .field("UEE", &self.UEE())
+            .field("PCE", &self.PCE())
+            .field("FRE", &self.FRE())
+            .field("SEE", &self.SEE())
+            .field("AAE", &self.AAE())
+            .field("URE", &self.URE())
+            .field("SRE", &self.SRE())
+            .field("SLE", &self.SLE())
+            .field("NAKE", &self.NAKE())
+            .field("UAIE", &self.UAIE())
+            .field("UPIE", &self.UPIE())
+            .field("TIE0", &self.TIE0())
+            .field("TIE1", &self.TIE1())
+            .field("LPM_L1_EXITIE", &self.LPM_L1_EXITIE())
+            .field("LPM_L1_ENTRYIE", &self.LPM_L1_ENTRYIE())
+            .field("LPM_DEV_RCVDIE", &self.LPM_DEV_RCVDIE())
+            .field("LPM_HST_COMPIE", &self.LPM_HST_COMPIE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USBINTR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USBINTR {{ UE: {:?}, UEE: {:?}, PCE: {:?}, FRE: {:?}, SEE: {:?}, AAE: {:?}, URE: {:?}, SRE: {:?}, SLE: {:?}, NAKE: {:?}, UAIE: {:?}, UPIE: {:?}, TIE0: {:?}, TIE1: {:?}, LPM_L1_EXITIE: {:?}, LPM_L1_ENTRYIE: {:?}, LPM_DEV_RCVDIE: {:?}, LPM_HST_COMPIE: {:?} }}",
+            self.UE(),
+            self.UEE(),
+            self.PCE(),
+            self.FRE(),
+            self.SEE(),
+            self.AAE(),
+            self.URE(),
+            self.SRE(),
+            self.SLE(),
+            self.NAKE(),
+            self.UAIE(),
+            self.UPIE(),
+            self.TIE0(),
+            self.TIE1(),
+            self.LPM_L1_EXITIE(),
+            self.LPM_L1_ENTRYIE(),
+            self.LPM_DEV_RCVDIE(),
+            self.LPM_HST_COMPIE()
+        )
+    }
+}
+#[doc = "USB Device Mode."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USBMODE(pub u32);
+impl USBMODE {
+    #[doc = "Controller Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CM(&self) -> CM {
+        let val = (self.0 >> 0usize) & 0x03;
+        CM::from_bits(val as u8)
+    }
+    #[doc = "Controller Mode."]
+    #[inline(always)]
+    pub const fn set_CM(&mut self, val: CM) {
+        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
+    }
+    #[doc = "Endian Select."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ES(&self) -> ES {
+        let val = (self.0 >> 2usize) & 0x01;
+        ES::from_bits(val as u8)
+    }
+    #[doc = "Endian Select."]
+    #[inline(always)]
+    pub const fn set_ES(&mut self, val: ES) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val.to_bits() as u32) & 0x01) << 2usize);
+    }
+    #[doc = "Setup Lockout Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SLOM(&self) -> SLOM {
+        let val = (self.0 >> 3usize) & 0x01;
+        SLOM::from_bits(val as u8)
+    }
+    #[doc = "Setup Lockout Mode."]
+    #[inline(always)]
+    pub const fn set_SLOM(&mut self, val: SLOM) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val.to_bits() as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Stream Disable Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SDIS(&self) -> SDIS {
+        let val = (self.0 >> 4usize) & 0x01;
+        SDIS::from_bits(val as u8)
+    }
+    #[doc = "Stream Disable Mode."]
+    #[inline(always)]
+    pub const fn set_SDIS(&mut self, val: SDIS) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u32) & 0x01) << 4usize);
+    }
+}
+impl Default for USBMODE {
+    #[inline(always)]
+    fn default() -> USBMODE {
+        USBMODE(0)
+    }
+}
+impl core::fmt::Debug for USBMODE {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USBMODE")
+            .field("CM", &self.CM())
+            .field("ES", &self.ES())
+            .field("SLOM", &self.SLOM())
+            .field("SDIS", &self.SDIS())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USBMODE {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USBMODE {{ CM: {:?}, ES: {:?}, SLOM: {:?}, SDIS: {:?} }}",
+            self.CM(),
+            self.ES(),
+            self.SLOM(),
+            self.SDIS()
+        )
+    }
+}
+#[doc = "USB Status."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USBSTS(pub u32);
+impl USBSTS {
+    #[doc = "USB Interrupt (USBINT) Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn UI(&self) -> UI {
+        let val = (self.0 >> 0usize) & 0x01;
+        UI::from_bits(val as u8)
+    }
+    #[doc = "USB Interrupt (USBINT) Flag."]
+    #[inline(always)]
+    pub const fn set_UI(&mut self, val: UI) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "USB Error Interrupt (USBERRINT) Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn UEI(&self) -> UEI {
+        let val = (self.0 >> 1usize) & 0x01;
+        UEI::from_bits(val as u8)
+    }
+    #[doc = "USB Error Interrupt (USBERRINT) Flag."]
+    #[inline(always)]
+    pub const fn set_UEI(&mut self, val: UEI) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val.to_bits() as u32) & 0x01) << 1usize);
+    }
+    #[doc = "Port Change Detect Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PCI(&self) -> PCI {
+        let val = (self.0 >> 2usize) & 0x01;
+        PCI::from_bits(val as u8)
+    }
+    #[doc = "Port Change Detect Flag."]
+    #[inline(always)]
+    pub const fn set_PCI(&mut self, val: PCI) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val.to_bits() as u32) & 0x01) << 2usize);
+    }
+    #[doc = "Frame List Rollover Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn FRI(&self) -> FRI {
+        let val = (self.0 >> 3usize) & 0x01;
+        FRI::from_bits(val as u8)
+    }
+    #[doc = "Frame List Rollover Flag."]
+    #[inline(always)]
+    pub const fn set_FRI(&mut self, val: FRI) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val.to_bits() as u32) & 0x01) << 3usize);
+    }
+    #[doc = "System Error Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SEI(&self) -> SEI {
+        let val = (self.0 >> 4usize) & 0x01;
+        SEI::from_bits(val as u8)
+    }
+    #[doc = "System Error Flag."]
+    #[inline(always)]
+    pub const fn set_SEI(&mut self, val: SEI) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u32) & 0x01) << 4usize);
+    }
+    #[doc = "Interrupt on Asynchronous Advance Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AAI(&self) -> AAI {
+        let val = (self.0 >> 5usize) & 0x01;
+        AAI::from_bits(val as u8)
+    }
+    #[doc = "Interrupt on Asynchronous Advance Flag."]
+    #[inline(always)]
+    pub const fn set_AAI(&mut self, val: AAI) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "USB Reset Received."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn URI(&self) -> URI {
+        let val = (self.0 >> 6usize) & 0x01;
+        URI::from_bits(val as u8)
+    }
+    #[doc = "USB Reset Received."]
+    #[inline(always)]
+    pub const fn set_URI(&mut self, val: URI) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "SOF Received Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SRI(&self) -> SRI {
+        let val = (self.0 >> 7usize) & 0x01;
+        SRI::from_bits(val as u8)
+    }
+    #[doc = "SOF Received Flag."]
+    #[inline(always)]
+    pub const fn set_SRI(&mut self, val: SRI) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "Device Controller Suspend Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SLI(&self) -> SLI {
+        let val = (self.0 >> 8usize) & 0x01;
+        SLI::from_bits(val as u8)
+    }
+    #[doc = "Device Controller Suspend Flag."]
+    #[inline(always)]
+    pub const fn set_SLI(&mut self, val: SLI) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val.to_bits() as u32) & 0x01) << 8usize);
+    }
+    #[doc = "ULPI Interrupt Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ULPII(&self) -> ULPII {
+        let val = (self.0 >> 10usize) & 0x01;
+        ULPII::from_bits(val as u8)
+    }
+    #[doc = "ULPI Interrupt Flag."]
+    #[inline(always)]
+    pub const fn set_ULPII(&mut self, val: ULPII) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val.to_bits() as u32) & 0x01) << 10usize);
+    }
+    #[doc = "HC Halted."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HCH(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "HC Halted."]
+    #[inline(always)]
+    pub const fn set_HCH(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "Reclamation."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RCL(&self) -> RCL {
+        let val = (self.0 >> 13usize) & 0x01;
+        RCL::from_bits(val as u8)
+    }
+    #[doc = "Reclamation."]
+    #[inline(always)]
+    pub const fn set_RCL(&mut self, val: RCL) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val.to_bits() as u32) & 0x01) << 13usize);
+    }
+    #[doc = "Periodic Schedule Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PS(&self) -> PS {
+        let val = (self.0 >> 14usize) & 0x01;
+        PS::from_bits(val as u8)
+    }
+    #[doc = "Periodic Schedule Status."]
+    #[inline(always)]
+    pub const fn set_PS(&mut self, val: PS) {
+        self.0 = (self.0 & !(0x01 << 14usize)) | (((val.to_bits() as u32) & 0x01) << 14usize);
+    }
+    #[doc = "Asynchronous Schedule Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AS(&self) -> AS {
+        let val = (self.0 >> 15usize) & 0x01;
+        AS::from_bits(val as u8)
+    }
+    #[doc = "Asynchronous Schedule Status."]
+    #[inline(always)]
+    pub const fn set_AS(&mut self, val: AS) {
+        self.0 = (self.0 & !(0x01 << 15usize)) | (((val.to_bits() as u32) & 0x01) << 15usize);
+    }
+    #[doc = "NAK Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn NAKI(&self) -> bool {
+        let val = (self.0 >> 16usize) & 0x01;
+        val != 0
+    }
+    #[doc = "NAK Interrupt."]
+    #[inline(always)]
+    pub const fn set_NAKI(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val as u32) & 0x01) << 16usize);
+    }
+    #[doc = "USB Host Asynchronous Interrupt Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn UAI(&self) -> UAI {
+        let val = (self.0 >> 18usize) & 0x01;
+        UAI::from_bits(val as u8)
+    }
+    #[doc = "USB Host Asynchronous Interrupt Flag."]
+    #[inline(always)]
+    pub const fn set_UAI(&mut self, val: UAI) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val.to_bits() as u32) & 0x01) << 18usize);
+    }
+    #[doc = "USB Host Periodic Interrupt Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn UPI(&self) -> UPI {
+        let val = (self.0 >> 19usize) & 0x01;
+        UPI::from_bits(val as u8)
+    }
+    #[doc = "USB Host Periodic Interrupt Flag."]
+    #[inline(always)]
+    pub const fn set_UPI(&mut self, val: UPI) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val.to_bits() as u32) & 0x01) << 19usize);
+    }
+    #[doc = "General Purpose Timer Interrupt 0 (GPTINT0) Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TI0(&self) -> TI0 {
+        let val = (self.0 >> 24usize) & 0x01;
+        TI0::from_bits(val as u8)
+    }
+    #[doc = "General Purpose Timer Interrupt 0 (GPTINT0) Flag."]
+    #[inline(always)]
+    pub const fn set_TI0(&mut self, val: TI0) {
+        self.0 = (self.0 & !(0x01 << 24usize)) | (((val.to_bits() as u32) & 0x01) << 24usize);
+    }
+    #[doc = "General Purpose Timer Interrupt 1 (GPTINT1) Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TI1(&self) -> TI1 {
+        let val = (self.0 >> 25usize) & 0x01;
+        TI1::from_bits(val as u8)
+    }
+    #[doc = "General Purpose Timer Interrupt 1 (GPTINT1) Flag."]
+    #[inline(always)]
+    pub const fn set_TI1(&mut self, val: TI1) {
+        self.0 = (self.0 & !(0x01 << 25usize)) | (((val.to_bits() as u32) & 0x01) << 25usize);
+    }
+    #[doc = "L1 Exit Interrupt Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_L1_EXITI(&self) -> LPM_L1_EXITI {
+        let val = (self.0 >> 28usize) & 0x01;
+        LPM_L1_EXITI::from_bits(val as u8)
+    }
+    #[doc = "L1 Exit Interrupt Flag."]
+    #[inline(always)]
+    pub const fn set_LPM_L1_EXITI(&mut self, val: LPM_L1_EXITI) {
+        self.0 = (self.0 & !(0x01 << 28usize)) | (((val.to_bits() as u32) & 0x01) << 28usize);
+    }
+    #[doc = "L1 Entry Interrupt Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_L1_ENTRYI(&self) -> LPM_L1_ENTRYI {
+        let val = (self.0 >> 29usize) & 0x01;
+        LPM_L1_ENTRYI::from_bits(val as u8)
+    }
+    #[doc = "L1 Entry Interrupt Flag."]
+    #[inline(always)]
+    pub const fn set_LPM_L1_ENTRYI(&mut self, val: LPM_L1_ENTRYI) {
+        self.0 = (self.0 & !(0x01 << 29usize)) | (((val.to_bits() as u32) & 0x01) << 29usize);
+    }
+    #[doc = "Device Received Extension Token Interrupt Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_DEV_RCVDI(&self) -> LPM_DEV_RCVDI {
+        let val = (self.0 >> 30usize) & 0x01;
+        LPM_DEV_RCVDI::from_bits(val as u8)
+    }
+    #[doc = "Device Received Extension Token Interrupt Flag."]
+    #[inline(always)]
+    pub const fn set_LPM_DEV_RCVDI(&mut self, val: LPM_DEV_RCVDI) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val.to_bits() as u32) & 0x01) << 30usize);
+    }
+    #[doc = "Host Completes the LPM Transaction Interrupt Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_HST_COMPI(&self) -> LPM_HST_COMPI {
+        let val = (self.0 >> 31usize) & 0x01;
+        LPM_HST_COMPI::from_bits(val as u8)
+    }
+    #[doc = "Host Completes the LPM Transaction Interrupt Flag."]
+    #[inline(always)]
+    pub const fn set_LPM_HST_COMPI(&mut self, val: LPM_HST_COMPI) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val.to_bits() as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for USBSTS {
+    #[inline(always)]
+    fn default() -> USBSTS {
+        USBSTS(0)
+    }
+}
+impl core::fmt::Debug for USBSTS {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USBSTS")
+            .field("UI", &self.UI())
+            .field("UEI", &self.UEI())
+            .field("PCI", &self.PCI())
+            .field("FRI", &self.FRI())
+            .field("SEI", &self.SEI())
+            .field("AAI", &self.AAI())
+            .field("URI", &self.URI())
+            .field("SRI", &self.SRI())
+            .field("SLI", &self.SLI())
+            .field("ULPII", &self.ULPII())
+            .field("HCH", &self.HCH())
+            .field("RCL", &self.RCL())
+            .field("PS", &self.PS())
+            .field("AS", &self.AS())
+            .field("NAKI", &self.NAKI())
+            .field("UAI", &self.UAI())
+            .field("UPI", &self.UPI())
+            .field("TI0", &self.TI0())
+            .field("TI1", &self.TI1())
+            .field("LPM_L1_EXITI", &self.LPM_L1_EXITI())
+            .field("LPM_L1_ENTRYI", &self.LPM_L1_ENTRYI())
+            .field("LPM_DEV_RCVDI", &self.LPM_DEV_RCVDI())
+            .field("LPM_HST_COMPI", &self.LPM_HST_COMPI())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USBSTS {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USBSTS {{ UI: {:?}, UEI: {:?}, PCI: {:?}, FRI: {:?}, SEI: {:?}, AAI: {:?}, URI: {:?}, SRI: {:?}, SLI: {:?}, ULPII: {:?}, HCH: {=bool:?}, RCL: {:?}, PS: {:?}, AS: {:?}, NAKI: {=bool:?}, UAI: {:?}, UPI: {:?}, TI0: {:?}, TI1: {:?}, LPM_L1_EXITI: {:?}, LPM_L1_ENTRYI: {:?}, LPM_DEV_RCVDI: {:?}, LPM_HST_COMPI: {:?} }}",
+            self.UI(),
+            self.UEI(),
+            self.PCI(),
+            self.FRI(),
+            self.SEI(),
+            self.AAI(),
+            self.URI(),
+            self.SRI(),
+            self.SLI(),
+            self.ULPII(),
+            self.HCH(),
+            self.RCL(),
+            self.PS(),
+            self.AS(),
+            self.NAKI(),
+            self.UAI(),
+            self.UPI(),
+            self.TI0(),
+            self.TI1(),
+            self.LPM_L1_EXITI(),
+            self.LPM_L1_ENTRYI(),
+            self.LPM_DEV_RCVDI(),
+            self.LPM_HST_COMPI()
+        )
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum AAE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl AAE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> AAE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for AAE {
+    #[inline(always)]
+    fn from(val: u8) -> AAE {
+        AAE::from_bits(val)
+    }
+}
+impl From<AAE> for u8 {
+    #[inline(always)]
+    fn from(val: AAE) -> u8 {
+        AAE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum AAI {
+    #[doc = "Interrupt did not occur."]
+    INT_NO = 0x0,
+    #[doc = "Interrupt occurred."]
+    INT_YES = 0x01,
+}
+impl AAI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> AAI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for AAI {
+    #[inline(always)]
+    fn from(val: u8) -> AAI {
+        AAI::from_bits(val)
+    }
+}
+impl From<AAI> for u8 {
+    #[inline(always)]
+    fn from(val: AAI) -> u8 {
+        AAI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum AHBBRST {
+    #[doc = "Incremental burst of unspecified length only."]
+    INCR_BURST = 0x0,
+    #[doc = "INCR4 burst, then single transfer."]
+    INCR4_BURST = 0x01,
+    #[doc = "INCR8 burst, INCR4 burst, then single transfer."]
+    INCR8_BURST = 0x02,
+    #[doc = "INCR16 burst, INCR8 burst, INCR4 burst, then single transfer."]
+    INCR16_BURST = 0x03,
+    _RESERVED_4 = 0x04,
+    #[doc = "INCR4 burst, then incremental burst of unspecified length."]
+    INCR4_UNSPEC = 0x05,
+    #[doc = "INCR8 burst, INCR4 burst, then incremental burst of unspecified length."]
+    INCR8_4_UNSPEC = 0x06,
+    #[doc = "INCR16 burst, INCR8 burst, INCR4 burst, then incremental burst of unspecified length."]
+    INCR16_8_4_UNSPEC = 0x07,
+}
+impl AHBBRST {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> AHBBRST {
+        unsafe { core::mem::transmute(val & 0x07) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for AHBBRST {
+    #[inline(always)]
+    fn from(val: u8) -> AHBBRST {
+        AHBBRST::from_bits(val)
+    }
+}
+impl From<AHBBRST> for u8 {
+    #[inline(always)]
+    fn from(val: AHBBRST) -> u8 {
+        AHBBRST::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum AS {
+    #[doc = "Disabled."]
+    DISABLE = 0x0,
+    #[doc = "Enabled."]
+    ENABLE = 0x01,
+}
+impl AS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> AS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for AS {
+    #[inline(always)]
+    fn from(val: u8) -> AS {
+        AS::from_bits(val)
+    }
+}
+impl From<AS> for u8 {
+    #[inline(always)]
+    fn from(val: AS) -> u8 {
+        AS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ASE {
+    #[doc = "Do not process the asynchronous schedule."]
+    DONT_PROCESS_ASYNC = 0x0,
+    #[doc = "Access the asynchronous schedule."]
+    ACCESS_ASYNC = 0x01,
+}
+impl ASE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ASE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ASE {
+    #[inline(always)]
+    fn from(val: u8) -> ASE {
+        ASE::from_bits(val)
+    }
+}
+impl From<ASE> for u8 {
+    #[inline(always)]
+    fn from(val: ASE) -> u8 {
+        ASE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ASPE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ASPE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ASPE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ASPE {
+    #[inline(always)]
+    fn from(val: u8) -> ASPE {
+        ASPE::from_bits(val)
+    }
+}
+impl From<ASPE> for u8 {
+    #[inline(always)]
+    fn from(val: ASPE) -> u8 {
+        ASPE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CCS {
+    #[doc = "No device present or attached."]
+    DEVICE_UNAVAILABLE = 0x0,
+    #[doc = "Device present and attached."]
+    DEVICE_AVAILABLE = 0x01,
+}
+impl CCS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> CCS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for CCS {
+    #[inline(always)]
+    fn from(val: u8) -> CCS {
+        CCS::from_bits(val)
+    }
+}
+impl From<CCS> for u8 {
+    #[inline(always)]
+    fn from(val: CCS) -> u8 {
+        CCS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CF {
+    #[doc = "Port routing to classic host controller."]
+    PORT_ROUTING_CLASSIC_HOST = 0x0,
+    #[doc = "Port routing to this host controller."]
+    PORT_ROUTING_HOST = 0x01,
+}
+impl CF {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> CF {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for CF {
+    #[inline(always)]
+    fn from(val: u8) -> CF {
+        CF::from_bits(val)
+    }
+}
+impl From<CF> for u8 {
+    #[inline(always)]
+    fn from(val: CF) -> u8 {
+        CF::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CM {
+    #[doc = "Idle (default for host and device combination)."]
+    IDL = 0x0,
+    _RESERVED_1 = 0x01,
+    #[doc = "Device controller (default for device-only controller)."]
+    DEVICE_CONTR = 0x02,
+    #[doc = "Host controller (default for host-only controller)."]
+    HOST_CONTR = 0x03,
+}
+impl CM {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> CM {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for CM {
+    #[inline(always)]
+    fn from(val: u8) -> CM {
+        CM::from_bits(val)
+    }
+}
+impl From<CM> for u8 {
+    #[inline(always)]
+    fn from(val: CM) -> u8 {
+        CM::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CSC {
+    #[doc = "No change occurred."]
+    NO_CHANGE = 0x0,
+    #[doc = "Change occurred."]
+    CHANGE = 0x01,
+}
+impl CSC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> CSC {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for CSC {
+    #[inline(always)]
+    fn from(val: u8) -> CSC {
+        CSC::from_bits(val)
+    }
+}
+impl From<CSC> for u8 {
+    #[inline(always)]
+    fn from(val: CSC) -> u8 {
+        CSC::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DCCPARAMS_DC {
+    #[doc = "Not device capable."]
+    NOT_DC = 0x0,
+    #[doc = "Device capable."]
+    DC = 0x01,
+}
+impl DCCPARAMS_DC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> DCCPARAMS_DC {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for DCCPARAMS_DC {
+    #[inline(always)]
+    fn from(val: u8) -> DCCPARAMS_DC {
+        DCCPARAMS_DC::from_bits(val)
+    }
+}
+impl From<DCCPARAMS_DC> for u8 {
+    #[inline(always)]
+    fn from(val: DCCPARAMS_DC) -> u8 {
+        DCCPARAMS_DC::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DCCPARAMS_HC {
+    #[doc = "Not host capable."]
+    NOT_HC = 0x0,
+    #[doc = "Host capable."]
+    HC = 0x01,
+}
+impl DCCPARAMS_HC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> DCCPARAMS_HC {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for DCCPARAMS_HC {
+    #[inline(always)]
+    fn from(val: u8) -> DCCPARAMS_HC {
+        DCCPARAMS_HC::from_bits(val)
+    }
+}
+impl From<DCCPARAMS_HC> for u8 {
+    #[inline(always)]
+    fn from(val: DCCPARAMS_HC) -> u8 {
+        DCCPARAMS_HC::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DEN {
+    #[doc = "Not device capable."]
+    NOT_DEN = 0x0,
+    #[doc = "Device capable."]
+    DEN = 0x01,
+    _RESERVED_2 = 0x02,
+    _RESERVED_3 = 0x03,
+    _RESERVED_4 = 0x04,
+    _RESERVED_5 = 0x05,
+    _RESERVED_6 = 0x06,
+    _RESERVED_7 = 0x07,
+    _RESERVED_8 = 0x08,
+    _RESERVED_9 = 0x09,
+    _RESERVED_a = 0x0a,
+    _RESERVED_b = 0x0b,
+    _RESERVED_c = 0x0c,
+    _RESERVED_d = 0x0d,
+    _RESERVED_e = 0x0e,
+    _RESERVED_f = 0x0f,
+    _RESERVED_10 = 0x10,
+    _RESERVED_11 = 0x11,
+    _RESERVED_12 = 0x12,
+    _RESERVED_13 = 0x13,
+    _RESERVED_14 = 0x14,
+    _RESERVED_15 = 0x15,
+    _RESERVED_16 = 0x16,
+    _RESERVED_17 = 0x17,
+    _RESERVED_18 = 0x18,
+    _RESERVED_19 = 0x19,
+    _RESERVED_1a = 0x1a,
+    _RESERVED_1b = 0x1b,
+    _RESERVED_1c = 0x1c,
+    _RESERVED_1d = 0x1d,
+    _RESERVED_1e = 0x1e,
+    _RESERVED_1f = 0x1f,
+}
+impl DEN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> DEN {
+        unsafe { core::mem::transmute(val & 0x1f) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for DEN {
+    #[inline(always)]
+    fn from(val: u8) -> DEN {
+        DEN::from_bits(val)
+    }
+}
+impl From<DEN> for u8 {
+    #[inline(always)]
+    fn from(val: DEN) -> u8 {
+        DEN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL0_RXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL0_RXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL0_RXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL0_RXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL0_RXE {
+        ENDPTCTRL0_RXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL0_RXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL0_RXE) -> u8 {
+        ENDPTCTRL0_RXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL0_RXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL0_RXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL0_RXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL0_RXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL0_RXS {
+        ENDPTCTRL0_RXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL0_RXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL0_RXS) -> u8 {
+        ENDPTCTRL0_RXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL0_TXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL0_TXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL0_TXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL0_TXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL0_TXE {
+        ENDPTCTRL0_TXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL0_TXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL0_TXE) -> u8 {
+        ENDPTCTRL0_TXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL0_TXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL0_TXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL0_TXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL0_TXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL0_TXS {
+        ENDPTCTRL0_TXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL0_TXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL0_TXS) -> u8 {
+        ENDPTCTRL0_TXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL1_RXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL1_RXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL1_RXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL1_RXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL1_RXE {
+        ENDPTCTRL1_RXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL1_RXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL1_RXE) -> u8 {
+        ENDPTCTRL1_RXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL1_RXI {
+    #[doc = "Allow."]
+    ENABLE = 0x0,
+    #[doc = "Inhibit."]
+    INHIBIT = 0x01,
+}
+impl ENDPTCTRL1_RXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL1_RXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL1_RXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL1_RXI {
+        ENDPTCTRL1_RXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL1_RXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL1_RXI) -> u8 {
+        ENDPTCTRL1_RXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL1_RXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL1_RXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL1_RXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL1_RXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL1_RXR {
+        ENDPTCTRL1_RXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL1_RXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL1_RXR) -> u8 {
+        ENDPTCTRL1_RXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL1_RXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL1_RXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL1_RXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL1_RXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL1_RXS {
+        ENDPTCTRL1_RXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL1_RXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL1_RXS) -> u8 {
+        ENDPTCTRL1_RXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL1_RXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL1_RXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL1_RXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL1_RXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL1_RXT {
+        ENDPTCTRL1_RXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL1_RXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL1_RXT) -> u8 {
+        ENDPTCTRL1_RXT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL1_TXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL1_TXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL1_TXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL1_TXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL1_TXE {
+        ENDPTCTRL1_TXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL1_TXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL1_TXE) -> u8 {
+        ENDPTCTRL1_TXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL1_TXI {
+    #[doc = "Allow."]
+    ENABLE = 0x0,
+    #[doc = "Inhibit."]
+    INHIBIT = 0x01,
+}
+impl ENDPTCTRL1_TXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL1_TXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL1_TXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL1_TXI {
+        ENDPTCTRL1_TXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL1_TXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL1_TXI) -> u8 {
+        ENDPTCTRL1_TXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL1_TXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL1_TXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL1_TXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL1_TXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL1_TXR {
+        ENDPTCTRL1_TXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL1_TXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL1_TXR) -> u8 {
+        ENDPTCTRL1_TXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL1_TXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL1_TXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL1_TXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL1_TXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL1_TXS {
+        ENDPTCTRL1_TXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL1_TXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL1_TXS) -> u8 {
+        ENDPTCTRL1_TXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL1_TXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL1_TXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL1_TXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL1_TXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL1_TXT {
+        ENDPTCTRL1_TXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL1_TXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL1_TXT) -> u8 {
+        ENDPTCTRL1_TXT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL2_RXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL2_RXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL2_RXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL2_RXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL2_RXE {
+        ENDPTCTRL2_RXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL2_RXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL2_RXE) -> u8 {
+        ENDPTCTRL2_RXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL2_RXI {
+    #[doc = "Allow."]
+    ENABLE = 0x0,
+    #[doc = "Inhibit."]
+    INHIBIT = 0x01,
+}
+impl ENDPTCTRL2_RXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL2_RXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL2_RXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL2_RXI {
+        ENDPTCTRL2_RXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL2_RXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL2_RXI) -> u8 {
+        ENDPTCTRL2_RXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL2_RXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL2_RXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL2_RXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL2_RXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL2_RXR {
+        ENDPTCTRL2_RXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL2_RXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL2_RXR) -> u8 {
+        ENDPTCTRL2_RXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL2_RXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL2_RXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL2_RXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL2_RXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL2_RXS {
+        ENDPTCTRL2_RXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL2_RXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL2_RXS) -> u8 {
+        ENDPTCTRL2_RXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL2_RXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL2_RXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL2_RXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL2_RXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL2_RXT {
+        ENDPTCTRL2_RXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL2_RXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL2_RXT) -> u8 {
+        ENDPTCTRL2_RXT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL2_TXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL2_TXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL2_TXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL2_TXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL2_TXE {
+        ENDPTCTRL2_TXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL2_TXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL2_TXE) -> u8 {
+        ENDPTCTRL2_TXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL2_TXI {
+    #[doc = "Allow."]
+    ENABLE = 0x0,
+    #[doc = "Inhibit."]
+    INHIBIT = 0x01,
+}
+impl ENDPTCTRL2_TXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL2_TXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL2_TXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL2_TXI {
+        ENDPTCTRL2_TXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL2_TXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL2_TXI) -> u8 {
+        ENDPTCTRL2_TXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL2_TXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL2_TXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL2_TXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL2_TXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL2_TXR {
+        ENDPTCTRL2_TXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL2_TXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL2_TXR) -> u8 {
+        ENDPTCTRL2_TXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL2_TXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL2_TXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL2_TXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL2_TXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL2_TXS {
+        ENDPTCTRL2_TXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL2_TXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL2_TXS) -> u8 {
+        ENDPTCTRL2_TXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL2_TXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL2_TXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL2_TXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL2_TXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL2_TXT {
+        ENDPTCTRL2_TXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL2_TXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL2_TXT) -> u8 {
+        ENDPTCTRL2_TXT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL3_RXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL3_RXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL3_RXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL3_RXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL3_RXE {
+        ENDPTCTRL3_RXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL3_RXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL3_RXE) -> u8 {
+        ENDPTCTRL3_RXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL3_RXI {
+    #[doc = "Allow."]
+    ENABLE = 0x0,
+    #[doc = "Inhibit."]
+    INHIBIT = 0x01,
+}
+impl ENDPTCTRL3_RXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL3_RXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL3_RXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL3_RXI {
+        ENDPTCTRL3_RXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL3_RXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL3_RXI) -> u8 {
+        ENDPTCTRL3_RXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL3_RXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL3_RXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL3_RXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL3_RXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL3_RXR {
+        ENDPTCTRL3_RXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL3_RXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL3_RXR) -> u8 {
+        ENDPTCTRL3_RXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL3_RXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL3_RXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL3_RXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL3_RXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL3_RXS {
+        ENDPTCTRL3_RXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL3_RXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL3_RXS) -> u8 {
+        ENDPTCTRL3_RXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL3_RXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL3_RXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL3_RXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL3_RXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL3_RXT {
+        ENDPTCTRL3_RXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL3_RXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL3_RXT) -> u8 {
+        ENDPTCTRL3_RXT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL3_TXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL3_TXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL3_TXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL3_TXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL3_TXE {
+        ENDPTCTRL3_TXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL3_TXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL3_TXE) -> u8 {
+        ENDPTCTRL3_TXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL3_TXI {
+    #[doc = "Allow."]
+    ENABLE = 0x0,
+    #[doc = "Inhibit."]
+    INHIBIT = 0x01,
+}
+impl ENDPTCTRL3_TXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL3_TXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL3_TXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL3_TXI {
+        ENDPTCTRL3_TXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL3_TXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL3_TXI) -> u8 {
+        ENDPTCTRL3_TXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL3_TXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL3_TXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL3_TXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL3_TXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL3_TXR {
+        ENDPTCTRL3_TXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL3_TXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL3_TXR) -> u8 {
+        ENDPTCTRL3_TXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL3_TXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL3_TXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL3_TXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL3_TXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL3_TXS {
+        ENDPTCTRL3_TXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL3_TXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL3_TXS) -> u8 {
+        ENDPTCTRL3_TXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL3_TXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL3_TXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL3_TXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL3_TXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL3_TXT {
+        ENDPTCTRL3_TXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL3_TXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL3_TXT) -> u8 {
+        ENDPTCTRL3_TXT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL4_RXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL4_RXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL4_RXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL4_RXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL4_RXE {
+        ENDPTCTRL4_RXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL4_RXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL4_RXE) -> u8 {
+        ENDPTCTRL4_RXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL4_RXI {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL4_RXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL4_RXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL4_RXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL4_RXI {
+        ENDPTCTRL4_RXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL4_RXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL4_RXI) -> u8 {
+        ENDPTCTRL4_RXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL4_RXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL4_RXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL4_RXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL4_RXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL4_RXR {
+        ENDPTCTRL4_RXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL4_RXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL4_RXR) -> u8 {
+        ENDPTCTRL4_RXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL4_RXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL4_RXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL4_RXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL4_RXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL4_RXS {
+        ENDPTCTRL4_RXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL4_RXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL4_RXS) -> u8 {
+        ENDPTCTRL4_RXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL4_RXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL4_RXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL4_RXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL4_RXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL4_RXT {
+        ENDPTCTRL4_RXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL4_RXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL4_RXT) -> u8 {
+        ENDPTCTRL4_RXT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL4_TXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL4_TXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL4_TXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL4_TXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL4_TXE {
+        ENDPTCTRL4_TXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL4_TXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL4_TXE) -> u8 {
+        ENDPTCTRL4_TXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL4_TXI {
+    #[doc = "Allow."]
+    ENABLE = 0x0,
+    #[doc = "Inhibit."]
+    INHIBIT = 0x01,
+}
+impl ENDPTCTRL4_TXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL4_TXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL4_TXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL4_TXI {
+        ENDPTCTRL4_TXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL4_TXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL4_TXI) -> u8 {
+        ENDPTCTRL4_TXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL4_TXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL4_TXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL4_TXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL4_TXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL4_TXR {
+        ENDPTCTRL4_TXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL4_TXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL4_TXR) -> u8 {
+        ENDPTCTRL4_TXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL4_TXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL4_TXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL4_TXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL4_TXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL4_TXS {
+        ENDPTCTRL4_TXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL4_TXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL4_TXS) -> u8 {
+        ENDPTCTRL4_TXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL4_TXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL4_TXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL4_TXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL4_TXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL4_TXT {
+        ENDPTCTRL4_TXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL4_TXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL4_TXT) -> u8 {
+        ENDPTCTRL4_TXT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL5_RXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL5_RXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL5_RXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL5_RXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL5_RXE {
+        ENDPTCTRL5_RXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL5_RXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL5_RXE) -> u8 {
+        ENDPTCTRL5_RXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL5_RXI {
+    #[doc = "Allow."]
+    ENABLE = 0x0,
+    #[doc = "Inhibit."]
+    INHIBIT = 0x01,
+}
+impl ENDPTCTRL5_RXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL5_RXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL5_RXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL5_RXI {
+        ENDPTCTRL5_RXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL5_RXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL5_RXI) -> u8 {
+        ENDPTCTRL5_RXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL5_RXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL5_RXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL5_RXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL5_RXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL5_RXR {
+        ENDPTCTRL5_RXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL5_RXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL5_RXR) -> u8 {
+        ENDPTCTRL5_RXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL5_RXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL5_RXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL5_RXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL5_RXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL5_RXS {
+        ENDPTCTRL5_RXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL5_RXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL5_RXS) -> u8 {
+        ENDPTCTRL5_RXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL5_RXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL5_RXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL5_RXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL5_RXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL5_RXT {
+        ENDPTCTRL5_RXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL5_RXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL5_RXT) -> u8 {
+        ENDPTCTRL5_RXT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL5_TXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL5_TXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL5_TXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL5_TXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL5_TXE {
+        ENDPTCTRL5_TXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL5_TXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL5_TXE) -> u8 {
+        ENDPTCTRL5_TXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL5_TXI {
+    #[doc = "Allow."]
+    ENABLE = 0x0,
+    #[doc = "Inhibit."]
+    INHIBIT = 0x01,
+}
+impl ENDPTCTRL5_TXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL5_TXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL5_TXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL5_TXI {
+        ENDPTCTRL5_TXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL5_TXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL5_TXI) -> u8 {
+        ENDPTCTRL5_TXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL5_TXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL5_TXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL5_TXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL5_TXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL5_TXR {
+        ENDPTCTRL5_TXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL5_TXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL5_TXR) -> u8 {
+        ENDPTCTRL5_TXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL5_TXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL5_TXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL5_TXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL5_TXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL5_TXS {
+        ENDPTCTRL5_TXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL5_TXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL5_TXS) -> u8 {
+        ENDPTCTRL5_TXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL5_TXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL5_TXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL5_TXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL5_TXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL5_TXT {
+        ENDPTCTRL5_TXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL5_TXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL5_TXT) -> u8 {
+        ENDPTCTRL5_TXT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL6_RXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL6_RXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL6_RXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL6_RXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL6_RXE {
+        ENDPTCTRL6_RXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL6_RXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL6_RXE) -> u8 {
+        ENDPTCTRL6_RXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL6_RXI {
+    #[doc = "Allow."]
+    ENABLE = 0x0,
+    #[doc = "Inhibit."]
+    INHIBIT = 0x01,
+}
+impl ENDPTCTRL6_RXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL6_RXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL6_RXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL6_RXI {
+        ENDPTCTRL6_RXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL6_RXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL6_RXI) -> u8 {
+        ENDPTCTRL6_RXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL6_RXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL6_RXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL6_RXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL6_RXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL6_RXR {
+        ENDPTCTRL6_RXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL6_RXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL6_RXR) -> u8 {
+        ENDPTCTRL6_RXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL6_RXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL6_RXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL6_RXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL6_RXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL6_RXS {
+        ENDPTCTRL6_RXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL6_RXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL6_RXS) -> u8 {
+        ENDPTCTRL6_RXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL6_RXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL6_RXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL6_RXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL6_RXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL6_RXT {
+        ENDPTCTRL6_RXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL6_RXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL6_RXT) -> u8 {
+        ENDPTCTRL6_RXT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL6_TXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL6_TXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL6_TXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL6_TXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL6_TXE {
+        ENDPTCTRL6_TXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL6_TXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL6_TXE) -> u8 {
+        ENDPTCTRL6_TXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL6_TXI {
+    #[doc = "Allow."]
+    ENABLE = 0x0,
+    #[doc = "Inhibit."]
+    INHIBIT = 0x01,
+}
+impl ENDPTCTRL6_TXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL6_TXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL6_TXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL6_TXI {
+        ENDPTCTRL6_TXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL6_TXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL6_TXI) -> u8 {
+        ENDPTCTRL6_TXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL6_TXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL6_TXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL6_TXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL6_TXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL6_TXR {
+        ENDPTCTRL6_TXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL6_TXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL6_TXR) -> u8 {
+        ENDPTCTRL6_TXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL6_TXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL6_TXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL6_TXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL6_TXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL6_TXS {
+        ENDPTCTRL6_TXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL6_TXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL6_TXS) -> u8 {
+        ENDPTCTRL6_TXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL6_TXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL6_TXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL6_TXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL6_TXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL6_TXT {
+        ENDPTCTRL6_TXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL6_TXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL6_TXT) -> u8 {
+        ENDPTCTRL6_TXT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL7_RXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL7_RXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL7_RXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL7_RXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL7_RXE {
+        ENDPTCTRL7_RXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL7_RXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL7_RXE) -> u8 {
+        ENDPTCTRL7_RXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL7_RXI {
+    #[doc = "Allow."]
+    ENABLE = 0x0,
+    #[doc = "Inhibit."]
+    INHIBIT = 0x01,
+}
+impl ENDPTCTRL7_RXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL7_RXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL7_RXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL7_RXI {
+        ENDPTCTRL7_RXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL7_RXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL7_RXI) -> u8 {
+        ENDPTCTRL7_RXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL7_RXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL7_RXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL7_RXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL7_RXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL7_RXR {
+        ENDPTCTRL7_RXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL7_RXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL7_RXR) -> u8 {
+        ENDPTCTRL7_RXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL7_RXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL7_RXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL7_RXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL7_RXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL7_RXS {
+        ENDPTCTRL7_RXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL7_RXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL7_RXS) -> u8 {
+        ENDPTCTRL7_RXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL7_RXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL7_RXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL7_RXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL7_RXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL7_RXT {
+        ENDPTCTRL7_RXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL7_RXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL7_RXT) -> u8 {
+        ENDPTCTRL7_RXT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL7_TXE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL7_TXE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL7_TXE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL7_TXE {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL7_TXE {
+        ENDPTCTRL7_TXE::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL7_TXE> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL7_TXE) -> u8 {
+        ENDPTCTRL7_TXE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL7_TXI {
+    #[doc = "Allow."]
+    ENABLE = 0x0,
+    #[doc = "Inhibit."]
+    INHIBIT = 0x01,
+}
+impl ENDPTCTRL7_TXI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL7_TXI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL7_TXI {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL7_TXI {
+        ENDPTCTRL7_TXI::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL7_TXI> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL7_TXI) -> u8 {
+        ENDPTCTRL7_TXI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL7_TXR {
+    #[doc = "Does not reset."]
+    NO_RESET = 0x0,
+    #[doc = "Resets."]
+    RESET = 0x01,
+}
+impl ENDPTCTRL7_TXR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL7_TXR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL7_TXR {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL7_TXR {
+        ENDPTCTRL7_TXR::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL7_TXR> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL7_TXR) -> u8 {
+        ENDPTCTRL7_TXR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL7_TXS {
+    #[doc = "Endpoint OK."]
+    DISABLE = 0x0,
+    #[doc = "Endpoint stalled."]
+    ENABLE = 0x01,
+}
+impl ENDPTCTRL7_TXS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL7_TXS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL7_TXS {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL7_TXS {
+        ENDPTCTRL7_TXS::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL7_TXS> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL7_TXS) -> u8 {
+        ENDPTCTRL7_TXS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDPTCTRL7_TXT {
+    #[doc = "Control."]
+    CTL = 0x0,
+    #[doc = "Isochronous."]
+    ISO = 0x01,
+    #[doc = "Bulk."]
+    BLK = 0x02,
+    #[doc = "Interrupt."]
+    IRQ = 0x03,
+}
+impl ENDPTCTRL7_TXT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDPTCTRL7_TXT {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDPTCTRL7_TXT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDPTCTRL7_TXT {
+        ENDPTCTRL7_TXT::from_bits(val)
+    }
+}
+impl From<ENDPTCTRL7_TXT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDPTCTRL7_TXT) -> u8 {
+        ENDPTCTRL7_TXT::to_bits(val)
+    }
+}
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct ENDPTSETUPSTAT_FLAG(u16);
+impl ENDPTSETUPSTAT_FLAG {
+    #[doc = "Not received."]
+    pub const NOTREC: Self = Self(0x0);
+    #[doc = "Received."]
+    pub const RECVD: Self = Self(0x01);
+}
+impl ENDPTSETUPSTAT_FLAG {
+    pub const fn from_bits(val: u16) -> ENDPTSETUPSTAT_FLAG {
+        Self(val & 0xffff)
+    }
+    pub const fn to_bits(self) -> u16 {
+        self.0
+    }
+}
+impl core::fmt::Debug for ENDPTSETUPSTAT_FLAG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("NOTREC"),
+            0x01 => f.write_str("RECVD"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ENDPTSETUPSTAT_FLAG {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "NOTREC"),
+            0x01 => defmt::write!(f, "RECVD"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+impl From<u16> for ENDPTSETUPSTAT_FLAG {
+    #[inline(always)]
+    fn from(val: u16) -> ENDPTSETUPSTAT_FLAG {
+        ENDPTSETUPSTAT_FLAG::from_bits(val)
+    }
+}
+impl From<ENDPTSETUPSTAT_FLAG> for u16 {
+    #[inline(always)]
+    fn from(val: ENDPTSETUPSTAT_FLAG) -> u16 {
+        ENDPTSETUPSTAT_FLAG::to_bits(val)
+    }
+}
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct EPRN(u8);
+impl EPRN {
+    #[doc = "No NACK."]
+    pub const NONACK: Self = Self(0x0);
+    #[doc = "NACK."]
+    pub const NACK: Self = Self(0x01);
+}
+impl EPRN {
+    pub const fn from_bits(val: u8) -> EPRN {
+        Self(val & 0xff)
+    }
+    pub const fn to_bits(self) -> u8 {
+        self.0
+    }
+}
+impl core::fmt::Debug for EPRN {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("NONACK"),
+            0x01 => f.write_str("NACK"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EPRN {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "NONACK"),
+            0x01 => defmt::write!(f, "NACK"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+impl From<u8> for EPRN {
+    #[inline(always)]
+    fn from(val: u8) -> EPRN {
+        EPRN::from_bits(val)
+    }
+}
+impl From<EPRN> for u8 {
+    #[inline(always)]
+    fn from(val: EPRN) -> u8 {
+        EPRN::to_bits(val)
+    }
+}
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct EPTN(u8);
+impl EPTN {
+    #[doc = "No NACK."]
+    pub const NONACK: Self = Self(0x0);
+    #[doc = "NACK."]
+    pub const NACK: Self = Self(0x01);
+}
+impl EPTN {
+    pub const fn from_bits(val: u8) -> EPTN {
+        Self(val & 0xff)
+    }
+    pub const fn to_bits(self) -> u8 {
+        self.0
+    }
+}
+impl core::fmt::Debug for EPTN {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("NONACK"),
+            0x01 => f.write_str("NACK"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EPTN {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "NONACK"),
+            0x01 => defmt::write!(f, "NACK"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+impl From<u8> for EPTN {
+    #[inline(always)]
+    fn from(val: u8) -> EPTN {
+        EPTN::from_bits(val)
+    }
+}
+impl From<EPTN> for u8 {
+    #[inline(always)]
+    fn from(val: EPTN) -> u8 {
+        EPTN::to_bits(val)
+    }
+}
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct ERCE(u8);
+impl ERCE {
+    #[doc = "Transmit incomplete."]
+    pub const TRANSNOTCOMP: Self = Self(0x0);
+    #[doc = "Transmit complete."]
+    pub const TRANSCOMP: Self = Self(0x01);
+}
+impl ERCE {
+    pub const fn from_bits(val: u8) -> ERCE {
+        Self(val & 0xff)
+    }
+    pub const fn to_bits(self) -> u8 {
+        self.0
+    }
+}
+impl core::fmt::Debug for ERCE {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("TRANSNOTCOMP"),
+            0x01 => f.write_str("TRANSCOMP"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ERCE {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "TRANSNOTCOMP"),
+            0x01 => defmt::write!(f, "TRANSCOMP"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+impl From<u8> for ERCE {
+    #[inline(always)]
+    fn from(val: u8) -> ERCE {
+        ERCE::from_bits(val)
+    }
+}
+impl From<ERCE> for u8 {
+    #[inline(always)]
+    fn from(val: ERCE) -> u8 {
+        ERCE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ES {
+    #[doc = "Little endian (default)."]
+    LITTLE_ENDIAN = 0x0,
+    #[doc = "Big endian."]
+    BIG_ENDIAN = 0x01,
+}
+impl ES {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ES {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ES {
+    #[inline(always)]
+    fn from(val: u8) -> ES {
+        ES::from_bits(val)
+    }
+}
+impl From<ES> for u8 {
+    #[inline(always)]
+    fn from(val: ES) -> u8 {
+        ES::to_bits(val)
+    }
+}
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct ETCE(u8);
+impl ETCE {
+    #[doc = "Transmit incomplete."]
+    pub const TRANSNOTCOMP: Self = Self(0x0);
+    #[doc = "Transmit complete."]
+    pub const TRANSCOMP: Self = Self(0x01);
+}
+impl ETCE {
+    pub const fn from_bits(val: u8) -> ETCE {
+        Self(val & 0xff)
+    }
+    pub const fn to_bits(self) -> u8 {
+        self.0
+    }
+}
+impl core::fmt::Debug for ETCE {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("TRANSNOTCOMP"),
+            0x01 => f.write_str("TRANSCOMP"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ETCE {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "TRANSNOTCOMP"),
+            0x01 => defmt::write!(f, "TRANSCOMP"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+impl From<u8> for ETCE {
+    #[inline(always)]
+    fn from(val: u8) -> ETCE {
+        ETCE::from_bits(val)
+    }
+}
+impl From<ETCE> for u8 {
+    #[inline(always)]
+    fn from(val: ETCE) -> u8 {
+        ETCE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum FPR {
+    #[doc = "No resume (K-state) detected or driven on port."]
+    DISABLE = 0x0,
+    #[doc = "Resume detected or driven on port."]
+    ENABLE = 0x01,
+}
+impl FPR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> FPR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for FPR {
+    #[inline(always)]
+    fn from(val: u8) -> FPR {
+        FPR::from_bits(val)
+    }
+}
+impl From<FPR> for u8 {
+    #[inline(always)]
+    fn from(val: FPR) -> u8 {
+        FPR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum FRE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl FRE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> FRE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for FRE {
+    #[inline(always)]
+    fn from(val: u8) -> FRE {
+        FRE::from_bits(val)
+    }
+}
+impl From<FRE> for u8 {
+    #[inline(always)]
+    fn from(val: FRE) -> u8 {
+        FRE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum FRI {
+    #[doc = "Frame list index did not roll over."]
+    ROLL_NO = 0x0,
+    #[doc = "Frame list index rolled over."]
+    ROLL_YES = 0x01,
+}
+impl FRI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> FRI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for FRI {
+    #[inline(always)]
+    fn from(val: u8) -> FRI {
+        FRI::from_bits(val)
+    }
+}
+impl From<FRI> for u8 {
+    #[inline(always)]
+    fn from(val: FRI) -> u8 {
+        FRI::to_bits(val)
+    }
+}
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct FRINDEX_VALUE(u16);
+impl FRINDEX_VALUE {
+    #[doc = "(1024) 12."]
+    pub const FRINDEX_1024: Self = Self(0x0);
+    #[doc = "(512) 11."]
+    pub const FRINDEX_512: Self = Self(0x01);
+    #[doc = "(256) 10."]
+    pub const FRINDEX_256: Self = Self(0x02);
+    #[doc = "(128) 9."]
+    pub const FRINDEX_128: Self = Self(0x03);
+    #[doc = "(64) 8."]
+    pub const FRINDEX_64: Self = Self(0x04);
+    #[doc = "(32) 7."]
+    pub const FRINDEX_32: Self = Self(0x05);
+    #[doc = "(16) 6."]
+    pub const FRINDEX_16: Self = Self(0x06);
+    #[doc = "(8) 5."]
+    pub const FRINDEX_8: Self = Self(0x07);
+}
+impl FRINDEX_VALUE {
+    pub const fn from_bits(val: u16) -> FRINDEX_VALUE {
+        Self(val & 0x3fff)
+    }
+    pub const fn to_bits(self) -> u16 {
+        self.0
+    }
+}
+impl core::fmt::Debug for FRINDEX_VALUE {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("FRINDEX_1024"),
+            0x01 => f.write_str("FRINDEX_512"),
+            0x02 => f.write_str("FRINDEX_256"),
+            0x03 => f.write_str("FRINDEX_128"),
+            0x04 => f.write_str("FRINDEX_64"),
+            0x05 => f.write_str("FRINDEX_32"),
+            0x06 => f.write_str("FRINDEX_16"),
+            0x07 => f.write_str("FRINDEX_8"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FRINDEX_VALUE {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "FRINDEX_1024"),
+            0x01 => defmt::write!(f, "FRINDEX_512"),
+            0x02 => defmt::write!(f, "FRINDEX_256"),
+            0x03 => defmt::write!(f, "FRINDEX_128"),
+            0x04 => defmt::write!(f, "FRINDEX_64"),
+            0x05 => defmt::write!(f, "FRINDEX_32"),
+            0x06 => defmt::write!(f, "FRINDEX_16"),
+            0x07 => defmt::write!(f, "FRINDEX_8"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+impl From<u16> for FRINDEX_VALUE {
+    #[inline(always)]
+    fn from(val: u16) -> FRINDEX_VALUE {
+        FRINDEX_VALUE::from_bits(val)
+    }
+}
+impl From<FRINDEX_VALUE> for u16 {
+    #[inline(always)]
+    fn from(val: FRINDEX_VALUE) -> u16 {
+        FRINDEX_VALUE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum GPTIMER0CTRL_GPTMODE {
+    #[doc = "One Shot mode."]
+    ONE_SHOT = 0x0,
+    #[doc = "Repeat mode."]
+    REPEAT = 0x01,
+}
+impl GPTIMER0CTRL_GPTMODE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> GPTIMER0CTRL_GPTMODE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for GPTIMER0CTRL_GPTMODE {
+    #[inline(always)]
+    fn from(val: u8) -> GPTIMER0CTRL_GPTMODE {
+        GPTIMER0CTRL_GPTMODE::from_bits(val)
+    }
+}
+impl From<GPTIMER0CTRL_GPTMODE> for u8 {
+    #[inline(always)]
+    fn from(val: GPTIMER0CTRL_GPTMODE) -> u8 {
+        GPTIMER0CTRL_GPTMODE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum GPTIMER0CTRL_GPTRST {
+    #[doc = "No action."]
+    NO_ACTION = 0x0,
+    #[doc = "Load counter value."]
+    LOAD_CNTR = 0x01,
+}
+impl GPTIMER0CTRL_GPTRST {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> GPTIMER0CTRL_GPTRST {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for GPTIMER0CTRL_GPTRST {
+    #[inline(always)]
+    fn from(val: u8) -> GPTIMER0CTRL_GPTRST {
+        GPTIMER0CTRL_GPTRST::from_bits(val)
+    }
+}
+impl From<GPTIMER0CTRL_GPTRST> for u8 {
+    #[inline(always)]
+    fn from(val: GPTIMER0CTRL_GPTRST) -> u8 {
+        GPTIMER0CTRL_GPTRST::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum GPTIMER0CTRL_GPTRUN {
+    #[doc = "Stopped counting."]
+    STOP_CNTR = 0x0,
+    #[doc = "Running."]
+    RUN = 0x01,
+}
+impl GPTIMER0CTRL_GPTRUN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> GPTIMER0CTRL_GPTRUN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for GPTIMER0CTRL_GPTRUN {
+    #[inline(always)]
+    fn from(val: u8) -> GPTIMER0CTRL_GPTRUN {
+        GPTIMER0CTRL_GPTRUN::from_bits(val)
+    }
+}
+impl From<GPTIMER0CTRL_GPTRUN> for u8 {
+    #[inline(always)]
+    fn from(val: GPTIMER0CTRL_GPTRUN) -> u8 {
+        GPTIMER0CTRL_GPTRUN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum GPTIMER1CTRL_GPTMODE {
+    #[doc = "One Shot mode."]
+    ONE_SHOT = 0x0,
+    #[doc = "Repeat mode."]
+    REPEAT = 0x01,
+}
+impl GPTIMER1CTRL_GPTMODE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> GPTIMER1CTRL_GPTMODE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for GPTIMER1CTRL_GPTMODE {
+    #[inline(always)]
+    fn from(val: u8) -> GPTIMER1CTRL_GPTMODE {
+        GPTIMER1CTRL_GPTMODE::from_bits(val)
+    }
+}
+impl From<GPTIMER1CTRL_GPTMODE> for u8 {
+    #[inline(always)]
+    fn from(val: GPTIMER1CTRL_GPTMODE) -> u8 {
+        GPTIMER1CTRL_GPTMODE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum GPTIMER1CTRL_GPTRST {
+    #[doc = "No action."]
+    NO_ACTION = 0x0,
+    #[doc = "Load counter value."]
+    LOAD_CNTR = 0x01,
+}
+impl GPTIMER1CTRL_GPTRST {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> GPTIMER1CTRL_GPTRST {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for GPTIMER1CTRL_GPTRST {
+    #[inline(always)]
+    fn from(val: u8) -> GPTIMER1CTRL_GPTRST {
+        GPTIMER1CTRL_GPTRST::from_bits(val)
+    }
+}
+impl From<GPTIMER1CTRL_GPTRST> for u8 {
+    #[inline(always)]
+    fn from(val: GPTIMER1CTRL_GPTRST) -> u8 {
+        GPTIMER1CTRL_GPTRST::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum GPTIMER1CTRL_GPTRUN {
+    #[doc = "Stopped counting."]
+    STOP_CNTR = 0x0,
+    #[doc = "Running."]
+    RUN = 0x01,
+}
+impl GPTIMER1CTRL_GPTRUN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> GPTIMER1CTRL_GPTRUN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for GPTIMER1CTRL_GPTRUN {
+    #[inline(always)]
+    fn from(val: u8) -> GPTIMER1CTRL_GPTRUN {
+        GPTIMER1CTRL_GPTRUN::from_bits(val)
+    }
+}
+impl From<GPTIMER1CTRL_GPTRUN> for u8 {
+    #[inline(always)]
+    fn from(val: GPTIMER1CTRL_GPTRUN) -> u8 {
+        GPTIMER1CTRL_GPTRUN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum HAAR {
+    #[doc = "Disable."]
+    HAAR_0 = 0x0,
+    #[doc = "Enable."]
+    HAAR_1 = 0x01,
+}
+impl HAAR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> HAAR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for HAAR {
+    #[inline(always)]
+    fn from(val: u8) -> HAAR {
+        HAAR::from_bits(val)
+    }
+}
+impl From<HAAR> for u8 {
+    #[inline(always)]
+    fn from(val: HAAR) -> u8 {
+        HAAR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum HABA {
+    #[doc = "Disable."]
+    HABA_0 = 0x0,
+    #[doc = "Enable."]
+    HABA_1 = 0x01,
+}
+impl HABA {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> HABA {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for HABA {
+    #[inline(always)]
+    fn from(val: u8) -> HABA {
+        HABA::from_bits(val)
+    }
+}
+impl From<HABA> for u8 {
+    #[inline(always)]
+    fn from(val: HABA) -> u8 {
+        HABA::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum HADP {
+    #[doc = "Disable."]
+    HADP_0 = 0x0,
+    #[doc = "Enable."]
+    HADP_1 = 0x01,
+}
+impl HADP {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> HADP {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for HADP {
+    #[inline(always)]
+    fn from(val: u8) -> HADP {
+        HADP::from_bits(val)
+    }
+}
+impl From<HADP> for u8 {
+    #[inline(always)]
+    fn from(val: HADP) -> u8 {
+        HADP::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum HSP {
+    #[doc = "Not in HS mode."]
+    NOTHS = 0x0,
+    #[doc = "In HS mode."]
+    HS = 0x01,
+}
+impl HSP {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> HSP {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for HSP {
+    #[inline(always)]
+    fn from(val: u8) -> HSP {
+        HSP::from_bits(val)
+    }
+}
+impl From<HSP> for u8 {
+    #[inline(always)]
+    fn from(val: HSP) -> u8 {
+        HSP::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum HWDEVICE_DC {
+    #[doc = "Not supported."]
+    DEVICE_OP_DIS = 0x0,
+    #[doc = "Supported."]
+    DEVICE_OP_EN = 0x01,
+}
+impl HWDEVICE_DC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> HWDEVICE_DC {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for HWDEVICE_DC {
+    #[inline(always)]
+    fn from(val: u8) -> HWDEVICE_DC {
+        HWDEVICE_DC::from_bits(val)
+    }
+}
+impl From<HWDEVICE_DC> for u8 {
+    #[inline(always)]
+    fn from(val: HWDEVICE_DC) -> u8 {
+        HWDEVICE_DC::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum HWHOST_HC {
+    #[doc = "Not supported."]
+    HOST_OP_DIS = 0x0,
+    #[doc = "Supported."]
+    HOST_OP_EN = 0x01,
+}
+impl HWHOST_HC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> HWHOST_HC {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for HWHOST_HC {
+    #[inline(always)]
+    fn from(val: u8) -> HWHOST_HC {
+        HWHOST_HC::from_bits(val)
+    }
+}
+impl From<HWHOST_HC> for u8 {
+    #[inline(always)]
+    fn from(val: HWHOST_HC) -> u8 {
+        HWHOST_HC::to_bits(val)
+    }
+}
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct ITC(u8);
+impl ITC {
+    #[doc = "Immediate (no threshold)."]
+    pub const IMMEDIATE: Self = Self(0x0);
+    #[doc = "1 microframe."]
+    pub const MICROFRAME_1: Self = Self(0x01);
+    #[doc = "2 microframes."]
+    pub const MICROFRAME_2: Self = Self(0x02);
+    #[doc = "4 microframes."]
+    pub const MICROFRAME_4: Self = Self(0x04);
+    #[doc = "8 microframes."]
+    pub const MICROFRAME_8: Self = Self(0x08);
+    #[doc = "16 microframes."]
+    pub const MICROFRAME_16: Self = Self(0x10);
+    #[doc = "32 microframes."]
+    pub const MICROFRAME_32: Self = Self(0x20);
+    #[doc = "64 microframes."]
+    pub const MICROFRAME_64: Self = Self(0x40);
+}
+impl ITC {
+    pub const fn from_bits(val: u8) -> ITC {
+        Self(val & 0xff)
+    }
+    pub const fn to_bits(self) -> u8 {
+        self.0
+    }
+}
+impl core::fmt::Debug for ITC {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("IMMEDIATE"),
+            0x01 => f.write_str("MICROFRAME_1"),
+            0x02 => f.write_str("MICROFRAME_2"),
+            0x04 => f.write_str("MICROFRAME_4"),
+            0x08 => f.write_str("MICROFRAME_8"),
+            0x10 => f.write_str("MICROFRAME_16"),
+            0x20 => f.write_str("MICROFRAME_32"),
+            0x40 => f.write_str("MICROFRAME_64"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ITC {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "IMMEDIATE"),
+            0x01 => defmt::write!(f, "MICROFRAME_1"),
+            0x02 => defmt::write!(f, "MICROFRAME_2"),
+            0x04 => defmt::write!(f, "MICROFRAME_4"),
+            0x08 => defmt::write!(f, "MICROFRAME_8"),
+            0x10 => defmt::write!(f, "MICROFRAME_16"),
+            0x20 => defmt::write!(f, "MICROFRAME_32"),
+            0x40 => defmt::write!(f, "MICROFRAME_64"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+impl From<u8> for ITC {
+    #[inline(always)]
+    fn from(val: u8) -> ITC {
+        ITC::from_bits(val)
+    }
+}
+impl From<ITC> for u8 {
+    #[inline(always)]
+    fn from(val: ITC) -> u8 {
+        ITC::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM {
+    #[doc = "Not supported."]
+    LPM_NO = 0x0,
+    #[doc = "Supported."]
+    LPM_EN = 0x01,
+}
+impl LPM {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM {
+    #[inline(always)]
+    fn from(val: u8) -> LPM {
+        LPM::from_bits(val)
+    }
+}
+impl From<LPM> for u8 {
+    #[inline(always)]
+    fn from(val: LPM) -> u8 {
+        LPM::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_DEV_RCVDI {
+    #[doc = "Interrupt did not occur."]
+    INT_NO = 0x0,
+    #[doc = "Interrupt occurred."]
+    INT_YES = 0x01,
+}
+impl LPM_DEV_RCVDI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_DEV_RCVDI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_DEV_RCVDI {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_DEV_RCVDI {
+        LPM_DEV_RCVDI::from_bits(val)
+    }
+}
+impl From<LPM_DEV_RCVDI> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_DEV_RCVDI) -> u8 {
+        LPM_DEV_RCVDI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_DEV_RCVDIE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl LPM_DEV_RCVDIE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_DEV_RCVDIE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_DEV_RCVDIE {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_DEV_RCVDIE {
+        LPM_DEV_RCVDIE::from_bits(val)
+    }
+}
+impl From<LPM_DEV_RCVDIE> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_DEV_RCVDIE) -> u8 {
+        LPM_DEV_RCVDIE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_HST_COMPI {
+    #[doc = "Interrupt did not occur."]
+    INT_NO = 0x0,
+    #[doc = "Interrupt occurred."]
+    INT_YES = 0x01,
+}
+impl LPM_HST_COMPI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_HST_COMPI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_HST_COMPI {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_HST_COMPI {
+        LPM_HST_COMPI::from_bits(val)
+    }
+}
+impl From<LPM_HST_COMPI> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_HST_COMPI) -> u8 {
+        LPM_HST_COMPI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_HST_COMPIE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl LPM_HST_COMPIE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_HST_COMPIE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_HST_COMPIE {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_HST_COMPIE {
+        LPM_HST_COMPIE::from_bits(val)
+    }
+}
+impl From<LPM_HST_COMPIE> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_HST_COMPIE) -> u8 {
+        LPM_HST_COMPIE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_L1_ENTRYI {
+    #[doc = "Interrupt did not occur."]
+    INT_NO = 0x0,
+    #[doc = "Interrupt occurred."]
+    INT_YES = 0x01,
+}
+impl LPM_L1_ENTRYI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_L1_ENTRYI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_L1_ENTRYI {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_L1_ENTRYI {
+        LPM_L1_ENTRYI::from_bits(val)
+    }
+}
+impl From<LPM_L1_ENTRYI> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_L1_ENTRYI) -> u8 {
+        LPM_L1_ENTRYI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_L1_ENTRYIE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl LPM_L1_ENTRYIE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_L1_ENTRYIE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_L1_ENTRYIE {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_L1_ENTRYIE {
+        LPM_L1_ENTRYIE::from_bits(val)
+    }
+}
+impl From<LPM_L1_ENTRYIE> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_L1_ENTRYIE) -> u8 {
+        LPM_L1_ENTRYIE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_L1_EXITI {
+    #[doc = "Interrupt did not occur."]
+    INT_NO = 0x0,
+    #[doc = "Interrupt occurred."]
+    INT_YES = 0x01,
+}
+impl LPM_L1_EXITI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_L1_EXITI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_L1_EXITI {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_L1_EXITI {
+        LPM_L1_EXITI::from_bits(val)
+    }
+}
+impl From<LPM_L1_EXITI> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_L1_EXITI) -> u8 {
+        LPM_L1_EXITI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_L1_EXITIE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl LPM_L1_EXITIE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_L1_EXITIE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_L1_EXITIE {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_L1_EXITIE {
+        LPM_L1_EXITIE::from_bits(val)
+    }
+}
+impl From<LPM_L1_EXITIE> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_L1_EXITIE) -> u8 {
+        LPM_L1_EXITIE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LS {
+    #[doc = "SE0."]
+    SE0 = 0x0,
+    #[doc = "K-state."]
+    K_STATE = 0x01,
+    #[doc = "J-state."]
+    J_STATE = 0x02,
+    #[doc = "Undefined."]
+    UNDEFINED = 0x03,
+}
+impl LS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LS {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LS {
+    #[inline(always)]
+    fn from(val: u8) -> LS {
+        LS::from_bits(val)
+    }
+}
+impl From<LS> for u8 {
+    #[inline(always)]
+    fn from(val: LS) -> u8 {
+        LS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum NAKE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl NAKE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> NAKE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for NAKE {
+    #[inline(always)]
+    fn from(val: u8) -> NAKE {
+        NAKE::from_bits(val)
+    }
+}
+impl From<NAKE> for u8 {
+    #[inline(always)]
+    fn from(val: NAKE) -> u8 {
+        NAKE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum N_CC {
+    #[doc = "No internal companion controller exists."]
+    NO_COMP_CONTROLLER = 0x0,
+    #[doc = "Internal companion controllers exist."]
+    COMP_CONTROLLER = 0x01,
+    _RESERVED_2 = 0x02,
+    _RESERVED_3 = 0x03,
+    _RESERVED_4 = 0x04,
+    _RESERVED_5 = 0x05,
+    _RESERVED_6 = 0x06,
+    _RESERVED_7 = 0x07,
+    _RESERVED_8 = 0x08,
+    _RESERVED_9 = 0x09,
+    _RESERVED_a = 0x0a,
+    _RESERVED_b = 0x0b,
+    _RESERVED_c = 0x0c,
+    _RESERVED_d = 0x0d,
+    _RESERVED_e = 0x0e,
+    _RESERVED_f = 0x0f,
+}
+impl N_CC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> N_CC {
+        unsafe { core::mem::transmute(val & 0x0f) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for N_CC {
+    #[inline(always)]
+    fn from(val: u8) -> N_CC {
+        N_CC::from_bits(val)
+    }
+}
+impl From<N_CC> for u8 {
+    #[inline(always)]
+    fn from(val: N_CC) -> u8 {
+        N_CC::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OCA {
+    #[doc = "No overcurrent condition exists."]
+    NO_OVERCURRENT = 0x0,
+    #[doc = "Overcurrent condition exists."]
+    OVERCURRENT = 0x01,
+}
+impl OCA {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> OCA {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for OCA {
+    #[inline(always)]
+    fn from(val: u8) -> OCA {
+        OCA::from_bits(val)
+    }
+}
+impl From<OCA> for u8 {
+    #[inline(always)]
+    fn from(val: OCA) -> u8 {
+        OCA::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OCC {
+    #[doc = "No change occurred."]
+    NO_CHANGE = 0x0,
+    #[doc = "Change occurred."]
+    CHANGE = 0x01,
+}
+impl OCC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> OCC {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for OCC {
+    #[inline(always)]
+    fn from(val: u8) -> OCC {
+        OCC::from_bits(val)
+    }
+}
+impl From<OCC> for u8 {
+    #[inline(always)]
+    fn from(val: OCC) -> u8 {
+        OCC::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OTG_ID {
+    #[doc = "A device."]
+    DEV_A = 0x0,
+    #[doc = "B device."]
+    DEV_B = 0x01,
+}
+impl OTG_ID {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> OTG_ID {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for OTG_ID {
+    #[inline(always)]
+    fn from(val: u8) -> OTG_ID {
+        OTG_ID::from_bits(val)
+    }
+}
+impl From<OTG_ID> for u8 {
+    #[inline(always)]
+    fn from(val: OTG_ID) -> u8 {
+        OTG_ID::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PCE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl PCE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PCE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PCE {
+    #[inline(always)]
+    fn from(val: u8) -> PCE {
+        PCE::from_bits(val)
+    }
+}
+impl From<PCE> for u8 {
+    #[inline(always)]
+    fn from(val: PCE) -> u8 {
+        PCE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PCI {
+    #[doc = "Port change not detected."]
+    DETECT_NO = 0x0,
+    #[doc = "Port change detected."]
+    DETECT_YES = 0x01,
+}
+impl PCI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PCI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PCI {
+    #[inline(always)]
+    fn from(val: u8) -> PCI {
+        PCI::from_bits(val)
+    }
+}
+impl From<PCI> for u8 {
+    #[inline(always)]
+    fn from(val: PCI) -> u8 {
+        PCI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl PE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PE {
+    #[inline(always)]
+    fn from(val: u8) -> PE {
+        PE::from_bits(val)
+    }
+}
+impl From<PE> for u8 {
+    #[inline(always)]
+    fn from(val: PE) -> u8 {
+        PE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PEC {
+    #[doc = "No change occurred."]
+    DISABLE = 0x0,
+    #[doc = "Change occurred."]
+    ENABLE = 0x01,
+}
+impl PEC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PEC {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PEC {
+    #[inline(always)]
+    fn from(val: u8) -> PEC {
+        PEC::from_bits(val)
+    }
+}
+impl From<PEC> for u8 {
+    #[inline(always)]
+    fn from(val: PEC) -> u8 {
+        PEC::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PFSC {
+    #[doc = "Normal operation."]
+    NORMAL = 0x0,
+    #[doc = "Forced to full speed."]
+    FULL_SPEED = 0x01,
+}
+impl PFSC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PFSC {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PFSC {
+    #[inline(always)]
+    fn from(val: u8) -> PFSC {
+        PFSC::from_bits(val)
+    }
+}
+impl From<PFSC> for u8 {
+    #[inline(always)]
+    fn from(val: PFSC) -> u8 {
+        PFSC::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PHCD {
+    #[doc = "Enable."]
+    PHY_CLK_EN = 0x0,
+    #[doc = "Disable."]
+    PHY_CLK_DIS = 0x01,
+}
+impl PHCD {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PHCD {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PHCD {
+    #[inline(always)]
+    fn from(val: u8) -> PHCD {
+        PHCD::from_bits(val)
+    }
+}
+impl From<PHCD> for u8 {
+    #[inline(always)]
+    fn from(val: PHCD) -> u8 {
+        PHCD::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PHYM {
+    #[doc = "UTMI/UMTI+."]
+    UTMI = 0x0,
+    #[doc = "ULPI DDR."]
+    ULPI_DDR = 0x01,
+    #[doc = "ULPI."]
+    ULPI = 0x02,
+    #[doc = "Serial only."]
+    SERIAL = 0x03,
+    #[doc = "Software programmable: reset to UTMI/UTMI+."]
+    SW_RST_UTMI = 0x04,
+    #[doc = "Software programmable: reset to ULPI DDR."]
+    SW_RST_ULPI_DDR = 0x05,
+    #[doc = "Software programmable: reset to ULPI."]
+    SW_RST_ULPI = 0x06,
+    #[doc = "Software programmable: reset to Serial."]
+    SW_RST_SERIAL = 0x07,
+    #[doc = "IC-USB."]
+    ICUSB = 0x08,
+    #[doc = "Software programmable: reset to IC-USB."]
+    SW_RST_ICUSB = 0x09,
+    #[doc = "HSIC."]
+    HSIC = 0x0a,
+    #[doc = "Software programmable: reset to HSIC."]
+    SW_RST_HSIC = 0x0b,
+    _RESERVED_c = 0x0c,
+    _RESERVED_d = 0x0d,
+    _RESERVED_e = 0x0e,
+    _RESERVED_f = 0x0f,
+}
+impl PHYM {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PHYM {
+        unsafe { core::mem::transmute(val & 0x0f) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PHYM {
+    #[inline(always)]
+    fn from(val: u8) -> PHYM {
+        PHYM::from_bits(val)
+    }
+}
+impl From<PHYM> for u8 {
+    #[inline(always)]
+    fn from(val: PHYM) -> u8 {
+        PHYM::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PHYW {
+    #[doc = "8-bit wide data bus (software nonprogrammable)."]
+    DATA_BUS_8 = 0x0,
+    #[doc = "16-bit wide data bus (software nonprogrammable)."]
+    DATA_BUS_16 = 0x01,
+    #[doc = "Reset to 8-bit wide data bus (software programmable)."]
+    SW_RST_8 = 0x02,
+    #[doc = "Reset to 16-bit wide data bus (software programmable)."]
+    SW_RST_16 = 0x03,
+}
+impl PHYW {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PHYW {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PHYW {
+    #[inline(always)]
+    fn from(val: u8) -> PHYW {
+        PHYW::from_bits(val)
+    }
+}
+impl From<PHYW> for u8 {
+    #[inline(always)]
+    fn from(val: PHYW) -> u8 {
+        PHYW::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PIC {
+    #[doc = "Port indicators are off."]
+    PORT_INDICATOR_OFF = 0x0,
+    #[doc = "Amber."]
+    PORT_IND_AMBER = 0x01,
+    #[doc = "Green."]
+    PORT_IND_GREEN = 0x02,
+    #[doc = "Undefined."]
+    UNDEFINED = 0x03,
+}
+impl PIC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PIC {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PIC {
+    #[inline(always)]
+    fn from(val: u8) -> PIC {
+        PIC::from_bits(val)
+    }
+}
+impl From<PIC> for u8 {
+    #[inline(always)]
+    fn from(val: PIC) -> u8 {
+        PIC::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PP {
+    #[doc = "Off."]
+    OFF = 0x0,
+    #[doc = "On."]
+    ON = 0x01,
+}
+impl PP {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PP {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PP {
+    #[inline(always)]
+    fn from(val: u8) -> PP {
+        PP::from_bits(val)
+    }
+}
+impl From<PP> for u8 {
+    #[inline(always)]
+    fn from(val: PP) -> u8 {
+        PP::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PPC {
+    #[doc = "No port power switches."]
+    NO_SWITCHES = 0x0,
+    #[doc = "Port power switches exist."]
+    PORT_SWITCHES = 0x01,
+}
+impl PPC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PPC {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PPC {
+    #[inline(always)]
+    fn from(val: u8) -> PPC {
+        PPC::from_bits(val)
+    }
+}
+impl From<PPC> for u8 {
+    #[inline(always)]
+    fn from(val: PPC) -> u8 {
+        PPC::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PR {
+    #[doc = "Port not in reset."]
+    DISABLE = 0x0,
+    #[doc = "Port in reset."]
+    ENABLE = 0x01,
+}
+impl PR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PR {
+    #[inline(always)]
+    fn from(val: u8) -> PR {
+        PR::from_bits(val)
+    }
+}
+impl From<PR> for u8 {
+    #[inline(always)]
+    fn from(val: PR) -> u8 {
+        PR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PS {
+    #[doc = "Disabled."]
+    DISABLE = 0x0,
+    #[doc = "Enabled."]
+    ENABLE = 0x01,
+}
+impl PS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PS {
+    #[inline(always)]
+    fn from(val: u8) -> PS {
+        PS::from_bits(val)
+    }
+}
+impl From<PS> for u8 {
+    #[inline(always)]
+    fn from(val: PS) -> u8 {
+        PS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PSE {
+    #[doc = "Do not process the periodic schedule."]
+    DONT_PROCESS_PT = 0x0,
+    #[doc = "Process the periodic schedule."]
+    PROCESS_PT_PERIODICLISTBASE = 0x01,
+}
+impl PSE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PSE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PSE {
+    #[inline(always)]
+    fn from(val: u8) -> PSE {
+        PSE::from_bits(val)
+    }
+}
+impl From<PSE> for u8 {
+    #[inline(always)]
+    fn from(val: PSE) -> u8 {
+        PSE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PSPD {
+    #[doc = "FS."]
+    FS = 0x0,
+    #[doc = "LS."]
+    LS = 0x01,
+    #[doc = "HS."]
+    HS = 0x02,
+    #[doc = "Undefined."]
+    UNDEFINED = 0x03,
+}
+impl PSPD {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PSPD {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PSPD {
+    #[inline(always)]
+    fn from(val: u8) -> PSPD {
+        PSPD::from_bits(val)
+    }
+}
+impl From<PSPD> for u8 {
+    #[inline(always)]
+    fn from(val: PSPD) -> u8 {
+        PSPD::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PTC {
+    #[doc = "TEST_MODE_DISABLE."]
+    TST_MODE_DIS = 0x0,
+    #[doc = "J_STATE."]
+    J_STATE = 0x01,
+    #[doc = "K_STATE."]
+    K_STATE = 0x02,
+    #[doc = "SE0 (host) or NAK (device)."]
+    SE0 = 0x03,
+    #[doc = "Packet."]
+    PCKT = 0x04,
+    #[doc = "FORCE_ENABLE_HS."]
+    HS = 0x05,
+    #[doc = "FORCE_ENABLE_FS."]
+    FS = 0x06,
+    #[doc = "FORCE_ENABLE_LS."]
+    LS = 0x07,
+    _RESERVED_8 = 0x08,
+    _RESERVED_9 = 0x09,
+    _RESERVED_a = 0x0a,
+    _RESERVED_b = 0x0b,
+    _RESERVED_c = 0x0c,
+    _RESERVED_d = 0x0d,
+    _RESERVED_e = 0x0e,
+    _RESERVED_f = 0x0f,
+}
+impl PTC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PTC {
+        unsafe { core::mem::transmute(val & 0x0f) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PTC {
+    #[inline(always)]
+    fn from(val: u8) -> PTC {
+        PTC::from_bits(val)
+    }
+}
+impl From<PTC> for u8 {
+    #[inline(always)]
+    fn from(val: PTC) -> u8 {
+        PTC::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PTW {
+    #[doc = "8-bit UTMI interface (60 MHz)."]
+    UTMI_8 = 0x0,
+    #[doc = "16-bit UTMI interface (30 MHz)."]
+    UTMI_16 = 0x01,
+}
+impl PTW {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PTW {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PTW {
+    #[inline(always)]
+    fn from(val: u8) -> PTW {
+        PTW::from_bits(val)
+    }
+}
+impl From<PTW> for u8 {
+    #[inline(always)]
+    fn from(val: PTW) -> u8 {
+        PTW::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RCL {
+    #[doc = "Does not detect."]
+    DISABLE = 0x0,
+    #[doc = "Detects."]
+    ENABLE = 0x01,
+}
+impl RCL {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> RCL {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for RCL {
+    #[inline(always)]
+    fn from(val: u8) -> RCL {
+        RCL::from_bits(val)
+    }
+}
+impl From<RCL> for u8 {
+    #[inline(always)]
+    fn from(val: RCL) -> u8 {
+        RCL::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RS {
+    #[doc = "Stopped executing."]
+    STOP = 0x0,
+    #[doc = "Running."]
+    RUN = 0x01,
+}
+impl RS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> RS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for RS {
+    #[inline(always)]
+    fn from(val: u8) -> RS {
+        RS::from_bits(val)
+    }
+}
+impl From<RS> for u8 {
+    #[inline(always)]
+    fn from(val: RS) -> u8 {
+        RS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SDIS {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl SDIS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> SDIS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for SDIS {
+    #[inline(always)]
+    fn from(val: u8) -> SDIS {
+        SDIS::from_bits(val)
+    }
+}
+impl From<SDIS> for u8 {
+    #[inline(always)]
+    fn from(val: SDIS) -> u8 {
+        SDIS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SEE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl SEE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> SEE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for SEE {
+    #[inline(always)]
+    fn from(val: u8) -> SEE {
+        SEE::from_bits(val)
+    }
+}
+impl From<SEE> for u8 {
+    #[inline(always)]
+    fn from(val: SEE) -> u8 {
+        SEE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SEI {
+    #[doc = "Error response did not occur."]
+    INT_NO = 0x0,
+    #[doc = "Error response occurred."]
+    INT_YES = 0x01,
+}
+impl SEI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> SEI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for SEI {
+    #[inline(always)]
+    fn from(val: u8) -> SEI {
+        SEI::from_bits(val)
+    }
+}
+impl From<SEI> for u8 {
+    #[inline(always)]
+    fn from(val: SEI) -> u8 {
+        SEI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SLE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl SLE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> SLE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for SLE {
+    #[inline(always)]
+    fn from(val: u8) -> SLE {
+        SLE::from_bits(val)
+    }
+}
+impl From<SLE> for u8 {
+    #[inline(always)]
+    fn from(val: SLE) -> u8 {
+        SLE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SLI {
+    #[doc = "Did not enter Suspended state."]
+    SUS_NO = 0x0,
+    #[doc = "Entered Suspended state."]
+    SUS_YES = 0x01,
+}
+impl SLI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> SLI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for SLI {
+    #[inline(always)]
+    fn from(val: u8) -> SLI {
+        SLI::from_bits(val)
+    }
+}
+impl From<SLI> for u8 {
+    #[inline(always)]
+    fn from(val: SLI) -> u8 {
+        SLI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SLOM {
+    #[doc = "On (default)."]
+    LOCKOUT_ON = 0x0,
+    #[doc = "Off."]
+    LOCKOUT_OFF = 0x01,
+}
+impl SLOM {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> SLOM {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for SLOM {
+    #[inline(always)]
+    fn from(val: u8) -> SLOM {
+        SLOM::from_bits(val)
+    }
+}
+impl From<SLOM> for u8 {
+    #[inline(always)]
+    fn from(val: SLOM) -> u8 {
+        SLOM::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SM {
+    #[doc = "No serial engine; always use parallel signaling."]
+    SERIAL_ENGINE_NO = 0x0,
+    #[doc = "Serial engine present; always use serial signaling for FS and LS."]
+    SERIAL_ENGINE_EN = 0x01,
+    #[doc = "Software programmable; reset to use parallel signaling for FS and LS."]
+    SW_RST_PARALLEL = 0x02,
+    #[doc = "Software programmable; reset to use serial signaling for FS and LS."]
+    SW_RST_SERIAL_ENG = 0x03,
+}
+impl SM {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> SM {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for SM {
+    #[inline(always)]
+    fn from(val: u8) -> SM {
+        SM::from_bits(val)
+    }
+}
+impl From<SM> for u8 {
+    #[inline(always)]
+    fn from(val: SM) -> u8 {
+        SM::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SRE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl SRE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> SRE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for SRE {
+    #[inline(always)]
+    fn from(val: u8) -> SRE {
+        SRE::from_bits(val)
+    }
+}
+impl From<SRE> for u8 {
+    #[inline(always)]
+    fn from(val: SRE) -> u8 {
+        SRE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SRI {
+    #[doc = "SOF not received."]
+    SOF_NO = 0x0,
+    #[doc = "SOF received."]
+    SOF_YES = 0x01,
+}
+impl SRI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> SRI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for SRI {
+    #[inline(always)]
+    fn from(val: u8) -> SRI {
+        SRI::from_bits(val)
+    }
+}
+impl From<SRI> for u8 {
+    #[inline(always)]
+    fn from(val: SRI) -> u8 {
+        SRI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum STS {
+    #[doc = "Parallel interface signals."]
+    DISABLE = 0x0,
+    #[doc = "Serial interface engine."]
+    ENABLE = 0x01,
+}
+impl STS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> STS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for STS {
+    #[inline(always)]
+    fn from(val: u8) -> STS {
+        STS::from_bits(val)
+    }
+}
+impl From<STS> for u8 {
+    #[inline(always)]
+    fn from(val: STS) -> u8 {
+        STS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SUSP {
+    #[doc = "Port not in Suspended state."]
+    DISABLE = 0x0,
+    #[doc = "Port in Suspended state."]
+    ENABLE = 0x01,
+}
+impl SUSP {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> SUSP {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for SUSP {
+    #[inline(always)]
+    fn from(val: u8) -> SUSP {
+        SUSP::from_bits(val)
+    }
+}
+impl From<SUSP> for u8 {
+    #[inline(always)]
+    fn from(val: SUSP) -> u8 {
+        SUSP::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TI0 {
+    #[doc = "Interrupt did not occur."]
+    INT_NO = 0x0,
+    #[doc = "Interrupt occurred."]
+    INT_YES = 0x01,
+}
+impl TI0 {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> TI0 {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for TI0 {
+    #[inline(always)]
+    fn from(val: u8) -> TI0 {
+        TI0::from_bits(val)
+    }
+}
+impl From<TI0> for u8 {
+    #[inline(always)]
+    fn from(val: TI0) -> u8 {
+        TI0::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TI1 {
+    #[doc = "Interrupt did not occur."]
+    INT_NO = 0x0,
+    #[doc = "Interrupt occurred."]
+    INT_YES = 0x01,
+}
+impl TI1 {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> TI1 {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for TI1 {
+    #[inline(always)]
+    fn from(val: u8) -> TI1 {
+        TI1::from_bits(val)
+    }
+}
+impl From<TI1> for u8 {
+    #[inline(always)]
+    fn from(val: TI1) -> u8 {
+        TI1::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TIE0 {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl TIE0 {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> TIE0 {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for TIE0 {
+    #[inline(always)]
+    fn from(val: u8) -> TIE0 {
+        TIE0::from_bits(val)
+    }
+}
+impl From<TIE0> for u8 {
+    #[inline(always)]
+    fn from(val: TIE0) -> u8 {
+        TIE0::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TIE1 {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl TIE1 {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> TIE1 {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for TIE1 {
+    #[inline(always)]
+    fn from(val: u8) -> TIE1 {
+        TIE1::from_bits(val)
+    }
+}
+impl From<TIE1> for u8 {
+    #[inline(always)]
+    fn from(val: TIE1) -> u8 {
+        TIE1::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum UAI {
+    #[doc = "Interrupt did not occur."]
+    INT_NO = 0x0,
+    #[doc = "Interrupt occurred."]
+    INT_YES = 0x01,
+}
+impl UAI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> UAI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for UAI {
+    #[inline(always)]
+    fn from(val: u8) -> UAI {
+        UAI::from_bits(val)
+    }
+}
+impl From<UAI> for u8 {
+    #[inline(always)]
+    fn from(val: UAI) -> u8 {
+        UAI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum UAIE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl UAIE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> UAIE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for UAIE {
+    #[inline(always)]
+    fn from(val: u8) -> UAIE {
+        UAIE::from_bits(val)
+    }
+}
+impl From<UAIE> for u8 {
+    #[inline(always)]
+    fn from(val: UAIE) -> u8 {
+        UAIE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum UE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl UE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> UE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for UE {
+    #[inline(always)]
+    fn from(val: u8) -> UE {
+        UE::from_bits(val)
+    }
+}
+impl From<UE> for u8 {
+    #[inline(always)]
+    fn from(val: UE) -> u8 {
+        UE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum UEE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl UEE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> UEE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for UEE {
+    #[inline(always)]
+    fn from(val: u8) -> UEE {
+        UEE::from_bits(val)
+    }
+}
+impl From<UEE> for u8 {
+    #[inline(always)]
+    fn from(val: UEE) -> u8 {
+        UEE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum UEI {
+    #[doc = "Interrupt did not occur."]
+    INT_NO = 0x0,
+    #[doc = "Interrupt occurred."]
+    INT_YES = 0x01,
+}
+impl UEI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> UEI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for UEI {
+    #[inline(always)]
+    fn from(val: u8) -> UEI {
+        UEI::from_bits(val)
+    }
+}
+impl From<UEI> for u8 {
+    #[inline(always)]
+    fn from(val: UEI) -> u8 {
+        UEI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum UI {
+    #[doc = "Interrupt did not occur."]
+    INT_NO = 0x0,
+    #[doc = "Interrupt occurred."]
+    INT_YES = 0x01,
+}
+impl UI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> UI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for UI {
+    #[inline(always)]
+    fn from(val: u8) -> UI {
+        UI::from_bits(val)
+    }
+}
+impl From<UI> for u8 {
+    #[inline(always)]
+    fn from(val: UI) -> u8 {
+        UI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ULPII {
+    #[doc = "Event completion did not occur."]
+    EVENT_NO = 0x0,
+    #[doc = "Event completion occurred."]
+    EVENT_YES = 0x01,
+}
+impl ULPII {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ULPII {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ULPII {
+    #[inline(always)]
+    fn from(val: u8) -> ULPII {
+        ULPII::from_bits(val)
+    }
+}
+impl From<ULPII> for u8 {
+    #[inline(always)]
+    fn from(val: ULPII) -> u8 {
+        ULPII::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum UPI {
+    #[doc = "Interrupt did not occur."]
+    INT_NO = 0x0,
+    #[doc = "Interrupt occurred."]
+    INT_YES = 0x01,
+}
+impl UPI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> UPI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for UPI {
+    #[inline(always)]
+    fn from(val: u8) -> UPI {
+        UPI::from_bits(val)
+    }
+}
+impl From<UPI> for u8 {
+    #[inline(always)]
+    fn from(val: UPI) -> u8 {
+        UPI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum UPIE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl UPIE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> UPIE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for UPIE {
+    #[inline(always)]
+    fn from(val: u8) -> UPIE {
+        UPIE::from_bits(val)
+    }
+}
+impl From<UPIE> for u8 {
+    #[inline(always)]
+    fn from(val: UPIE) -> u8 {
+        UPIE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum URE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl URE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> URE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for URE {
+    #[inline(always)]
+    fn from(val: u8) -> URE {
+        URE::from_bits(val)
+    }
+}
+impl From<URE> for u8 {
+    #[inline(always)]
+    fn from(val: URE) -> u8 {
+        URE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum URI {
+    #[doc = "USB reset not received."]
+    USB_NO = 0x0,
+    #[doc = "USB reset received."]
+    USB_YES = 0x01,
+}
+impl URI {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> URI {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for URI {
+    #[inline(always)]
+    fn from(val: u8) -> URI {
+        URI::from_bits(val)
+    }
+}
+impl From<URI> for u8 {
+    #[inline(always)]
+    fn from(val: URI) -> u8 {
+        URI::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WKCN {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl WKCN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> WKCN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for WKCN {
+    #[inline(always)]
+    fn from(val: u8) -> WKCN {
+        WKCN::from_bits(val)
+    }
+}
+impl From<WKCN> for u8 {
+    #[inline(always)]
+    fn from(val: WKCN) -> u8 {
+        WKCN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WKDC {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl WKDC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> WKDC {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for WKDC {
+    #[inline(always)]
+    fn from(val: u8) -> WKDC {
+        WKDC::from_bits(val)
+    }
+}
+impl From<WKDC> for u8 {
+    #[inline(always)]
+    fn from(val: WKDC) -> u8 {
+        WKDC::to_bits(val)
+    }
+}

--- a/nxp-pac/src/meta_peripherals/mcxa/USBNC.rs
+++ b/nxp-pac/src/meta_peripherals/mcxa/USBNC.rs
@@ -1,0 +1,2068 @@
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e5ab29f 2026-04-30))"]
+#[doc = "USBNC."]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct Usbnc {
+    ptr: *mut u8,
+}
+unsafe impl Send for Usbnc {}
+unsafe impl Sync for Usbnc {}
+impl Usbnc {
+    #[inline(always)]
+    pub const unsafe fn from_ptr(ptr: *mut ()) -> Self {
+        Self { ptr: ptr as _ }
+    }
+    #[inline(always)]
+    pub const fn as_ptr(&self) -> *mut () {
+        self.ptr as _
+    }
+    #[doc = "USB Control 1."]
+    #[inline(always)]
+    pub const fn CTRL1(self) -> crate::pac::common::Reg<CTRL1, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+    }
+    #[doc = "USB Control 2."]
+    #[inline(always)]
+    pub const fn CTRL2(self) -> crate::pac::common::Reg<CTRL2, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
+    }
+    #[doc = "HSIC DLL Configure Register 4."]
+    #[inline(always)]
+    pub const fn HSIC_DLL_CFG4(
+        self,
+    ) -> crate::pac::common::Reg<HSIC_DLL_CFG4, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
+    }
+    #[doc = "USB LPM Control and Status 0."]
+    #[inline(always)]
+    pub const fn LPM_CSR0(self) -> crate::pac::common::Reg<LPM_CSR0, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xa0usize) as _) }
+    }
+    #[doc = "USB LPM Control and Status 1."]
+    #[inline(always)]
+    pub const fn LPM_CSR1(self) -> crate::pac::common::Reg<LPM_CSR1, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xa4usize) as _) }
+    }
+    #[doc = "USB LPM Control and Status 2."]
+    #[inline(always)]
+    pub const fn LPM_CSR2(self) -> crate::pac::common::Reg<LPM_CSR2, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xa8usize) as _) }
+    }
+    #[doc = "USB Clock Recovery Control."]
+    #[inline(always)]
+    pub const fn CLK_RECOVER_CTRL(
+        self,
+    ) -> crate::pac::common::Reg<CLK_RECOVER_CTRL, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0200usize) as _) }
+    }
+    #[doc = "FIRC Oscillator Enable."]
+    #[inline(always)]
+    pub const fn CLK_RECOVER_IRC_EN(
+        self,
+    ) -> crate::pac::common::Reg<CLK_RECOVER_IRC_EN, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0204usize) as _) }
+    }
+    #[doc = "Clock Recovery Combined Interrupt Enable."]
+    #[inline(always)]
+    pub const fn CLK_RECOVER_INT_EN(
+        self,
+    ) -> crate::pac::common::Reg<CLK_RECOVER_INT_EN, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0214usize) as _) }
+    }
+    #[doc = "Clock Recovery Separated Interrupt Status."]
+    #[inline(always)]
+    pub const fn CLK_RECOVER_INT_STATUS(
+        self,
+    ) -> crate::pac::common::Reg<CLK_RECOVER_INT_STATUS, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x021cusize) as _) }
+    }
+}
+#[doc = "USB Clock Recovery Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct CLK_RECOVER_CTRL(pub u8);
+impl CLK_RECOVER_CTRL {
+    #[doc = "Selects the source for the initial FIRC192M trim fine value used after a reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TRIM_INIT_VAL_SEL(&self) -> TRIM_INIT_VAL_SEL {
+        let val = (self.0 >> 3usize) & 0x01;
+        TRIM_INIT_VAL_SEL::from_bits(val as u8)
+    }
+    #[doc = "Selects the source for the initial FIRC192M trim fine value used after a reset."]
+    #[inline(always)]
+    pub const fn set_TRIM_INIT_VAL_SEL(&mut self, val: TRIM_INIT_VAL_SEL) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val.to_bits() as u8) & 0x01) << 3usize);
+    }
+    #[doc = "Restart from IFR Trim Value."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RESTART_IFRTRIM_EN(&self) -> RESTART_IFRTRIM_EN {
+        let val = (self.0 >> 5usize) & 0x01;
+        RESTART_IFRTRIM_EN::from_bits(val as u8)
+    }
+    #[doc = "Restart from IFR Trim Value."]
+    #[inline(always)]
+    pub const fn set_RESTART_IFRTRIM_EN(&mut self, val: RESTART_IFRTRIM_EN) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u8) & 0x01) << 5usize);
+    }
+    #[doc = "Reset or Resume to Rough Phase Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RESET_RESUME_ROUGH_EN(&self) -> RESET_RESUME_ROUGH_EN {
+        let val = (self.0 >> 6usize) & 0x01;
+        RESET_RESUME_ROUGH_EN::from_bits(val as u8)
+    }
+    #[doc = "Reset or Resume to Rough Phase Enable."]
+    #[inline(always)]
+    pub const fn set_RESET_RESUME_ROUGH_EN(&mut self, val: RESET_RESUME_ROUGH_EN) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u8) & 0x01) << 6usize);
+    }
+    #[doc = "Crystal-Less USB Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CLOCK_RECOVER_EN(&self) -> CLOCK_RECOVER_EN {
+        let val = (self.0 >> 7usize) & 0x01;
+        CLOCK_RECOVER_EN::from_bits(val as u8)
+    }
+    #[doc = "Crystal-Less USB Enable."]
+    #[inline(always)]
+    pub const fn set_CLOCK_RECOVER_EN(&mut self, val: CLOCK_RECOVER_EN) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u8) & 0x01) << 7usize);
+    }
+}
+impl Default for CLK_RECOVER_CTRL {
+    #[inline(always)]
+    fn default() -> CLK_RECOVER_CTRL {
+        CLK_RECOVER_CTRL(0)
+    }
+}
+impl core::fmt::Debug for CLK_RECOVER_CTRL {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CLK_RECOVER_CTRL")
+            .field("TRIM_INIT_VAL_SEL", &self.TRIM_INIT_VAL_SEL())
+            .field("RESTART_IFRTRIM_EN", &self.RESTART_IFRTRIM_EN())
+            .field("RESET_RESUME_ROUGH_EN", &self.RESET_RESUME_ROUGH_EN())
+            .field("CLOCK_RECOVER_EN", &self.CLOCK_RECOVER_EN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CLK_RECOVER_CTRL {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "CLK_RECOVER_CTRL {{ TRIM_INIT_VAL_SEL: {:?}, RESTART_IFRTRIM_EN: {:?}, RESET_RESUME_ROUGH_EN: {:?}, CLOCK_RECOVER_EN: {:?} }}",
+            self.TRIM_INIT_VAL_SEL(),
+            self.RESTART_IFRTRIM_EN(),
+            self.RESET_RESUME_ROUGH_EN(),
+            self.CLOCK_RECOVER_EN()
+        )
+    }
+}
+#[doc = "Clock Recovery Combined Interrupt Enable."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct CLK_RECOVER_INT_EN(pub u8);
+impl CLK_RECOVER_INT_EN {
+    #[doc = "Overflow error interrupt enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OVF_ERROR_EN(&self) -> OVF_ERROR_EN {
+        let val = (self.0 >> 4usize) & 0x01;
+        OVF_ERROR_EN::from_bits(val as u8)
+    }
+    #[doc = "Overflow error interrupt enable."]
+    #[inline(always)]
+    pub const fn set_OVF_ERROR_EN(&mut self, val: OVF_ERROR_EN) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u8) & 0x01) << 4usize);
+    }
+}
+impl Default for CLK_RECOVER_INT_EN {
+    #[inline(always)]
+    fn default() -> CLK_RECOVER_INT_EN {
+        CLK_RECOVER_INT_EN(0)
+    }
+}
+impl core::fmt::Debug for CLK_RECOVER_INT_EN {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CLK_RECOVER_INT_EN")
+            .field("OVF_ERROR_EN", &self.OVF_ERROR_EN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CLK_RECOVER_INT_EN {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "CLK_RECOVER_INT_EN {{ OVF_ERROR_EN: {:?} }}",
+            self.OVF_ERROR_EN()
+        )
+    }
+}
+#[doc = "Clock Recovery Separated Interrupt Status."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct CLK_RECOVER_INT_STATUS(pub u8);
+impl CLK_RECOVER_INT_STATUS {
+    #[doc = "Overflow Error Interrupt Status Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OVF_ERROR(&self) -> OVF_ERROR {
+        let val = (self.0 >> 4usize) & 0x01;
+        OVF_ERROR::from_bits(val as u8)
+    }
+    #[doc = "Overflow Error Interrupt Status Flag."]
+    #[inline(always)]
+    pub const fn set_OVF_ERROR(&mut self, val: OVF_ERROR) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u8) & 0x01) << 4usize);
+    }
+}
+impl Default for CLK_RECOVER_INT_STATUS {
+    #[inline(always)]
+    fn default() -> CLK_RECOVER_INT_STATUS {
+        CLK_RECOVER_INT_STATUS(0)
+    }
+}
+impl core::fmt::Debug for CLK_RECOVER_INT_STATUS {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CLK_RECOVER_INT_STATUS")
+            .field("OVF_ERROR", &self.OVF_ERROR())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CLK_RECOVER_INT_STATUS {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "CLK_RECOVER_INT_STATUS {{ OVF_ERROR: {:?} }}",
+            self.OVF_ERROR()
+        )
+    }
+}
+#[doc = "FIRC Oscillator Enable."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct CLK_RECOVER_IRC_EN(pub u8);
+impl CLK_RECOVER_IRC_EN {
+    #[doc = "Fast IRC enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn IRC_EN(&self) -> IRC_EN {
+        let val = (self.0 >> 1usize) & 0x01;
+        IRC_EN::from_bits(val as u8)
+    }
+    #[doc = "Fast IRC enable."]
+    #[inline(always)]
+    pub const fn set_IRC_EN(&mut self, val: IRC_EN) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val.to_bits() as u8) & 0x01) << 1usize);
+    }
+}
+impl Default for CLK_RECOVER_IRC_EN {
+    #[inline(always)]
+    fn default() -> CLK_RECOVER_IRC_EN {
+        CLK_RECOVER_IRC_EN(0)
+    }
+}
+impl core::fmt::Debug for CLK_RECOVER_IRC_EN {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CLK_RECOVER_IRC_EN")
+            .field("IRC_EN", &self.IRC_EN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CLK_RECOVER_IRC_EN {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "CLK_RECOVER_IRC_EN {{ IRC_EN: {:?} }}", self.IRC_EN())
+    }
+}
+#[doc = "USB Control 1."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct CTRL1(pub u32);
+impl CTRL1 {
+    #[doc = "Overcurrent Disable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OVER_CUR_DIS(&self) -> OVER_CUR_DIS {
+        let val = (self.0 >> 7usize) & 0x01;
+        OVER_CUR_DIS::from_bits(val as u8)
+    }
+    #[doc = "Overcurrent Disable."]
+    #[inline(always)]
+    pub const fn set_OVER_CUR_DIS(&mut self, val: OVER_CUR_DIS) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "Overcurrent Polarity."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OVER_CUR_POL(&self) -> OVER_CUR_POL {
+        let val = (self.0 >> 8usize) & 0x01;
+        OVER_CUR_POL::from_bits(val as u8)
+    }
+    #[doc = "Overcurrent Polarity."]
+    #[inline(always)]
+    pub const fn set_OVER_CUR_POL(&mut self, val: OVER_CUR_POL) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val.to_bits() as u32) & 0x01) << 8usize);
+    }
+    #[doc = "Power Polarity."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PWR_POL(&self) -> PWR_POL {
+        let val = (self.0 >> 9usize) & 0x01;
+        PWR_POL::from_bits(val as u8)
+    }
+    #[doc = "Power Polarity."]
+    #[inline(always)]
+    pub const fn set_PWR_POL(&mut self, val: PWR_POL) {
+        self.0 = (self.0 & !(0x01 << 9usize)) | (((val.to_bits() as u32) & 0x01) << 9usize);
+    }
+    #[doc = "Wake-Up Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WIE(&self) -> WIE {
+        let val = (self.0 >> 10usize) & 0x01;
+        WIE::from_bits(val as u8)
+    }
+    #[doc = "Wake-Up Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_WIE(&mut self, val: WIE) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val.to_bits() as u32) & 0x01) << 10usize);
+    }
+    #[doc = "Software Wake-Up Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WKUP_SW_EN(&self) -> WKUP_SW_EN {
+        let val = (self.0 >> 14usize) & 0x01;
+        WKUP_SW_EN::from_bits(val as u8)
+    }
+    #[doc = "Software Wake-Up Enable."]
+    #[inline(always)]
+    pub const fn set_WKUP_SW_EN(&mut self, val: WKUP_SW_EN) {
+        self.0 = (self.0 & !(0x01 << 14usize)) | (((val.to_bits() as u32) & 0x01) << 14usize);
+    }
+    #[doc = "Software Wake-Up."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WKUP_SW(&self) -> WKUP_SW {
+        let val = (self.0 >> 15usize) & 0x01;
+        WKUP_SW::from_bits(val as u8)
+    }
+    #[doc = "Software Wake-Up."]
+    #[inline(always)]
+    pub const fn set_WKUP_SW(&mut self, val: WKUP_SW) {
+        self.0 = (self.0 & !(0x01 << 15usize)) | (((val.to_bits() as u32) & 0x01) << 15usize);
+    }
+    #[doc = "Wake-Up After ID Change Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WKUP_ID_EN(&self) -> WKUP_ID_EN {
+        let val = (self.0 >> 16usize) & 0x01;
+        WKUP_ID_EN::from_bits(val as u8)
+    }
+    #[doc = "Wake-Up After ID Change Enable."]
+    #[inline(always)]
+    pub const fn set_WKUP_ID_EN(&mut self, val: WKUP_ID_EN) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val.to_bits() as u32) & 0x01) << 16usize);
+    }
+    #[doc = "Wake-Up After VBUS Change Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WKUP_VBUS_EN(&self) -> WKUP_VBUS_EN {
+        let val = (self.0 >> 17usize) & 0x01;
+        WKUP_VBUS_EN::from_bits(val as u8)
+    }
+    #[doc = "Wake-Up After VBUS Change Enable."]
+    #[inline(always)]
+    pub const fn set_WKUP_VBUS_EN(&mut self, val: WKUP_VBUS_EN) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val.to_bits() as u32) & 0x01) << 17usize);
+    }
+    #[doc = "Remote Wake-Up Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn REMOTE_WAKEUP_EN(&self) -> REMOTE_WAKEUP_EN {
+        let val = (self.0 >> 28usize) & 0x01;
+        REMOTE_WAKEUP_EN::from_bits(val as u8)
+    }
+    #[doc = "Remote Wake-Up Enable."]
+    #[inline(always)]
+    pub const fn set_REMOTE_WAKEUP_EN(&mut self, val: REMOTE_WAKEUP_EN) {
+        self.0 = (self.0 & !(0x01 << 28usize)) | (((val.to_bits() as u32) & 0x01) << 28usize);
+    }
+    #[doc = "Wake-Up After DP or DM Change Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WKUP_DPDM_EN(&self) -> WKUP_DPDM_EN {
+        let val = (self.0 >> 29usize) & 0x01;
+        WKUP_DPDM_EN::from_bits(val as u8)
+    }
+    #[doc = "Wake-Up After DP or DM Change Enable."]
+    #[inline(always)]
+    pub const fn set_WKUP_DPDM_EN(&mut self, val: WKUP_DPDM_EN) {
+        self.0 = (self.0 & !(0x01 << 29usize)) | (((val.to_bits() as u32) & 0x01) << 29usize);
+    }
+    #[doc = "Wake-Up Interrupt Request."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WIR(&self) -> WIR {
+        let val = (self.0 >> 31usize) & 0x01;
+        WIR::from_bits(val as u8)
+    }
+    #[doc = "Wake-Up Interrupt Request."]
+    #[inline(always)]
+    pub const fn set_WIR(&mut self, val: WIR) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val.to_bits() as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for CTRL1 {
+    #[inline(always)]
+    fn default() -> CTRL1 {
+        CTRL1(0)
+    }
+}
+impl core::fmt::Debug for CTRL1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CTRL1")
+            .field("OVER_CUR_DIS", &self.OVER_CUR_DIS())
+            .field("OVER_CUR_POL", &self.OVER_CUR_POL())
+            .field("PWR_POL", &self.PWR_POL())
+            .field("WIE", &self.WIE())
+            .field("WKUP_SW_EN", &self.WKUP_SW_EN())
+            .field("WKUP_SW", &self.WKUP_SW())
+            .field("WKUP_ID_EN", &self.WKUP_ID_EN())
+            .field("WKUP_VBUS_EN", &self.WKUP_VBUS_EN())
+            .field("REMOTE_WAKEUP_EN", &self.REMOTE_WAKEUP_EN())
+            .field("WKUP_DPDM_EN", &self.WKUP_DPDM_EN())
+            .field("WIR", &self.WIR())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CTRL1 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "CTRL1 {{ OVER_CUR_DIS: {:?}, OVER_CUR_POL: {:?}, PWR_POL: {:?}, WIE: {:?}, WKUP_SW_EN: {:?}, WKUP_SW: {:?}, WKUP_ID_EN: {:?}, WKUP_VBUS_EN: {:?}, REMOTE_WAKEUP_EN: {:?}, WKUP_DPDM_EN: {:?}, WIR: {:?} }}",
+            self.OVER_CUR_DIS(),
+            self.OVER_CUR_POL(),
+            self.PWR_POL(),
+            self.WIE(),
+            self.WKUP_SW_EN(),
+            self.WKUP_SW(),
+            self.WKUP_ID_EN(),
+            self.WKUP_VBUS_EN(),
+            self.REMOTE_WAKEUP_EN(),
+            self.WKUP_DPDM_EN(),
+            self.WIR()
+        )
+    }
+}
+#[doc = "USB Control 2."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct CTRL2(pub u32);
+impl CTRL2 {
+    #[doc = "VBUS Source Select."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_SOURCE_SEL(&self) -> VBUS_SOURCE_SEL {
+        let val = (self.0 >> 0usize) & 0x03;
+        VBUS_SOURCE_SEL::from_bits(val as u8)
+    }
+    #[doc = "VBUS Source Select."]
+    #[inline(always)]
+    pub const fn set_VBUS_SOURCE_SEL(&mut self, val: VBUS_SOURCE_SEL) {
+        self.0 = (self.0 & !(0x03 << 0usize)) | (((val.to_bits() as u32) & 0x03) << 0usize);
+    }
+    #[doc = "UTMI Clock Valid Flag."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn UTMI_CLK_VLD(&self) -> UTMI_CLK_VLD {
+        let val = (self.0 >> 31usize) & 0x01;
+        UTMI_CLK_VLD::from_bits(val as u8)
+    }
+    #[doc = "UTMI Clock Valid Flag."]
+    #[inline(always)]
+    pub const fn set_UTMI_CLK_VLD(&mut self, val: UTMI_CLK_VLD) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val.to_bits() as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for CTRL2 {
+    #[inline(always)]
+    fn default() -> CTRL2 {
+        CTRL2(0)
+    }
+}
+impl core::fmt::Debug for CTRL2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CTRL2")
+            .field("VBUS_SOURCE_SEL", &self.VBUS_SOURCE_SEL())
+            .field("UTMI_CLK_VLD", &self.UTMI_CLK_VLD())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CTRL2 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "CTRL2 {{ VBUS_SOURCE_SEL: {:?}, UTMI_CLK_VLD: {:?} }}",
+            self.VBUS_SOURCE_SEL(),
+            self.UTMI_CLK_VLD()
+        )
+    }
+}
+#[doc = "HSIC DLL Configure Register 4."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct HSIC_DLL_CFG4(pub u32);
+impl HSIC_DLL_CFG4 {
+    #[doc = "LPM EXT token ENDP check enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_EN_ENDP_CHK(&self) -> LPM_EN_ENDP_CHK {
+        let val = (self.0 >> 30usize) & 0x01;
+        LPM_EN_ENDP_CHK::from_bits(val as u8)
+    }
+    #[doc = "LPM EXT token ENDP check enable."]
+    #[inline(always)]
+    pub const fn set_LPM_EN_ENDP_CHK(&mut self, val: LPM_EN_ENDP_CHK) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val.to_bits() as u32) & 0x01) << 30usize);
+    }
+    #[doc = "FS Isochronous back to back transfer enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn FS_ISO_B2B_FIXEN(&self) -> FS_ISO_B2B_FIXEN {
+        let val = (self.0 >> 31usize) & 0x01;
+        FS_ISO_B2B_FIXEN::from_bits(val as u8)
+    }
+    #[doc = "FS Isochronous back to back transfer enable."]
+    #[inline(always)]
+    pub const fn set_FS_ISO_B2B_FIXEN(&mut self, val: FS_ISO_B2B_FIXEN) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val.to_bits() as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for HSIC_DLL_CFG4 {
+    #[inline(always)]
+    fn default() -> HSIC_DLL_CFG4 {
+        HSIC_DLL_CFG4(0)
+    }
+}
+impl core::fmt::Debug for HSIC_DLL_CFG4 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("HSIC_DLL_CFG4")
+            .field("LPM_EN_ENDP_CHK", &self.LPM_EN_ENDP_CHK())
+            .field("FS_ISO_B2B_FIXEN", &self.FS_ISO_B2B_FIXEN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for HSIC_DLL_CFG4 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "HSIC_DLL_CFG4 {{ LPM_EN_ENDP_CHK: {:?}, FS_ISO_B2B_FIXEN: {:?} }}",
+            self.LPM_EN_ENDP_CHK(),
+            self.FS_ISO_B2B_FIXEN()
+        )
+    }
+}
+#[doc = "USB LPM Control and Status 0."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct LPM_CSR0(pub u32);
+impl LPM_CSR0 {
+    #[doc = "Link Power Management Feature Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_EN(&self) -> LPM_EN {
+        let val = (self.0 >> 0usize) & 0x01;
+        LPM_EN::from_bits(val as u8)
+    }
+    #[doc = "Link Power Management Feature Enable."]
+    #[inline(always)]
+    pub const fn set_LPM_EN(&mut self, val: LPM_EN) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Link Power Management ECN Errata Feature Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_ERRATA_EN(&self) -> LPM_ERRATA_EN {
+        let val = (self.0 >> 1usize) & 0x01;
+        LPM_ERRATA_EN::from_bits(val as u8)
+    }
+    #[doc = "Link Power Management ECN Errata Feature Enable."]
+    #[inline(always)]
+    pub const fn set_LPM_ERRATA_EN(&mut self, val: LPM_ERRATA_EN) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val.to_bits() as u32) & 0x01) << 1usize);
+    }
+    #[doc = "Auto Low-Power Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_AUTO_PHCD(&self) -> LPM_AUTO_PHCD {
+        let val = (self.0 >> 3usize) & 0x01;
+        LPM_AUTO_PHCD::from_bits(val as u8)
+    }
+    #[doc = "Auto Low-Power Mode."]
+    #[inline(always)]
+    pub const fn set_LPM_AUTO_PHCD(&mut self, val: LPM_AUTO_PHCD) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val.to_bits() as u32) & 0x01) << 3usize);
+    }
+    #[doc = "LPM Resume OK."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_RESUMEOK(&self) -> LPM_RESUMEOK {
+        let val = (self.0 >> 30usize) & 0x01;
+        LPM_RESUMEOK::from_bits(val as u8)
+    }
+    #[doc = "LPM Resume OK."]
+    #[inline(always)]
+    pub const fn set_LPM_RESUMEOK(&mut self, val: LPM_RESUMEOK) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val.to_bits() as u32) & 0x01) << 30usize);
+    }
+    #[doc = "LPM Active."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_L1_ACTIVE(&self) -> LPM_L1_ACTIVE {
+        let val = (self.0 >> 31usize) & 0x01;
+        LPM_L1_ACTIVE::from_bits(val as u8)
+    }
+    #[doc = "LPM Active."]
+    #[inline(always)]
+    pub const fn set_LPM_L1_ACTIVE(&mut self, val: LPM_L1_ACTIVE) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val.to_bits() as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for LPM_CSR0 {
+    #[inline(always)]
+    fn default() -> LPM_CSR0 {
+        LPM_CSR0(0)
+    }
+}
+impl core::fmt::Debug for LPM_CSR0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LPM_CSR0")
+            .field("LPM_EN", &self.LPM_EN())
+            .field("LPM_ERRATA_EN", &self.LPM_ERRATA_EN())
+            .field("LPM_AUTO_PHCD", &self.LPM_AUTO_PHCD())
+            .field("LPM_RESUMEOK", &self.LPM_RESUMEOK())
+            .field("LPM_L1_ACTIVE", &self.LPM_L1_ACTIVE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for LPM_CSR0 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "LPM_CSR0 {{ LPM_EN: {:?}, LPM_ERRATA_EN: {:?}, LPM_AUTO_PHCD: {:?}, LPM_RESUMEOK: {:?}, LPM_L1_ACTIVE: {:?} }}",
+            self.LPM_EN(),
+            self.LPM_ERRATA_EN(),
+            self.LPM_AUTO_PHCD(),
+            self.LPM_RESUMEOK(),
+            self.LPM_L1_ACTIVE()
+        )
+    }
+}
+#[doc = "USB LPM Control and Status 1."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct LPM_CSR1(pub u32);
+impl LPM_CSR1 {
+    #[doc = "Device Required Host Initiated Resume Duration."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_DEV_BESLTHRES(&self) -> LPM_DEV_BESLTHRES {
+        let val = (self.0 >> 0usize) & 0x0f;
+        LPM_DEV_BESLTHRES::from_bits(val as u8)
+    }
+    #[doc = "Device Required Host Initiated Resume Duration."]
+    #[inline(always)]
+    pub const fn set_LPM_DEV_BESLTHRES(&mut self, val: LPM_DEV_BESLTHRES) {
+        self.0 = (self.0 & !(0x0f << 0usize)) | (((val.to_bits() as u32) & 0x0f) << 0usize);
+    }
+    #[doc = "LPM Device Response."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_DEV_RES(&self) -> LPM_DEV_RES {
+        let val = (self.0 >> 4usize) & 0x01;
+        LPM_DEV_RES::from_bits(val as u8)
+    }
+    #[doc = "LPM Device Response."]
+    #[inline(always)]
+    pub const fn set_LPM_DEV_RES(&mut self, val: LPM_DEV_RES) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u32) & 0x01) << 4usize);
+    }
+    #[doc = "LPM Device Data Pending."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_DEV_DP(&self) -> LPM_DEV_DP {
+        let val = (self.0 >> 5usize) & 0x01;
+        LPM_DEV_DP::from_bits(val as u8)
+    }
+    #[doc = "LPM Device Data Pending."]
+    #[inline(always)]
+    pub const fn set_LPM_DEV_DP(&mut self, val: LPM_DEV_DP) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "LPM Device Response Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_DEV_RSPSTS(&self) -> LPM_DEV_RSPSTS {
+        let val = (self.0 >> 20usize) & 0x03;
+        LPM_DEV_RSPSTS::from_bits(val as u8)
+    }
+    #[doc = "LPM Device Response Status."]
+    #[inline(always)]
+    pub const fn set_LPM_DEV_RSPSTS(&mut self, val: LPM_DEV_RSPSTS) {
+        self.0 = (self.0 & !(0x03 << 20usize)) | (((val.to_bits() as u32) & 0x03) << 20usize);
+    }
+    #[doc = "LPM Device Received bRemoteWake."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_DEV_RWKENRCVD(&self) -> LPM_DEV_RWKENRCVD {
+        let val = (self.0 >> 23usize) & 0x01;
+        LPM_DEV_RWKENRCVD::from_bits(val as u8)
+    }
+    #[doc = "LPM Device Received bRemoteWake."]
+    #[inline(always)]
+    pub const fn set_LPM_DEV_RWKENRCVD(&mut self, val: LPM_DEV_RWKENRCVD) {
+        self.0 = (self.0 & !(0x01 << 23usize)) | (((val.to_bits() as u32) & 0x01) << 23usize);
+    }
+    #[doc = "LPM Device Received bLinkState."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_DEV_LNKSTRCVD(&self) -> LPM_DEV_LNKSTRCVD {
+        let val = (self.0 >> 24usize) & 0x0f;
+        LPM_DEV_LNKSTRCVD::from_bits(val as u8)
+    }
+    #[doc = "LPM Device Received bLinkState."]
+    #[inline(always)]
+    pub const fn set_LPM_DEV_LNKSTRCVD(&mut self, val: LPM_DEV_LNKSTRCVD) {
+        self.0 = (self.0 & !(0x0f << 24usize)) | (((val.to_bits() as u32) & 0x0f) << 24usize);
+    }
+    #[doc = "LPM Device Received BESL."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_DEV_BESLRCVD(&self) -> u8 {
+        let val = (self.0 >> 28usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "LPM Device Received BESL."]
+    #[inline(always)]
+    pub const fn set_LPM_DEV_BESLRCVD(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 28usize)) | (((val as u32) & 0x0f) << 28usize);
+    }
+}
+impl Default for LPM_CSR1 {
+    #[inline(always)]
+    fn default() -> LPM_CSR1 {
+        LPM_CSR1(0)
+    }
+}
+impl core::fmt::Debug for LPM_CSR1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LPM_CSR1")
+            .field("LPM_DEV_BESLTHRES", &self.LPM_DEV_BESLTHRES())
+            .field("LPM_DEV_RES", &self.LPM_DEV_RES())
+            .field("LPM_DEV_DP", &self.LPM_DEV_DP())
+            .field("LPM_DEV_RSPSTS", &self.LPM_DEV_RSPSTS())
+            .field("LPM_DEV_RWKENRCVD", &self.LPM_DEV_RWKENRCVD())
+            .field("LPM_DEV_LNKSTRCVD", &self.LPM_DEV_LNKSTRCVD())
+            .field("LPM_DEV_BESLRCVD", &self.LPM_DEV_BESLRCVD())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for LPM_CSR1 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "LPM_CSR1 {{ LPM_DEV_BESLTHRES: {:?}, LPM_DEV_RES: {:?}, LPM_DEV_DP: {:?}, LPM_DEV_RSPSTS: {:?}, LPM_DEV_RWKENRCVD: {:?}, LPM_DEV_LNKSTRCVD: {:?}, LPM_DEV_BESLRCVD: {=u8:?} }}",
+            self.LPM_DEV_BESLTHRES(),
+            self.LPM_DEV_RES(),
+            self.LPM_DEV_DP(),
+            self.LPM_DEV_RSPSTS(),
+            self.LPM_DEV_RWKENRCVD(),
+            self.LPM_DEV_LNKSTRCVD(),
+            self.LPM_DEV_BESLRCVD()
+        )
+    }
+}
+#[doc = "USB LPM Control and Status 2."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct LPM_CSR2(pub u32);
+impl LPM_CSR2 {
+    #[doc = "LPM Host Send Extension Token."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_HST_SEND(&self) -> LPM_HST_SEND {
+        let val = (self.0 >> 0usize) & 0x01;
+        LPM_HST_SEND::from_bits(val as u8)
+    }
+    #[doc = "LPM Host Send Extension Token."]
+    #[inline(always)]
+    pub const fn set_LPM_HST_SEND(&mut self, val: LPM_HST_SEND) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "LPM Host Extension Token's Device Address."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_HST_DEVADD(&self) -> u8 {
+        let val = (self.0 >> 1usize) & 0x7f;
+        val as u8
+    }
+    #[doc = "LPM Host Extension Token's Device Address."]
+    #[inline(always)]
+    pub const fn set_LPM_HST_DEVADD(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x7f << 1usize)) | (((val as u32) & 0x7f) << 1usize);
+    }
+    #[doc = "LPM Host Extension Token's BESL or HIRD."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_HST_BESL(&self) -> u8 {
+        let val = (self.0 >> 8usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "LPM Host Extension Token's BESL or HIRD."]
+    #[inline(always)]
+    pub const fn set_LPM_HST_BESL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 8usize)) | (((val as u32) & 0x0f) << 8usize);
+    }
+    #[doc = "LPM Host Extension Token's bRemoteWake."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_HST_RWKEN(&self) -> LPM_HST_RWKEN {
+        let val = (self.0 >> 12usize) & 0x01;
+        LPM_HST_RWKEN::from_bits(val as u8)
+    }
+    #[doc = "LPM Host Extension Token's bRemoteWake."]
+    #[inline(always)]
+    pub const fn set_LPM_HST_RWKEN(&mut self, val: LPM_HST_RWKEN) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val.to_bits() as u32) & 0x01) << 12usize);
+    }
+    #[doc = "LPM Host Response Status from the Device."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LPM_HST_STSRCVD(&self) -> LPM_HST_STSRCVD {
+        let val = (self.0 >> 28usize) & 0x07;
+        LPM_HST_STSRCVD::from_bits(val as u8)
+    }
+    #[doc = "LPM Host Response Status from the Device."]
+    #[inline(always)]
+    pub const fn set_LPM_HST_STSRCVD(&mut self, val: LPM_HST_STSRCVD) {
+        self.0 = (self.0 & !(0x07 << 28usize)) | (((val.to_bits() as u32) & 0x07) << 28usize);
+    }
+}
+impl Default for LPM_CSR2 {
+    #[inline(always)]
+    fn default() -> LPM_CSR2 {
+        LPM_CSR2(0)
+    }
+}
+impl core::fmt::Debug for LPM_CSR2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LPM_CSR2")
+            .field("LPM_HST_SEND", &self.LPM_HST_SEND())
+            .field("LPM_HST_DEVADD", &self.LPM_HST_DEVADD())
+            .field("LPM_HST_BESL", &self.LPM_HST_BESL())
+            .field("LPM_HST_RWKEN", &self.LPM_HST_RWKEN())
+            .field("LPM_HST_STSRCVD", &self.LPM_HST_STSRCVD())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for LPM_CSR2 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "LPM_CSR2 {{ LPM_HST_SEND: {:?}, LPM_HST_DEVADD: {=u8:?}, LPM_HST_BESL: {=u8:?}, LPM_HST_RWKEN: {:?}, LPM_HST_STSRCVD: {:?} }}",
+            self.LPM_HST_SEND(),
+            self.LPM_HST_DEVADD(),
+            self.LPM_HST_BESL(),
+            self.LPM_HST_RWKEN(),
+            self.LPM_HST_STSRCVD()
+        )
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CLOCK_RECOVER_EN {
+    #[doc = "Disable."]
+    DIS_CLK_RECOVER = 0x0,
+    #[doc = "Enable."]
+    EN_CLK_RECOVER = 0x01,
+}
+impl CLOCK_RECOVER_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> CLOCK_RECOVER_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for CLOCK_RECOVER_EN {
+    #[inline(always)]
+    fn from(val: u8) -> CLOCK_RECOVER_EN {
+        CLOCK_RECOVER_EN::from_bits(val)
+    }
+}
+impl From<CLOCK_RECOVER_EN> for u8 {
+    #[inline(always)]
+    fn from(val: CLOCK_RECOVER_EN) -> u8 {
+        CLOCK_RECOVER_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum FS_ISO_B2B_FIXEN {
+    #[doc = "Disabled."]
+    FS_ISO_B2B_FIXEN_0 = 0x0,
+    #[doc = "Enabled."]
+    FS_ISO_B2B_FIXEN_1 = 0x01,
+}
+impl FS_ISO_B2B_FIXEN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> FS_ISO_B2B_FIXEN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for FS_ISO_B2B_FIXEN {
+    #[inline(always)]
+    fn from(val: u8) -> FS_ISO_B2B_FIXEN {
+        FS_ISO_B2B_FIXEN::from_bits(val)
+    }
+}
+impl From<FS_ISO_B2B_FIXEN> for u8 {
+    #[inline(always)]
+    fn from(val: FS_ISO_B2B_FIXEN) -> u8 {
+        FS_ISO_B2B_FIXEN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum IRC_EN {
+    #[doc = "Disable."]
+    DIS_IRC = 0x0,
+    #[doc = "Enable."]
+    EN_IRC = 0x01,
+}
+impl IRC_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> IRC_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for IRC_EN {
+    #[inline(always)]
+    fn from(val: u8) -> IRC_EN {
+        IRC_EN::from_bits(val)
+    }
+}
+impl From<IRC_EN> for u8 {
+    #[inline(always)]
+    fn from(val: IRC_EN) -> u8 {
+        IRC_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_AUTO_PHCD {
+    #[doc = "Disable."]
+    LPM_AUTO_PHCD0 = 0x0,
+    #[doc = "Enable."]
+    LPM_AUTO_PHCD1 = 0x01,
+}
+impl LPM_AUTO_PHCD {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_AUTO_PHCD {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_AUTO_PHCD {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_AUTO_PHCD {
+        LPM_AUTO_PHCD::from_bits(val)
+    }
+}
+impl From<LPM_AUTO_PHCD> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_AUTO_PHCD) -> u8 {
+        LPM_AUTO_PHCD::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_DEV_BESLTHRES {
+    #[doc = "75 us, if LPM_ERRATA_EN = 1; 50 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRES0 = 0x0,
+    #[doc = "100 us, if LPM_ERRATA_EN = 1; 125 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRES1 = 0x01,
+    #[doc = "150 us, if LPM_ERRATA_EN = 1; 200 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRES2 = 0x02,
+    #[doc = "250 us, if LPM_ERRATA_EN = 1; 275 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRES3 = 0x03,
+    #[doc = "350 us, if LPM_ERRATA_EN = 1; 350 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRES4 = 0x04,
+    #[doc = "450 us, if LPM_ERRATA_EN = 1; 425 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRES5 = 0x05,
+    #[doc = "950 us, if LPM_ERRATA_EN = 1; 500 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRES6 = 0x06,
+    #[doc = "1950 us, if LPM_ERRATA_EN = 1; 575 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRES7 = 0x07,
+    #[doc = "2950 us, if LPM_ERRATA_EN = 1; 650 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRES8 = 0x08,
+    #[doc = "3950 us, if LPM_ERRATA_EN = 1; 725 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRES9 = 0x09,
+    #[doc = "4950 us, if LPM_ERRATA_EN = 1; 800 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRESA = 0x0a,
+    #[doc = "5950 us, if LPM_ERRATA_EN = 1; 875 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRESB = 0x0b,
+    #[doc = "6950 us, if LPM_ERRATA_EN = 1; 950 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRESC = 0x0c,
+    #[doc = "7950 us, if LPM_ERRATA_EN = 1; 1025 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRESD = 0x0d,
+    #[doc = "8950 us, if LPM_ERRATA_EN = 1; 1100 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRESE = 0x0e,
+    #[doc = "9950 us, if LPM_ERRATA_EN = 1; 1175 us, if LPM_ERRATA_EN = 0."]
+    LPM_DEV_BESLTHRESF = 0x0f,
+}
+impl LPM_DEV_BESLTHRES {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_DEV_BESLTHRES {
+        unsafe { core::mem::transmute(val & 0x0f) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_DEV_BESLTHRES {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_DEV_BESLTHRES {
+        LPM_DEV_BESLTHRES::from_bits(val)
+    }
+}
+impl From<LPM_DEV_BESLTHRES> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_DEV_BESLTHRES) -> u8 {
+        LPM_DEV_BESLTHRES::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_DEV_DP {
+    #[doc = "Not pending."]
+    LPM_DEV_DP0 = 0x0,
+    #[doc = "Pending."]
+    LPM_DEV_DP1 = 0x01,
+}
+impl LPM_DEV_DP {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_DEV_DP {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_DEV_DP {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_DEV_DP {
+        LPM_DEV_DP::from_bits(val)
+    }
+}
+impl From<LPM_DEV_DP> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_DEV_DP) -> u8 {
+        LPM_DEV_DP::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_DEV_LNKSTRCVD {
+    _RESERVED_0 = 0x0,
+    #[doc = "L1 (Sleep mode)."]
+    LPM_DEV_LNKSTRCVD1 = 0x01,
+    _RESERVED_2 = 0x02,
+    _RESERVED_3 = 0x03,
+    _RESERVED_4 = 0x04,
+    _RESERVED_5 = 0x05,
+    _RESERVED_6 = 0x06,
+    _RESERVED_7 = 0x07,
+    _RESERVED_8 = 0x08,
+    _RESERVED_9 = 0x09,
+    _RESERVED_a = 0x0a,
+    _RESERVED_b = 0x0b,
+    _RESERVED_c = 0x0c,
+    _RESERVED_d = 0x0d,
+    _RESERVED_e = 0x0e,
+    _RESERVED_f = 0x0f,
+}
+impl LPM_DEV_LNKSTRCVD {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_DEV_LNKSTRCVD {
+        unsafe { core::mem::transmute(val & 0x0f) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_DEV_LNKSTRCVD {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_DEV_LNKSTRCVD {
+        LPM_DEV_LNKSTRCVD::from_bits(val)
+    }
+}
+impl From<LPM_DEV_LNKSTRCVD> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_DEV_LNKSTRCVD) -> u8 {
+        LPM_DEV_LNKSTRCVD::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_DEV_RES {
+    #[doc = "Fourth condition not needed."]
+    LPM_DEV_RES0 = 0x0,
+    #[doc = "Fourth condition needed."]
+    LPM_DEV_RES1 = 0x01,
+}
+impl LPM_DEV_RES {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_DEV_RES {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_DEV_RES {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_DEV_RES {
+        LPM_DEV_RES::from_bits(val)
+    }
+}
+impl From<LPM_DEV_RES> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_DEV_RES) -> u8 {
+        LPM_DEV_RES::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_DEV_RSPSTS {
+    #[doc = "Invalid."]
+    LPM_DEV_RSPSTS0 = 0x0,
+    #[doc = "ACK."]
+    LPM_DEV_RSPSTS1 = 0x01,
+    #[doc = "NYET."]
+    LPM_DEV_RSPSTS2 = 0x02,
+    #[doc = "STALL."]
+    LPM_DEV_RSPSTS3 = 0x03,
+}
+impl LPM_DEV_RSPSTS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_DEV_RSPSTS {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_DEV_RSPSTS {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_DEV_RSPSTS {
+        LPM_DEV_RSPSTS::from_bits(val)
+    }
+}
+impl From<LPM_DEV_RSPSTS> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_DEV_RSPSTS) -> u8 {
+        LPM_DEV_RSPSTS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_DEV_RWKENRCVD {
+    #[doc = "0."]
+    LPM_DEV_RWKENRCVD0 = 0x0,
+    #[doc = "1."]
+    LPM_DEV_RWKENRCVD1 = 0x01,
+}
+impl LPM_DEV_RWKENRCVD {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_DEV_RWKENRCVD {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_DEV_RWKENRCVD {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_DEV_RWKENRCVD {
+        LPM_DEV_RWKENRCVD::from_bits(val)
+    }
+}
+impl From<LPM_DEV_RWKENRCVD> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_DEV_RWKENRCVD) -> u8 {
+        LPM_DEV_RWKENRCVD::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_EN {
+    #[doc = "Disable."]
+    LPM_EN0 = 0x0,
+    #[doc = "Enable."]
+    LPM_EN1 = 0x01,
+}
+impl LPM_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_EN {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_EN {
+        LPM_EN::from_bits(val)
+    }
+}
+impl From<LPM_EN> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_EN) -> u8 {
+        LPM_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_EN_ENDP_CHK {
+    #[doc = "Disabled."]
+    LPM_EN_ENDP_CHK_0 = 0x0,
+    #[doc = "Enabled."]
+    LPM_EN_ENDP_CHK_1 = 0x01,
+}
+impl LPM_EN_ENDP_CHK {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_EN_ENDP_CHK {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_EN_ENDP_CHK {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_EN_ENDP_CHK {
+        LPM_EN_ENDP_CHK::from_bits(val)
+    }
+}
+impl From<LPM_EN_ENDP_CHK> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_EN_ENDP_CHK) -> u8 {
+        LPM_EN_ENDP_CHK::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_ERRATA_EN {
+    #[doc = "Disable."]
+    LPM_ERRATA_EN0 = 0x0,
+    #[doc = "Enable."]
+    LPM_ERRATA_EN1 = 0x01,
+}
+impl LPM_ERRATA_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_ERRATA_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_ERRATA_EN {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_ERRATA_EN {
+        LPM_ERRATA_EN::from_bits(val)
+    }
+}
+impl From<LPM_ERRATA_EN> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_ERRATA_EN) -> u8 {
+        LPM_ERRATA_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_HST_RWKEN {
+    #[doc = "Disable."]
+    LPM_HST_RWKEN0 = 0x0,
+    #[doc = "Enable."]
+    LPM_HST_RWKEN1 = 0x01,
+}
+impl LPM_HST_RWKEN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_HST_RWKEN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_HST_RWKEN {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_HST_RWKEN {
+        LPM_HST_RWKEN::from_bits(val)
+    }
+}
+impl From<LPM_HST_RWKEN> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_HST_RWKEN) -> u8 {
+        LPM_HST_RWKEN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_HST_SEND {
+    #[doc = "LPM transaction did not happen or is complete."]
+    LPM_HST_SEND0 = 0x0,
+    #[doc = "LPM transaction is ongoing."]
+    LPM_HST_SEND1 = 0x01,
+}
+impl LPM_HST_SEND {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_HST_SEND {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_HST_SEND {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_HST_SEND {
+        LPM_HST_SEND::from_bits(val)
+    }
+}
+impl From<LPM_HST_SEND> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_HST_SEND) -> u8 {
+        LPM_HST_SEND::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_HST_STSRCVD {
+    #[doc = "Invalid."]
+    LPM_HST_STSRCVD0 = 0x0,
+    #[doc = "ACK."]
+    LPM_HST_STSRCVD1 = 0x01,
+    #[doc = "NYET."]
+    LPM_HST_STSRCVD2 = 0x02,
+    #[doc = "STALL."]
+    LPM_HST_STSRCVD3 = 0x03,
+    #[doc = "Timeout."]
+    LPM_HST_STSRCVD4 = 0x04,
+    #[doc = "ERR."]
+    LPM_HST_STSRCVD5 = 0x05,
+    _RESERVED_6 = 0x06,
+    _RESERVED_7 = 0x07,
+}
+impl LPM_HST_STSRCVD {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_HST_STSRCVD {
+        unsafe { core::mem::transmute(val & 0x07) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_HST_STSRCVD {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_HST_STSRCVD {
+        LPM_HST_STSRCVD::from_bits(val)
+    }
+}
+impl From<LPM_HST_STSRCVD> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_HST_STSRCVD) -> u8 {
+        LPM_HST_STSRCVD::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_L1_ACTIVE {
+    #[doc = "Inactive."]
+    LPM_L1_ACTIVE0 = 0x0,
+    #[doc = "Active."]
+    LPM_L1_ACTIVE1 = 0x01,
+}
+impl LPM_L1_ACTIVE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_L1_ACTIVE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_L1_ACTIVE {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_L1_ACTIVE {
+        LPM_L1_ACTIVE::from_bits(val)
+    }
+}
+impl From<LPM_L1_ACTIVE> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_L1_ACTIVE) -> u8 {
+        LPM_L1_ACTIVE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LPM_RESUMEOK {
+    #[doc = "Cannot resume."]
+    LPM_RESUMEOK0 = 0x0,
+    #[doc = "Can resume."]
+    LPM_RESUMEOK1 = 0x01,
+}
+impl LPM_RESUMEOK {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LPM_RESUMEOK {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LPM_RESUMEOK {
+    #[inline(always)]
+    fn from(val: u8) -> LPM_RESUMEOK {
+        LPM_RESUMEOK::from_bits(val)
+    }
+}
+impl From<LPM_RESUMEOK> for u8 {
+    #[inline(always)]
+    fn from(val: LPM_RESUMEOK) -> u8 {
+        LPM_RESUMEOK::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OVER_CUR_DIS {
+    #[doc = "Enable."]
+    OVRCRNT_DETCT_EN = 0x0,
+    #[doc = "Disable."]
+    OVRCRNT_DETCT_DIS = 0x01,
+}
+impl OVER_CUR_DIS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> OVER_CUR_DIS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for OVER_CUR_DIS {
+    #[inline(always)]
+    fn from(val: u8) -> OVER_CUR_DIS {
+        OVER_CUR_DIS::from_bits(val)
+    }
+}
+impl From<OVER_CUR_DIS> for u8 {
+    #[inline(always)]
+    fn from(val: OVER_CUR_DIS) -> u8 {
+        OVER_CUR_DIS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OVER_CUR_POL {
+    #[doc = "Active high."]
+    ACTIVE_HI_OVRCRNT = 0x0,
+    #[doc = "Active low."]
+    ACTIVE_LOW_OVRCRNT = 0x01,
+}
+impl OVER_CUR_POL {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> OVER_CUR_POL {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for OVER_CUR_POL {
+    #[inline(always)]
+    fn from(val: u8) -> OVER_CUR_POL {
+        OVER_CUR_POL::from_bits(val)
+    }
+}
+impl From<OVER_CUR_POL> for u8 {
+    #[inline(always)]
+    fn from(val: OVER_CUR_POL) -> u8 {
+        OVER_CUR_POL::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OVF_ERROR {
+    #[doc = "Interrupt did not occur."]
+    INT_NO = 0x0,
+    #[doc = "Unmasked interrupt occurred."]
+    INT_YES = 0x01,
+}
+impl OVF_ERROR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> OVF_ERROR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for OVF_ERROR {
+    #[inline(always)]
+    fn from(val: u8) -> OVF_ERROR {
+        OVF_ERROR::from_bits(val)
+    }
+}
+impl From<OVF_ERROR> for u8 {
+    #[inline(always)]
+    fn from(val: OVF_ERROR) -> u8 {
+        OVF_ERROR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OVF_ERROR_EN {
+    #[doc = "The interrupt is masked."]
+    MASK_OVF_ERR_INT = 0x0,
+    #[doc = "The interrupt is enabled."]
+    EN_OVF_ERR_INT = 0x01,
+}
+impl OVF_ERROR_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> OVF_ERROR_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for OVF_ERROR_EN {
+    #[inline(always)]
+    fn from(val: u8) -> OVF_ERROR_EN {
+        OVF_ERROR_EN::from_bits(val)
+    }
+}
+impl From<OVF_ERROR_EN> for u8 {
+    #[inline(always)]
+    fn from(val: OVF_ERROR_EN) -> u8 {
+        OVF_ERROR_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PWR_POL {
+    #[doc = "Active low."]
+    ACTIVE_LO_PMIC = 0x0,
+    #[doc = "Active high."]
+    ACTIVE_HI_PMIC = 0x01,
+}
+impl PWR_POL {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PWR_POL {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PWR_POL {
+    #[inline(always)]
+    fn from(val: u8) -> PWR_POL {
+        PWR_POL::from_bits(val)
+    }
+}
+impl From<PWR_POL> for u8 {
+    #[inline(always)]
+    fn from(val: PWR_POL) -> u8 {
+        PWR_POL::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum REMOTE_WAKEUP_EN {
+    #[doc = "Disable."]
+    REMOTE_WKUP_DIS = 0x0,
+    #[doc = "Enable."]
+    REMOTE_WKUP_EN = 0x01,
+}
+impl REMOTE_WAKEUP_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> REMOTE_WAKEUP_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for REMOTE_WAKEUP_EN {
+    #[inline(always)]
+    fn from(val: u8) -> REMOTE_WAKEUP_EN {
+        REMOTE_WAKEUP_EN::from_bits(val)
+    }
+}
+impl From<REMOTE_WAKEUP_EN> for u8 {
+    #[inline(always)]
+    fn from(val: REMOTE_WAKEUP_EN) -> u8 {
+        REMOTE_WAKEUP_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RESET_RESUME_ROUGH_EN {
+    #[doc = "Always works in tracking phase after the first time rough phase, to track transition."]
+    KEEP_TRIM_FINE_ON_RESET = 0x0,
+    #[doc = "Go back to rough stage whenever a bus reset or bus resume occurs."]
+    USE_IFR_TRIM_FINE_ON_RESET = 0x01,
+}
+impl RESET_RESUME_ROUGH_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> RESET_RESUME_ROUGH_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for RESET_RESUME_ROUGH_EN {
+    #[inline(always)]
+    fn from(val: u8) -> RESET_RESUME_ROUGH_EN {
+        RESET_RESUME_ROUGH_EN::from_bits(val)
+    }
+}
+impl From<RESET_RESUME_ROUGH_EN> for u8 {
+    #[inline(always)]
+    fn from(val: RESET_RESUME_ROUGH_EN) -> u8 {
+        RESET_RESUME_ROUGH_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RESTART_IFRTRIM_EN {
+    #[doc = "Trim fine adjustment always works based on the previous updated trim fine value."]
+    LOAD_TRIM_FINE_MID = 0x0,
+    #[doc = "Trim fine restarts from the IFR trim value whenever you detect bus_reset or bus_resume or deassert module enable."]
+    LOAD_TRIM_FINE_IFR = 0x01,
+}
+impl RESTART_IFRTRIM_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> RESTART_IFRTRIM_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for RESTART_IFRTRIM_EN {
+    #[inline(always)]
+    fn from(val: u8) -> RESTART_IFRTRIM_EN {
+        RESTART_IFRTRIM_EN::from_bits(val)
+    }
+}
+impl From<RESTART_IFRTRIM_EN> for u8 {
+    #[inline(always)]
+    fn from(val: RESTART_IFRTRIM_EN) -> u8 {
+        RESTART_IFRTRIM_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TRIM_INIT_VAL_SEL {
+    #[doc = "Mid-scale."]
+    INIT_TRIM_FINE_MID = 0x0,
+    #[doc = "IFR."]
+    INIT_TRIM_FINE_IFR = 0x01,
+}
+impl TRIM_INIT_VAL_SEL {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> TRIM_INIT_VAL_SEL {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for TRIM_INIT_VAL_SEL {
+    #[inline(always)]
+    fn from(val: u8) -> TRIM_INIT_VAL_SEL {
+        TRIM_INIT_VAL_SEL::from_bits(val)
+    }
+}
+impl From<TRIM_INIT_VAL_SEL> for u8 {
+    #[inline(always)]
+    fn from(val: TRIM_INIT_VAL_SEL) -> u8 {
+        TRIM_INIT_VAL_SEL::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum UTMI_CLK_VLD {
+    #[doc = "Not valid."]
+    NOTVALID = 0x0,
+    #[doc = "Valid."]
+    VALID = 0x01,
+}
+impl UTMI_CLK_VLD {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> UTMI_CLK_VLD {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for UTMI_CLK_VLD {
+    #[inline(always)]
+    fn from(val: u8) -> UTMI_CLK_VLD {
+        UTMI_CLK_VLD::from_bits(val)
+    }
+}
+impl From<UTMI_CLK_VLD> for u8 {
+    #[inline(always)]
+    fn from(val: UTMI_CLK_VLD) -> u8 {
+        UTMI_CLK_VLD::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum VBUS_SOURCE_SEL {
+    #[doc = "vbus_valid."]
+    VBUS_VALID = 0x0,
+    #[doc = "sess_valid."]
+    SESS_VALID_1 = 0x01,
+    #[doc = "sess_valid."]
+    SESS_VALID_2 = 0x02,
+    #[doc = "sess_valid."]
+    SESS_VALID_3 = 0x03,
+}
+impl VBUS_SOURCE_SEL {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> VBUS_SOURCE_SEL {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for VBUS_SOURCE_SEL {
+    #[inline(always)]
+    fn from(val: u8) -> VBUS_SOURCE_SEL {
+        VBUS_SOURCE_SEL::from_bits(val)
+    }
+}
+impl From<VBUS_SOURCE_SEL> for u8 {
+    #[inline(always)]
+    fn from(val: VBUS_SOURCE_SEL) -> u8 {
+        VBUS_SOURCE_SEL::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WIE {
+    #[doc = "Disable."]
+    INT_DIS = 0x0,
+    #[doc = "Enable."]
+    INT_EN = 0x01,
+}
+impl WIE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> WIE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for WIE {
+    #[inline(always)]
+    fn from(val: u8) -> WIE {
+        WIE::from_bits(val)
+    }
+}
+impl From<WIE> for u8 {
+    #[inline(always)]
+    fn from(val: WIE) -> u8 {
+        WIE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WIR {
+    #[doc = "Not received."]
+    NO_WKUP_REQ = 0x0,
+    #[doc = "Received."]
+    WKUP_REQ = 0x01,
+}
+impl WIR {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> WIR {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for WIR {
+    #[inline(always)]
+    fn from(val: u8) -> WIR {
+        WIR::from_bits(val)
+    }
+}
+impl From<WIR> for u8 {
+    #[inline(always)]
+    fn from(val: WIR) -> u8 {
+        WIR::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WKUP_DPDM_EN {
+    #[doc = "Disable only when VBUS is invalid."]
+    DPDM_WKUP_DIS = 0x0,
+    #[doc = "Enable (default)."]
+    DPDM_WKUP_EN = 0x01,
+}
+impl WKUP_DPDM_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> WKUP_DPDM_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for WKUP_DPDM_EN {
+    #[inline(always)]
+    fn from(val: u8) -> WKUP_DPDM_EN {
+        WKUP_DPDM_EN::from_bits(val)
+    }
+}
+impl From<WKUP_DPDM_EN> for u8 {
+    #[inline(always)]
+    fn from(val: WKUP_DPDM_EN) -> u8 {
+        WKUP_DPDM_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WKUP_ID_EN {
+    #[doc = "Disable."]
+    WKUP_ID_DIS = 0x0,
+    #[doc = "Enable."]
+    WKUP_ID_EN = 0x01,
+}
+impl WKUP_ID_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> WKUP_ID_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for WKUP_ID_EN {
+    #[inline(always)]
+    fn from(val: u8) -> WKUP_ID_EN {
+        WKUP_ID_EN::from_bits(val)
+    }
+}
+impl From<WKUP_ID_EN> for u8 {
+    #[inline(always)]
+    fn from(val: WKUP_ID_EN) -> u8 {
+        WKUP_ID_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WKUP_SW {
+    #[doc = "Inactive."]
+    INACTIVE = 0x0,
+    #[doc = "Force wake-up."]
+    FORCE_WKUP = 0x01,
+}
+impl WKUP_SW {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> WKUP_SW {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for WKUP_SW {
+    #[inline(always)]
+    fn from(val: u8) -> WKUP_SW {
+        WKUP_SW::from_bits(val)
+    }
+}
+impl From<WKUP_SW> for u8 {
+    #[inline(always)]
+    fn from(val: WKUP_SW) -> u8 {
+        WKUP_SW::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WKUP_SW_EN {
+    #[doc = "Disable."]
+    SW_WKUP_DIS = 0x0,
+    #[doc = "Enable."]
+    SW_WKUP_EN = 0x01,
+}
+impl WKUP_SW_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> WKUP_SW_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for WKUP_SW_EN {
+    #[inline(always)]
+    fn from(val: u8) -> WKUP_SW_EN {
+        WKUP_SW_EN::from_bits(val)
+    }
+}
+impl From<WKUP_SW_EN> for u8 {
+    #[inline(always)]
+    fn from(val: WKUP_SW_EN) -> u8 {
+        WKUP_SW_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WKUP_VBUS_EN {
+    #[doc = "Disable."]
+    WKUP_VBUS_DIS = 0x0,
+    #[doc = "Enable."]
+    WKUP_VBUS_EN = 0x01,
+}
+impl WKUP_VBUS_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> WKUP_VBUS_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for WKUP_VBUS_EN {
+    #[inline(always)]
+    fn from(val: u8) -> WKUP_VBUS_EN {
+        WKUP_VBUS_EN::from_bits(val)
+    }
+}
+impl From<WKUP_VBUS_EN> for u8 {
+    #[inline(always)]
+    fn from(val: WKUP_VBUS_EN) -> u8 {
+        WKUP_VBUS_EN::to_bits(val)
+    }
+}

--- a/nxp-pac/src/meta_peripherals/mcxa/USBPHY.rs
+++ b/nxp-pac/src/meta_peripherals/mcxa/USBPHY.rs
@@ -1,0 +1,10339 @@
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e5ab29f 2026-04-30))"]
+#[doc = "Universal Serial Bus 2.0 Integrated PHY."]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct Usbphy {
+    ptr: *mut u8,
+}
+unsafe impl Send for Usbphy {}
+unsafe impl Sync for Usbphy {}
+impl Usbphy {
+    #[inline(always)]
+    pub const unsafe fn from_ptr(ptr: *mut ()) -> Self {
+        Self { ptr: ptr as _ }
+    }
+    #[inline(always)]
+    pub const fn as_ptr(&self) -> *mut () {
+        self.ptr as _
+    }
+    #[doc = "Power Down."]
+    #[inline(always)]
+    pub const fn PWD(self) -> crate::pac::common::Reg<PWD, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+    }
+    #[doc = "Power Down."]
+    #[inline(always)]
+    pub const fn PWD_SET(self) -> crate::pac::common::Reg<PWD_SET, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
+    }
+    #[doc = "Power Down."]
+    #[inline(always)]
+    pub const fn PWD_CLR(self) -> crate::pac::common::Reg<PWD_CLR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x08usize) as _) }
+    }
+    #[doc = "Power Down."]
+    #[inline(always)]
+    pub const fn PWD_TOG(self) -> crate::pac::common::Reg<PWD_TOG, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0cusize) as _) }
+    }
+    #[doc = "TX Control."]
+    #[inline(always)]
+    pub const fn TX(self) -> crate::pac::common::Reg<TX, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x10usize) as _) }
+    }
+    #[doc = "TX Control."]
+    #[inline(always)]
+    pub const fn TX_SET(self) -> crate::pac::common::Reg<TX_SET, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x14usize) as _) }
+    }
+    #[doc = "TX Control."]
+    #[inline(always)]
+    pub const fn TX_CLR(self) -> crate::pac::common::Reg<TX_CLR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x18usize) as _) }
+    }
+    #[doc = "TX Control."]
+    #[inline(always)]
+    pub const fn TX_TOG(self) -> crate::pac::common::Reg<TX_TOG, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x1cusize) as _) }
+    }
+    #[doc = "RX Control."]
+    #[inline(always)]
+    pub const fn RX(self) -> crate::pac::common::Reg<RX, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x20usize) as _) }
+    }
+    #[doc = "RX Control."]
+    #[inline(always)]
+    pub const fn RX_SET(self) -> crate::pac::common::Reg<RX_SET, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x24usize) as _) }
+    }
+    #[doc = "RX Control."]
+    #[inline(always)]
+    pub const fn RX_CLR(self) -> crate::pac::common::Reg<RX_CLR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x28usize) as _) }
+    }
+    #[doc = "RX Control."]
+    #[inline(always)]
+    pub const fn RX_TOG(self) -> crate::pac::common::Reg<RX_TOG, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
+    }
+    #[doc = "General Purpose Control."]
+    #[inline(always)]
+    pub const fn CTRL(self) -> crate::pac::common::Reg<CTRL, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x30usize) as _) }
+    }
+    #[doc = "General Purpose Control."]
+    #[inline(always)]
+    pub const fn CTRL_SET(self) -> crate::pac::common::Reg<CTRL_SET, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x34usize) as _) }
+    }
+    #[doc = "General Purpose Control."]
+    #[inline(always)]
+    pub const fn CTRL_CLR(self) -> crate::pac::common::Reg<CTRL_CLR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x38usize) as _) }
+    }
+    #[doc = "General Purpose Control."]
+    #[inline(always)]
+    pub const fn CTRL_TOG(self) -> crate::pac::common::Reg<CTRL_TOG, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x3cusize) as _) }
+    }
+    #[doc = "Status."]
+    #[inline(always)]
+    pub const fn STATUS(self) -> crate::pac::common::Reg<STATUS, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x40usize) as _) }
+    }
+    #[doc = "Debug 0."]
+    #[inline(always)]
+    pub const fn DEBUG0(self) -> crate::pac::common::Reg<DEBUG0, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x50usize) as _) }
+    }
+    #[doc = "Debug 0."]
+    #[inline(always)]
+    pub const fn DEBUG0_SET(self) -> crate::pac::common::Reg<DEBUG0_SET, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x54usize) as _) }
+    }
+    #[doc = "Debug 0."]
+    #[inline(always)]
+    pub const fn DEBUG0_CLR(self) -> crate::pac::common::Reg<DEBUG0_CLR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x58usize) as _) }
+    }
+    #[doc = "Debug 0."]
+    #[inline(always)]
+    pub const fn DEBUG0_TOG(self) -> crate::pac::common::Reg<DEBUG0_TOG, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x5cusize) as _) }
+    }
+    #[doc = "Version."]
+    #[inline(always)]
+    pub const fn VERSION(self) -> crate::pac::common::Reg<VERSION, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x80usize) as _) }
+    }
+    #[doc = "IP Block."]
+    #[inline(always)]
+    pub const fn IP(self) -> crate::pac::common::Reg<IP, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x90usize) as _) }
+    }
+    #[doc = "IP Block."]
+    #[inline(always)]
+    pub const fn IP_SET(self) -> crate::pac::common::Reg<IP_SET, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x94usize) as _) }
+    }
+    #[doc = "IP Block."]
+    #[inline(always)]
+    pub const fn IP_CLR(self) -> crate::pac::common::Reg<IP_CLR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x98usize) as _) }
+    }
+    #[doc = "IP Block."]
+    #[inline(always)]
+    pub const fn IP_TOG(self) -> crate::pac::common::Reg<IP_TOG, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x9cusize) as _) }
+    }
+    #[doc = "PLL SIC."]
+    #[inline(always)]
+    pub const fn PLL_SIC(self) -> crate::pac::common::Reg<PLL_SIC, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xa0usize) as _) }
+    }
+    #[doc = "PLL SIC."]
+    #[inline(always)]
+    pub const fn PLL_SIC_SET(self) -> crate::pac::common::Reg<PLL_SIC_SET, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xa4usize) as _) }
+    }
+    #[doc = "PLL SIC."]
+    #[inline(always)]
+    pub const fn PLL_SIC_CLR(self) -> crate::pac::common::Reg<PLL_SIC_CLR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xa8usize) as _) }
+    }
+    #[doc = "PLL SIC."]
+    #[inline(always)]
+    pub const fn PLL_SIC_TOG(self) -> crate::pac::common::Reg<PLL_SIC_TOG, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xacusize) as _) }
+    }
+    #[doc = "VBUS Detect."]
+    #[inline(always)]
+    pub const fn USB1_VBUS_DETECT(
+        self,
+    ) -> crate::pac::common::Reg<USB1_VBUS_DETECT, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xc0usize) as _) }
+    }
+    #[doc = "VBUS Detect."]
+    #[inline(always)]
+    pub const fn USB1_VBUS_DETECT_SET(
+        self,
+    ) -> crate::pac::common::Reg<USB1_VBUS_DETECT_SET, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xc4usize) as _) }
+    }
+    #[doc = "VBUS Detect."]
+    #[inline(always)]
+    pub const fn USB1_VBUS_DETECT_CLR(
+        self,
+    ) -> crate::pac::common::Reg<USB1_VBUS_DETECT_CLR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xc8usize) as _) }
+    }
+    #[doc = "VBUS Detect."]
+    #[inline(always)]
+    pub const fn USB1_VBUS_DETECT_TOG(
+        self,
+    ) -> crate::pac::common::Reg<USB1_VBUS_DETECT_TOG, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xccusize) as _) }
+    }
+    #[doc = "VBUS Detect Status."]
+    #[inline(always)]
+    pub const fn USB1_VBUS_DET_STAT(
+        self,
+    ) -> crate::pac::common::Reg<USB1_VBUS_DET_STAT, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xd0usize) as _) }
+    }
+    #[doc = "VBUS Detect Status."]
+    #[inline(always)]
+    pub const fn USB1_VBUS_DET_STAT_SET(
+        self,
+    ) -> crate::pac::common::Reg<USB1_VBUS_DET_STAT_SET, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xd4usize) as _) }
+    }
+    #[doc = "VBUS Detect Status."]
+    #[inline(always)]
+    pub const fn USB1_VBUS_DET_STAT_CLR(
+        self,
+    ) -> crate::pac::common::Reg<USB1_VBUS_DET_STAT_CLR, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xd8usize) as _) }
+    }
+    #[doc = "VBUS Detect Status."]
+    #[inline(always)]
+    pub const fn USB1_VBUS_DET_STAT_TOG(
+        self,
+    ) -> crate::pac::common::Reg<USB1_VBUS_DET_STAT_TOG, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xdcusize) as _) }
+    }
+    #[doc = "Charger Detect."]
+    #[inline(always)]
+    pub const fn USB1_CHRG_DETECT(
+        self,
+    ) -> crate::pac::common::Reg<USB1_CHRG_DETECT, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xe0usize) as _) }
+    }
+    #[doc = "Charger Detect."]
+    #[inline(always)]
+    pub const fn USB1_CHRG_DETECT_SET(
+        self,
+    ) -> crate::pac::common::Reg<USB1_CHRG_DETECT_SET, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xe4usize) as _) }
+    }
+    #[doc = "Charger Detect."]
+    #[inline(always)]
+    pub const fn USB1_CHRG_DETECT_CLR(
+        self,
+    ) -> crate::pac::common::Reg<USB1_CHRG_DETECT_CLR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xe8usize) as _) }
+    }
+    #[doc = "Charger Detect."]
+    #[inline(always)]
+    pub const fn USB1_CHRG_DETECT_TOG(
+        self,
+    ) -> crate::pac::common::Reg<USB1_CHRG_DETECT_TOG, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xecusize) as _) }
+    }
+    #[doc = "Charger Detect Status."]
+    #[inline(always)]
+    pub const fn USB1_CHRG_DET_STAT(
+        self,
+    ) -> crate::pac::common::Reg<USB1_CHRG_DET_STAT, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xf0usize) as _) }
+    }
+    #[doc = "Charger Detect Status."]
+    #[inline(always)]
+    pub const fn USB1_CHRG_DET_STAT_SET(
+        self,
+    ) -> crate::pac::common::Reg<USB1_CHRG_DET_STAT_SET, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xf4usize) as _) }
+    }
+    #[doc = "Charger Detect Status."]
+    #[inline(always)]
+    pub const fn USB1_CHRG_DET_STAT_CLR(
+        self,
+    ) -> crate::pac::common::Reg<USB1_CHRG_DET_STAT_CLR, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xf8usize) as _) }
+    }
+    #[doc = "Charger Detect Status."]
+    #[inline(always)]
+    pub const fn USB1_CHRG_DET_STAT_TOG(
+        self,
+    ) -> crate::pac::common::Reg<USB1_CHRG_DET_STAT_TOG, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0xfcusize) as _) }
+    }
+    #[doc = "Analog Control."]
+    #[inline(always)]
+    pub const fn ANACTRL(self) -> crate::pac::common::Reg<ANACTRL, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0100usize) as _) }
+    }
+    #[doc = "Analog Control."]
+    #[inline(always)]
+    pub const fn ANACTRL_SET(self) -> crate::pac::common::Reg<ANACTRL_SET, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0104usize) as _) }
+    }
+    #[doc = "Analog Control."]
+    #[inline(always)]
+    pub const fn ANACTRL_CLR(self) -> crate::pac::common::Reg<ANACTRL_CLR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0108usize) as _) }
+    }
+    #[doc = "Analog Control."]
+    #[inline(always)]
+    pub const fn ANACTRL_TOG(self) -> crate::pac::common::Reg<ANACTRL_TOG, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x010cusize) as _) }
+    }
+    #[doc = "Trim."]
+    #[inline(always)]
+    pub const fn TRIM_OVERRIDE_EN(
+        self,
+    ) -> crate::pac::common::Reg<TRIM_OVERRIDE_EN, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0130usize) as _) }
+    }
+    #[doc = "Trim."]
+    #[inline(always)]
+    pub const fn TRIM_OVERRIDE_EN_SET(
+        self,
+    ) -> crate::pac::common::Reg<TRIM_OVERRIDE_EN_SET, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0134usize) as _) }
+    }
+    #[doc = "Trim."]
+    #[inline(always)]
+    pub const fn TRIM_OVERRIDE_EN_CLR(
+        self,
+    ) -> crate::pac::common::Reg<TRIM_OVERRIDE_EN_CLR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0138usize) as _) }
+    }
+    #[doc = "Trim."]
+    #[inline(always)]
+    pub const fn TRIM_OVERRIDE_EN_TOG(
+        self,
+    ) -> crate::pac::common::Reg<TRIM_OVERRIDE_EN_TOG, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x013cusize) as _) }
+    }
+    #[doc = "PFD A."]
+    #[inline(always)]
+    pub const fn PFDA(self) -> crate::pac::common::Reg<PFDA, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0140usize) as _) }
+    }
+    #[doc = "PFD A."]
+    #[inline(always)]
+    pub const fn PFDA_SET(self) -> crate::pac::common::Reg<PFDA_SET, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0144usize) as _) }
+    }
+    #[doc = "PFD A."]
+    #[inline(always)]
+    pub const fn PFDA_CLR(self) -> crate::pac::common::Reg<PFDA_CLR, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0148usize) as _) }
+    }
+    #[doc = "PFD A."]
+    #[inline(always)]
+    pub const fn PFDA_TOG(self) -> crate::pac::common::Reg<PFDA_TOG, crate::pac::common::RW> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x014cusize) as _) }
+    }
+}
+#[doc = "Analog Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ANACTRL(pub u32);
+impl ANACTRL {
+    #[doc = "Internal Low Voltage Detector Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LVI_EN(&self) -> LVI_EN {
+        let val = (self.0 >> 1usize) & 0x01;
+        LVI_EN::from_bits(val as u8)
+    }
+    #[doc = "Internal Low Voltage Detector Enable."]
+    #[inline(always)]
+    pub const fn set_LVI_EN(&mut self, val: LVI_EN) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val.to_bits() as u32) & 0x01) << 1usize);
+    }
+    #[doc = "PFD Clock Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD_CLK_SEL(&self) -> PFD_CLK_SEL {
+        let val = (self.0 >> 2usize) & 0x03;
+        PFD_CLK_SEL::from_bits(val as u8)
+    }
+    #[doc = "PFD Clock Selection."]
+    #[inline(always)]
+    pub const fn set_PFD_CLK_SEL(&mut self, val: PFD_CLK_SEL) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val.to_bits() as u32) & 0x03) << 2usize);
+    }
+    #[doc = "Device Pulldown Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEV_PULLDOWN(&self) -> DEV_PULLDOWN {
+        let val = (self.0 >> 10usize) & 0x01;
+        DEV_PULLDOWN::from_bits(val as u8)
+    }
+    #[doc = "Device Pulldown Enable."]
+    #[inline(always)]
+    pub const fn set_DEV_PULLDOWN(&mut self, val: DEV_PULLDOWN) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val.to_bits() as u32) & 0x01) << 10usize);
+    }
+}
+impl Default for ANACTRL {
+    #[inline(always)]
+    fn default() -> ANACTRL {
+        ANACTRL(0)
+    }
+}
+impl core::fmt::Debug for ANACTRL {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ANACTRL")
+            .field("LVI_EN", &self.LVI_EN())
+            .field("PFD_CLK_SEL", &self.PFD_CLK_SEL())
+            .field("DEV_PULLDOWN", &self.DEV_PULLDOWN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ANACTRL {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ANACTRL {{ LVI_EN: {:?}, PFD_CLK_SEL: {:?}, DEV_PULLDOWN: {:?} }}",
+            self.LVI_EN(),
+            self.PFD_CLK_SEL(),
+            self.DEV_PULLDOWN()
+        )
+    }
+}
+#[doc = "Analog Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ANACTRL_CLR(pub u32);
+impl ANACTRL_CLR {
+    #[doc = "Internal Low Voltage Detector Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LVI_EN(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Internal Low Voltage Detector Enable."]
+    #[inline(always)]
+    pub const fn set_LVI_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "PFD Clock Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD_CLK_SEL(&self) -> u8 {
+        let val = (self.0 >> 2usize) & 0x03;
+        val as u8
+    }
+    #[doc = "PFD Clock Selection."]
+    #[inline(always)]
+    pub const fn set_PFD_CLK_SEL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val as u32) & 0x03) << 2usize);
+    }
+    #[doc = "Device Pulldown Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEV_PULLDOWN(&self) -> bool {
+        let val = (self.0 >> 10usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Device Pulldown Enable."]
+    #[inline(always)]
+    pub const fn set_DEV_PULLDOWN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val as u32) & 0x01) << 10usize);
+    }
+}
+impl Default for ANACTRL_CLR {
+    #[inline(always)]
+    fn default() -> ANACTRL_CLR {
+        ANACTRL_CLR(0)
+    }
+}
+impl core::fmt::Debug for ANACTRL_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ANACTRL_CLR")
+            .field("LVI_EN", &self.LVI_EN())
+            .field("PFD_CLK_SEL", &self.PFD_CLK_SEL())
+            .field("DEV_PULLDOWN", &self.DEV_PULLDOWN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ANACTRL_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ANACTRL_CLR {{ LVI_EN: {=bool:?}, PFD_CLK_SEL: {=u8:?}, DEV_PULLDOWN: {=bool:?} }}",
+            self.LVI_EN(),
+            self.PFD_CLK_SEL(),
+            self.DEV_PULLDOWN()
+        )
+    }
+}
+#[doc = "Analog Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ANACTRL_SET(pub u32);
+impl ANACTRL_SET {
+    #[doc = "Internal Low Voltage Detector Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LVI_EN(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Internal Low Voltage Detector Enable."]
+    #[inline(always)]
+    pub const fn set_LVI_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "PFD Clock Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD_CLK_SEL(&self) -> u8 {
+        let val = (self.0 >> 2usize) & 0x03;
+        val as u8
+    }
+    #[doc = "PFD Clock Selection."]
+    #[inline(always)]
+    pub const fn set_PFD_CLK_SEL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val as u32) & 0x03) << 2usize);
+    }
+    #[doc = "Device Pulldown Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEV_PULLDOWN(&self) -> bool {
+        let val = (self.0 >> 10usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Device Pulldown Enable."]
+    #[inline(always)]
+    pub const fn set_DEV_PULLDOWN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val as u32) & 0x01) << 10usize);
+    }
+}
+impl Default for ANACTRL_SET {
+    #[inline(always)]
+    fn default() -> ANACTRL_SET {
+        ANACTRL_SET(0)
+    }
+}
+impl core::fmt::Debug for ANACTRL_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ANACTRL_SET")
+            .field("LVI_EN", &self.LVI_EN())
+            .field("PFD_CLK_SEL", &self.PFD_CLK_SEL())
+            .field("DEV_PULLDOWN", &self.DEV_PULLDOWN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ANACTRL_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ANACTRL_SET {{ LVI_EN: {=bool:?}, PFD_CLK_SEL: {=u8:?}, DEV_PULLDOWN: {=bool:?} }}",
+            self.LVI_EN(),
+            self.PFD_CLK_SEL(),
+            self.DEV_PULLDOWN()
+        )
+    }
+}
+#[doc = "Analog Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ANACTRL_TOG(pub u32);
+impl ANACTRL_TOG {
+    #[doc = "Internal Low Voltage Detector Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn LVI_EN(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Internal Low Voltage Detector Enable."]
+    #[inline(always)]
+    pub const fn set_LVI_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "PFD Clock Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD_CLK_SEL(&self) -> u8 {
+        let val = (self.0 >> 2usize) & 0x03;
+        val as u8
+    }
+    #[doc = "PFD Clock Selection."]
+    #[inline(always)]
+    pub const fn set_PFD_CLK_SEL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val as u32) & 0x03) << 2usize);
+    }
+    #[doc = "Device Pulldown Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEV_PULLDOWN(&self) -> bool {
+        let val = (self.0 >> 10usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Device Pulldown Enable."]
+    #[inline(always)]
+    pub const fn set_DEV_PULLDOWN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val as u32) & 0x01) << 10usize);
+    }
+}
+impl Default for ANACTRL_TOG {
+    #[inline(always)]
+    fn default() -> ANACTRL_TOG {
+        ANACTRL_TOG(0)
+    }
+}
+impl core::fmt::Debug for ANACTRL_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ANACTRL_TOG")
+            .field("LVI_EN", &self.LVI_EN())
+            .field("PFD_CLK_SEL", &self.PFD_CLK_SEL())
+            .field("DEV_PULLDOWN", &self.DEV_PULLDOWN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ANACTRL_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ANACTRL_TOG {{ LVI_EN: {=bool:?}, PFD_CLK_SEL: {=u8:?}, DEV_PULLDOWN: {=bool:?} }}",
+            self.LVI_EN(),
+            self.PFD_CLK_SEL(),
+            self.DEV_PULLDOWN()
+        )
+    }
+}
+#[doc = "General Purpose Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct CTRL(pub u32);
+impl CTRL {
+    #[doc = "OTG ID Change Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENOTG_ID_CHG_IRQ(&self) -> ENOTG_ID_CHG_IRQ {
+        let val = (self.0 >> 0usize) & 0x01;
+        ENOTG_ID_CHG_IRQ::from_bits(val as u8)
+    }
+    #[doc = "OTG ID Change Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_ENOTG_ID_CHG_IRQ(&mut self, val: ENOTG_ID_CHG_IRQ) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Host Disconnect Detection Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENHOSTDISCONDETECT(&self) -> ENHOSTDISCONDETECT {
+        let val = (self.0 >> 1usize) & 0x01;
+        ENHOSTDISCONDETECT::from_bits(val as u8)
+    }
+    #[doc = "Host Disconnect Detection Enable."]
+    #[inline(always)]
+    pub const fn set_ENHOSTDISCONDETECT(&mut self, val: ENHOSTDISCONDETECT) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val.to_bits() as u32) & 0x01) << 1usize);
+    }
+    #[doc = "Enable Interrupt for Host Disconnect."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQHOSTDISCON(&self) -> ENIRQHOSTDISCON {
+        let val = (self.0 >> 2usize) & 0x01;
+        ENIRQHOSTDISCON::from_bits(val as u8)
+    }
+    #[doc = "Enable Interrupt for Host Disconnect."]
+    #[inline(always)]
+    pub const fn set_ENIRQHOSTDISCON(&mut self, val: ENIRQHOSTDISCON) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val.to_bits() as u32) & 0x01) << 2usize);
+    }
+    #[doc = "Host Disconnect Detection Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HOSTDISCONDETECT_IRQ(&self) -> HOSTDISCONDETECT_IRQ {
+        let val = (self.0 >> 3usize) & 0x01;
+        HOSTDISCONDETECT_IRQ::from_bits(val as u8)
+    }
+    #[doc = "Host Disconnect Detection Interrupt."]
+    #[inline(always)]
+    pub const fn set_HOSTDISCONDETECT_IRQ(&mut self, val: HOSTDISCONDETECT_IRQ) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val.to_bits() as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Enable Nonstandard Resistive Plugged-In Detection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENDEVPLUGINDETECT(&self) -> ENDEVPLUGINDETECT {
+        let val = (self.0 >> 4usize) & 0x01;
+        ENDEVPLUGINDETECT::from_bits(val as u8)
+    }
+    #[doc = "Enable Nonstandard Resistive Plugged-In Detection."]
+    #[inline(always)]
+    pub const fn set_ENDEVPLUGINDETECT(&mut self, val: ENDEVPLUGINDETECT) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u32) & 0x01) << 4usize);
+    }
+    #[doc = "Device Plug-In Polarity."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEVPLUGIN_POLARITY(&self) -> DEVPLUGIN_POLARITY {
+        let val = (self.0 >> 5usize) & 0x01;
+        DEVPLUGIN_POLARITY::from_bits(val as u8)
+    }
+    #[doc = "Device Plug-In Polarity."]
+    #[inline(always)]
+    pub const fn set_DEVPLUGIN_POLARITY(&mut self, val: DEVPLUGIN_POLARITY) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "OTG ID Change Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OTG_ID_CHG_IRQ(&self) -> OTG_ID_CHG_IRQ {
+        let val = (self.0 >> 6usize) & 0x01;
+        OTG_ID_CHG_IRQ::from_bits(val as u8)
+    }
+    #[doc = "OTG ID Change Interrupt."]
+    #[inline(always)]
+    pub const fn set_OTG_ID_CHG_IRQ(&mut self, val: OTG_ID_CHG_IRQ) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "Enable Internal OTG ID Detector."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENOTGIDDETECT(&self) -> ENOTGIDDETECT {
+        let val = (self.0 >> 7usize) & 0x01;
+        ENOTGIDDETECT::from_bits(val as u8)
+    }
+    #[doc = "Enable Internal OTG ID Detector."]
+    #[inline(always)]
+    pub const fn set_ENOTGIDDETECT(&mut self, val: ENOTGIDDETECT) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+    #[doc = "Resume Interrupt Sticky."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RESUMEIRQSTICKY(&self) -> RESUMEIRQSTICKY {
+        let val = (self.0 >> 8usize) & 0x01;
+        RESUMEIRQSTICKY::from_bits(val as u8)
+    }
+    #[doc = "Resume Interrupt Sticky."]
+    #[inline(always)]
+    pub const fn set_RESUMEIRQSTICKY(&mut self, val: RESUMEIRQSTICKY) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val.to_bits() as u32) & 0x01) << 8usize);
+    }
+    #[doc = "Resume Detection Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQRESUMEDETECT(&self) -> ENIRQRESUMEDETECT {
+        let val = (self.0 >> 9usize) & 0x01;
+        ENIRQRESUMEDETECT::from_bits(val as u8)
+    }
+    #[doc = "Resume Detection Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_ENIRQRESUMEDETECT(&mut self, val: ENIRQRESUMEDETECT) {
+        self.0 = (self.0 & !(0x01 << 9usize)) | (((val.to_bits() as u32) & 0x01) << 9usize);
+    }
+    #[doc = "Resume Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RESUME_IRQ(&self) -> RESUME_IRQ {
+        let val = (self.0 >> 10usize) & 0x01;
+        RESUME_IRQ::from_bits(val as u8)
+    }
+    #[doc = "Resume Interrupt."]
+    #[inline(always)]
+    pub const fn set_RESUME_IRQ(&mut self, val: RESUME_IRQ) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val.to_bits() as u32) & 0x01) << 10usize);
+    }
+    #[doc = "Enable Interrupt for Nonstandard Resistive Plugged-In Detection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQDEVPLUGIN(&self) -> ENIRQDEVPLUGIN {
+        let val = (self.0 >> 11usize) & 0x01;
+        ENIRQDEVPLUGIN::from_bits(val as u8)
+    }
+    #[doc = "Enable Interrupt for Nonstandard Resistive Plugged-In Detection."]
+    #[inline(always)]
+    pub const fn set_ENIRQDEVPLUGIN(&mut self, val: ENIRQDEVPLUGIN) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val.to_bits() as u32) & 0x01) << 11usize);
+    }
+    #[doc = "Device Plug-In Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEVPLUGIN_IRQ(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Device Plug-In Interrupt."]
+    #[inline(always)]
+    pub const fn set_DEVPLUGIN_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "APB Clock Switch Option."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DATA_ON_LRADC(&self) -> bool {
+        let val = (self.0 >> 13usize) & 0x01;
+        val != 0
+    }
+    #[doc = "APB Clock Switch Option."]
+    #[inline(always)]
+    pub const fn set_DATA_ON_LRADC(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val as u32) & 0x01) << 13usize);
+    }
+    #[doc = "UTMI Level 2 Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENUTMILEVEL2(&self) -> ENUTMILEVEL2 {
+        let val = (self.0 >> 14usize) & 0x01;
+        ENUTMILEVEL2::from_bits(val as u8)
+    }
+    #[doc = "UTMI Level 2 Enable."]
+    #[inline(always)]
+    pub const fn set_ENUTMILEVEL2(&mut self, val: ENUTMILEVEL2) {
+        self.0 = (self.0 & !(0x01 << 14usize)) | (((val.to_bits() as u32) & 0x01) << 14usize);
+    }
+    #[doc = "UTMI Level 3 Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENUTMILEVEL3(&self) -> ENUTMILEVEL3 {
+        let val = (self.0 >> 15usize) & 0x01;
+        ENUTMILEVEL3::from_bits(val as u8)
+    }
+    #[doc = "UTMI Level 3 Enable."]
+    #[inline(always)]
+    pub const fn set_ENUTMILEVEL3(&mut self, val: ENUTMILEVEL3) {
+        self.0 = (self.0 & !(0x01 << 15usize)) | (((val.to_bits() as u32) & 0x01) << 15usize);
+    }
+    #[doc = "Wake-Up Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQWAKEUP(&self) -> ENIRQWAKEUP {
+        let val = (self.0 >> 16usize) & 0x01;
+        ENIRQWAKEUP::from_bits(val as u8)
+    }
+    #[doc = "Wake-Up Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_ENIRQWAKEUP(&mut self, val: ENIRQWAKEUP) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val.to_bits() as u32) & 0x01) << 16usize);
+    }
+    #[doc = "Wake-Up Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WAKEUP_IRQ(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Wake-Up Interrupt."]
+    #[inline(always)]
+    pub const fn set_WAKEUP_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "Autoresume Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AUTORESUME_EN(&self) -> AUTORESUME_EN {
+        let val = (self.0 >> 18usize) & 0x01;
+        AUTORESUME_EN::from_bits(val as u8)
+    }
+    #[doc = "Autoresume Enable."]
+    #[inline(always)]
+    pub const fn set_AUTORESUME_EN(&mut self, val: AUTORESUME_EN) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val.to_bits() as u32) & 0x01) << 18usize);
+    }
+    #[doc = "Autoclear Clock Gate Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENAUTOCLR_CLKGATE(&self) -> ENAUTOCLR_CLKGATE {
+        let val = (self.0 >> 19usize) & 0x01;
+        ENAUTOCLR_CLKGATE::from_bits(val as u8)
+    }
+    #[doc = "Autoclear Clock Gate Enable."]
+    #[inline(always)]
+    pub const fn set_ENAUTOCLR_CLKGATE(&mut self, val: ENAUTOCLR_CLKGATE) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val.to_bits() as u32) & 0x01) << 19usize);
+    }
+    #[doc = "PHY PWD Autoclear Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENAUTOCLR_PHY_PWD(&self) -> ENAUTOCLR_PHY_PWD {
+        let val = (self.0 >> 20usize) & 0x01;
+        ENAUTOCLR_PHY_PWD::from_bits(val as u8)
+    }
+    #[doc = "PHY PWD Autoclear Enable."]
+    #[inline(always)]
+    pub const fn set_ENAUTOCLR_PHY_PWD(&mut self, val: ENAUTOCLR_PHY_PWD) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val.to_bits() as u32) & 0x01) << 20usize);
+    }
+    #[doc = "OTG ID Value."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OTG_ID_VALUE(&self) -> OTG_ID_VALUE {
+        let val = (self.0 >> 27usize) & 0x01;
+        OTG_ID_VALUE::from_bits(val as u8)
+    }
+    #[doc = "OTG ID Value."]
+    #[inline(always)]
+    pub const fn set_OTG_ID_VALUE(&mut self, val: OTG_ID_VALUE) {
+        self.0 = (self.0 & !(0x01 << 27usize)) | (((val.to_bits() as u32) & 0x01) << 27usize);
+    }
+    #[doc = "UTMI Suspend."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn UTMI_SUSPENDM(&self) -> UTMI_SUSPENDM {
+        let val = (self.0 >> 29usize) & 0x01;
+        UTMI_SUSPENDM::from_bits(val as u8)
+    }
+    #[doc = "UTMI Suspend."]
+    #[inline(always)]
+    pub const fn set_UTMI_SUSPENDM(&mut self, val: UTMI_SUSPENDM) {
+        self.0 = (self.0 & !(0x01 << 29usize)) | (((val.to_bits() as u32) & 0x01) << 29usize);
+    }
+    #[doc = "UTMI Clock Gate."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CLKGATE(&self) -> CLKGATE {
+        let val = (self.0 >> 30usize) & 0x01;
+        CLKGATE::from_bits(val as u8)
+    }
+    #[doc = "UTMI Clock Gate."]
+    #[inline(always)]
+    pub const fn set_CLKGATE(&mut self, val: CLKGATE) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val.to_bits() as u32) & 0x01) << 30usize);
+    }
+    #[doc = "Software Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SFTRST(&self) -> SFTRST {
+        let val = (self.0 >> 31usize) & 0x01;
+        SFTRST::from_bits(val as u8)
+    }
+    #[doc = "Software Reset."]
+    #[inline(always)]
+    pub const fn set_SFTRST(&mut self, val: SFTRST) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val.to_bits() as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for CTRL {
+    #[inline(always)]
+    fn default() -> CTRL {
+        CTRL(0)
+    }
+}
+impl core::fmt::Debug for CTRL {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CTRL")
+            .field("ENOTG_ID_CHG_IRQ", &self.ENOTG_ID_CHG_IRQ())
+            .field("ENHOSTDISCONDETECT", &self.ENHOSTDISCONDETECT())
+            .field("ENIRQHOSTDISCON", &self.ENIRQHOSTDISCON())
+            .field("HOSTDISCONDETECT_IRQ", &self.HOSTDISCONDETECT_IRQ())
+            .field("ENDEVPLUGINDETECT", &self.ENDEVPLUGINDETECT())
+            .field("DEVPLUGIN_POLARITY", &self.DEVPLUGIN_POLARITY())
+            .field("OTG_ID_CHG_IRQ", &self.OTG_ID_CHG_IRQ())
+            .field("ENOTGIDDETECT", &self.ENOTGIDDETECT())
+            .field("RESUMEIRQSTICKY", &self.RESUMEIRQSTICKY())
+            .field("ENIRQRESUMEDETECT", &self.ENIRQRESUMEDETECT())
+            .field("RESUME_IRQ", &self.RESUME_IRQ())
+            .field("ENIRQDEVPLUGIN", &self.ENIRQDEVPLUGIN())
+            .field("DEVPLUGIN_IRQ", &self.DEVPLUGIN_IRQ())
+            .field("DATA_ON_LRADC", &self.DATA_ON_LRADC())
+            .field("ENUTMILEVEL2", &self.ENUTMILEVEL2())
+            .field("ENUTMILEVEL3", &self.ENUTMILEVEL3())
+            .field("ENIRQWAKEUP", &self.ENIRQWAKEUP())
+            .field("WAKEUP_IRQ", &self.WAKEUP_IRQ())
+            .field("AUTORESUME_EN", &self.AUTORESUME_EN())
+            .field("ENAUTOCLR_CLKGATE", &self.ENAUTOCLR_CLKGATE())
+            .field("ENAUTOCLR_PHY_PWD", &self.ENAUTOCLR_PHY_PWD())
+            .field("OTG_ID_VALUE", &self.OTG_ID_VALUE())
+            .field("UTMI_SUSPENDM", &self.UTMI_SUSPENDM())
+            .field("CLKGATE", &self.CLKGATE())
+            .field("SFTRST", &self.SFTRST())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CTRL {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "CTRL {{ ENOTG_ID_CHG_IRQ: {:?}, ENHOSTDISCONDETECT: {:?}, ENIRQHOSTDISCON: {:?}, HOSTDISCONDETECT_IRQ: {:?}, ENDEVPLUGINDETECT: {:?}, DEVPLUGIN_POLARITY: {:?}, OTG_ID_CHG_IRQ: {:?}, ENOTGIDDETECT: {:?}, RESUMEIRQSTICKY: {:?}, ENIRQRESUMEDETECT: {:?}, RESUME_IRQ: {:?}, ENIRQDEVPLUGIN: {:?}, DEVPLUGIN_IRQ: {=bool:?}, DATA_ON_LRADC: {=bool:?}, ENUTMILEVEL2: {:?}, ENUTMILEVEL3: {:?}, ENIRQWAKEUP: {:?}, WAKEUP_IRQ: {=bool:?}, AUTORESUME_EN: {:?}, ENAUTOCLR_CLKGATE: {:?}, ENAUTOCLR_PHY_PWD: {:?}, OTG_ID_VALUE: {:?}, UTMI_SUSPENDM: {:?}, CLKGATE: {:?}, SFTRST: {:?} }}",
+            self.ENOTG_ID_CHG_IRQ(),
+            self.ENHOSTDISCONDETECT(),
+            self.ENIRQHOSTDISCON(),
+            self.HOSTDISCONDETECT_IRQ(),
+            self.ENDEVPLUGINDETECT(),
+            self.DEVPLUGIN_POLARITY(),
+            self.OTG_ID_CHG_IRQ(),
+            self.ENOTGIDDETECT(),
+            self.RESUMEIRQSTICKY(),
+            self.ENIRQRESUMEDETECT(),
+            self.RESUME_IRQ(),
+            self.ENIRQDEVPLUGIN(),
+            self.DEVPLUGIN_IRQ(),
+            self.DATA_ON_LRADC(),
+            self.ENUTMILEVEL2(),
+            self.ENUTMILEVEL3(),
+            self.ENIRQWAKEUP(),
+            self.WAKEUP_IRQ(),
+            self.AUTORESUME_EN(),
+            self.ENAUTOCLR_CLKGATE(),
+            self.ENAUTOCLR_PHY_PWD(),
+            self.OTG_ID_VALUE(),
+            self.UTMI_SUSPENDM(),
+            self.CLKGATE(),
+            self.SFTRST()
+        )
+    }
+}
+#[doc = "General Purpose Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct CTRL_CLR(pub u32);
+impl CTRL_CLR {
+    #[doc = "OTG ID Change Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENOTG_ID_CHG_IRQ(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG ID Change Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_ENOTG_ID_CHG_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Host Disconnect Detection Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENHOSTDISCONDETECT(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Host Disconnect Detection Enable."]
+    #[inline(always)]
+    pub const fn set_ENHOSTDISCONDETECT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "Enable Interrupt for Host Disconnect."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQHOSTDISCON(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Interrupt for Host Disconnect."]
+    #[inline(always)]
+    pub const fn set_ENIRQHOSTDISCON(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "Host Disconnect Detection Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HOSTDISCONDETECT_IRQ(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Host Disconnect Detection Interrupt."]
+    #[inline(always)]
+    pub const fn set_HOSTDISCONDETECT_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Enable Nonstandard Resistive Plugged-In Detection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENDEVPLUGINDETECT(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Nonstandard Resistive Plugged-In Detection."]
+    #[inline(always)]
+    pub const fn set_ENDEVPLUGINDETECT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "Device Plug-In Polarity."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEVPLUGIN_POLARITY(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Device Plug-In Polarity."]
+    #[inline(always)]
+    pub const fn set_DEVPLUGIN_POLARITY(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+    #[doc = "OTG ID Change Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OTG_ID_CHG_IRQ(&self) -> bool {
+        let val = (self.0 >> 6usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG ID Change Interrupt."]
+    #[inline(always)]
+    pub const fn set_OTG_ID_CHG_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val as u32) & 0x01) << 6usize);
+    }
+    #[doc = "Enable Internal OTG ID Detector."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENOTGIDDETECT(&self) -> bool {
+        let val = (self.0 >> 7usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Internal OTG ID Detector."]
+    #[inline(always)]
+    pub const fn set_ENOTGIDDETECT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val as u32) & 0x01) << 7usize);
+    }
+    #[doc = "Resume Interrupt Sticky."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RESUMEIRQSTICKY(&self) -> bool {
+        let val = (self.0 >> 8usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Resume Interrupt Sticky."]
+    #[inline(always)]
+    pub const fn set_RESUMEIRQSTICKY(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val as u32) & 0x01) << 8usize);
+    }
+    #[doc = "Resume Detection Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQRESUMEDETECT(&self) -> bool {
+        let val = (self.0 >> 9usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Resume Detection Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_ENIRQRESUMEDETECT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 9usize)) | (((val as u32) & 0x01) << 9usize);
+    }
+    #[doc = "Resume Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RESUME_IRQ(&self) -> bool {
+        let val = (self.0 >> 10usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Resume Interrupt."]
+    #[inline(always)]
+    pub const fn set_RESUME_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val as u32) & 0x01) << 10usize);
+    }
+    #[doc = "Enable Interrupt for Nonstandard Resistive Plugged-In Detection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQDEVPLUGIN(&self) -> bool {
+        let val = (self.0 >> 11usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Interrupt for Nonstandard Resistive Plugged-In Detection."]
+    #[inline(always)]
+    pub const fn set_ENIRQDEVPLUGIN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val as u32) & 0x01) << 11usize);
+    }
+    #[doc = "Device Plug-In Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEVPLUGIN_IRQ(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Device Plug-In Interrupt."]
+    #[inline(always)]
+    pub const fn set_DEVPLUGIN_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "APB Clock Switch Option."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DATA_ON_LRADC(&self) -> bool {
+        let val = (self.0 >> 13usize) & 0x01;
+        val != 0
+    }
+    #[doc = "APB Clock Switch Option."]
+    #[inline(always)]
+    pub const fn set_DATA_ON_LRADC(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val as u32) & 0x01) << 13usize);
+    }
+    #[doc = "UTMI Level 2 Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENUTMILEVEL2(&self) -> bool {
+        let val = (self.0 >> 14usize) & 0x01;
+        val != 0
+    }
+    #[doc = "UTMI Level 2 Enable."]
+    #[inline(always)]
+    pub const fn set_ENUTMILEVEL2(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 14usize)) | (((val as u32) & 0x01) << 14usize);
+    }
+    #[doc = "UTMI Level 3 Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENUTMILEVEL3(&self) -> bool {
+        let val = (self.0 >> 15usize) & 0x01;
+        val != 0
+    }
+    #[doc = "UTMI Level 3 Enable."]
+    #[inline(always)]
+    pub const fn set_ENUTMILEVEL3(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 15usize)) | (((val as u32) & 0x01) << 15usize);
+    }
+    #[doc = "Wake-Up Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQWAKEUP(&self) -> bool {
+        let val = (self.0 >> 16usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Wake-Up Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_ENIRQWAKEUP(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val as u32) & 0x01) << 16usize);
+    }
+    #[doc = "Wake-Up Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WAKEUP_IRQ(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Wake-Up Interrupt."]
+    #[inline(always)]
+    pub const fn set_WAKEUP_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "Autoresume Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AUTORESUME_EN(&self) -> bool {
+        let val = (self.0 >> 18usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Autoresume Enable."]
+    #[inline(always)]
+    pub const fn set_AUTORESUME_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    }
+    #[doc = "Autoclear Clock Gate Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENAUTOCLR_CLKGATE(&self) -> bool {
+        let val = (self.0 >> 19usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Autoclear Clock Gate Enable."]
+    #[inline(always)]
+    pub const fn set_ENAUTOCLR_CLKGATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val as u32) & 0x01) << 19usize);
+    }
+    #[doc = "PHY PWD Autoclear Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENAUTOCLR_PHY_PWD(&self) -> bool {
+        let val = (self.0 >> 20usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PHY PWD Autoclear Enable."]
+    #[inline(always)]
+    pub const fn set_ENAUTOCLR_PHY_PWD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val as u32) & 0x01) << 20usize);
+    }
+    #[doc = "OTG ID Value."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OTG_ID_VALUE(&self) -> bool {
+        let val = (self.0 >> 27usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG ID Value."]
+    #[inline(always)]
+    pub const fn set_OTG_ID_VALUE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 27usize)) | (((val as u32) & 0x01) << 27usize);
+    }
+    #[doc = "UTMI Suspend."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn UTMI_SUSPENDM(&self) -> bool {
+        let val = (self.0 >> 29usize) & 0x01;
+        val != 0
+    }
+    #[doc = "UTMI Suspend."]
+    #[inline(always)]
+    pub const fn set_UTMI_SUSPENDM(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 29usize)) | (((val as u32) & 0x01) << 29usize);
+    }
+    #[doc = "UTMI Clock Gate."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CLKGATE(&self) -> bool {
+        let val = (self.0 >> 30usize) & 0x01;
+        val != 0
+    }
+    #[doc = "UTMI Clock Gate."]
+    #[inline(always)]
+    pub const fn set_CLKGATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val as u32) & 0x01) << 30usize);
+    }
+    #[doc = "Software Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SFTRST(&self) -> bool {
+        let val = (self.0 >> 31usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Software Reset."]
+    #[inline(always)]
+    pub const fn set_SFTRST(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for CTRL_CLR {
+    #[inline(always)]
+    fn default() -> CTRL_CLR {
+        CTRL_CLR(0)
+    }
+}
+impl core::fmt::Debug for CTRL_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CTRL_CLR")
+            .field("ENOTG_ID_CHG_IRQ", &self.ENOTG_ID_CHG_IRQ())
+            .field("ENHOSTDISCONDETECT", &self.ENHOSTDISCONDETECT())
+            .field("ENIRQHOSTDISCON", &self.ENIRQHOSTDISCON())
+            .field("HOSTDISCONDETECT_IRQ", &self.HOSTDISCONDETECT_IRQ())
+            .field("ENDEVPLUGINDETECT", &self.ENDEVPLUGINDETECT())
+            .field("DEVPLUGIN_POLARITY", &self.DEVPLUGIN_POLARITY())
+            .field("OTG_ID_CHG_IRQ", &self.OTG_ID_CHG_IRQ())
+            .field("ENOTGIDDETECT", &self.ENOTGIDDETECT())
+            .field("RESUMEIRQSTICKY", &self.RESUMEIRQSTICKY())
+            .field("ENIRQRESUMEDETECT", &self.ENIRQRESUMEDETECT())
+            .field("RESUME_IRQ", &self.RESUME_IRQ())
+            .field("ENIRQDEVPLUGIN", &self.ENIRQDEVPLUGIN())
+            .field("DEVPLUGIN_IRQ", &self.DEVPLUGIN_IRQ())
+            .field("DATA_ON_LRADC", &self.DATA_ON_LRADC())
+            .field("ENUTMILEVEL2", &self.ENUTMILEVEL2())
+            .field("ENUTMILEVEL3", &self.ENUTMILEVEL3())
+            .field("ENIRQWAKEUP", &self.ENIRQWAKEUP())
+            .field("WAKEUP_IRQ", &self.WAKEUP_IRQ())
+            .field("AUTORESUME_EN", &self.AUTORESUME_EN())
+            .field("ENAUTOCLR_CLKGATE", &self.ENAUTOCLR_CLKGATE())
+            .field("ENAUTOCLR_PHY_PWD", &self.ENAUTOCLR_PHY_PWD())
+            .field("OTG_ID_VALUE", &self.OTG_ID_VALUE())
+            .field("UTMI_SUSPENDM", &self.UTMI_SUSPENDM())
+            .field("CLKGATE", &self.CLKGATE())
+            .field("SFTRST", &self.SFTRST())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CTRL_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "CTRL_CLR {{ ENOTG_ID_CHG_IRQ: {=bool:?}, ENHOSTDISCONDETECT: {=bool:?}, ENIRQHOSTDISCON: {=bool:?}, HOSTDISCONDETECT_IRQ: {=bool:?}, ENDEVPLUGINDETECT: {=bool:?}, DEVPLUGIN_POLARITY: {=bool:?}, OTG_ID_CHG_IRQ: {=bool:?}, ENOTGIDDETECT: {=bool:?}, RESUMEIRQSTICKY: {=bool:?}, ENIRQRESUMEDETECT: {=bool:?}, RESUME_IRQ: {=bool:?}, ENIRQDEVPLUGIN: {=bool:?}, DEVPLUGIN_IRQ: {=bool:?}, DATA_ON_LRADC: {=bool:?}, ENUTMILEVEL2: {=bool:?}, ENUTMILEVEL3: {=bool:?}, ENIRQWAKEUP: {=bool:?}, WAKEUP_IRQ: {=bool:?}, AUTORESUME_EN: {=bool:?}, ENAUTOCLR_CLKGATE: {=bool:?}, ENAUTOCLR_PHY_PWD: {=bool:?}, OTG_ID_VALUE: {=bool:?}, UTMI_SUSPENDM: {=bool:?}, CLKGATE: {=bool:?}, SFTRST: {=bool:?} }}",
+            self.ENOTG_ID_CHG_IRQ(),
+            self.ENHOSTDISCONDETECT(),
+            self.ENIRQHOSTDISCON(),
+            self.HOSTDISCONDETECT_IRQ(),
+            self.ENDEVPLUGINDETECT(),
+            self.DEVPLUGIN_POLARITY(),
+            self.OTG_ID_CHG_IRQ(),
+            self.ENOTGIDDETECT(),
+            self.RESUMEIRQSTICKY(),
+            self.ENIRQRESUMEDETECT(),
+            self.RESUME_IRQ(),
+            self.ENIRQDEVPLUGIN(),
+            self.DEVPLUGIN_IRQ(),
+            self.DATA_ON_LRADC(),
+            self.ENUTMILEVEL2(),
+            self.ENUTMILEVEL3(),
+            self.ENIRQWAKEUP(),
+            self.WAKEUP_IRQ(),
+            self.AUTORESUME_EN(),
+            self.ENAUTOCLR_CLKGATE(),
+            self.ENAUTOCLR_PHY_PWD(),
+            self.OTG_ID_VALUE(),
+            self.UTMI_SUSPENDM(),
+            self.CLKGATE(),
+            self.SFTRST()
+        )
+    }
+}
+#[doc = "General Purpose Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct CTRL_SET(pub u32);
+impl CTRL_SET {
+    #[doc = "OTG ID Change Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENOTG_ID_CHG_IRQ(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG ID Change Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_ENOTG_ID_CHG_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Host Disconnect Detection Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENHOSTDISCONDETECT(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Host Disconnect Detection Enable."]
+    #[inline(always)]
+    pub const fn set_ENHOSTDISCONDETECT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "Enable Interrupt for Host Disconnect."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQHOSTDISCON(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Interrupt for Host Disconnect."]
+    #[inline(always)]
+    pub const fn set_ENIRQHOSTDISCON(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "Host Disconnect Detection Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HOSTDISCONDETECT_IRQ(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Host Disconnect Detection Interrupt."]
+    #[inline(always)]
+    pub const fn set_HOSTDISCONDETECT_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Enable Nonstandard Resistive Plugged-In Detection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENDEVPLUGINDETECT(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Nonstandard Resistive Plugged-In Detection."]
+    #[inline(always)]
+    pub const fn set_ENDEVPLUGINDETECT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "Device Plug-In Polarity."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEVPLUGIN_POLARITY(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Device Plug-In Polarity."]
+    #[inline(always)]
+    pub const fn set_DEVPLUGIN_POLARITY(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+    #[doc = "OTG ID Change Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OTG_ID_CHG_IRQ(&self) -> bool {
+        let val = (self.0 >> 6usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG ID Change Interrupt."]
+    #[inline(always)]
+    pub const fn set_OTG_ID_CHG_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val as u32) & 0x01) << 6usize);
+    }
+    #[doc = "Enable Internal OTG ID Detector."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENOTGIDDETECT(&self) -> bool {
+        let val = (self.0 >> 7usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Internal OTG ID Detector."]
+    #[inline(always)]
+    pub const fn set_ENOTGIDDETECT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val as u32) & 0x01) << 7usize);
+    }
+    #[doc = "Resume Interrupt Sticky."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RESUMEIRQSTICKY(&self) -> bool {
+        let val = (self.0 >> 8usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Resume Interrupt Sticky."]
+    #[inline(always)]
+    pub const fn set_RESUMEIRQSTICKY(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val as u32) & 0x01) << 8usize);
+    }
+    #[doc = "Resume Detection Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQRESUMEDETECT(&self) -> bool {
+        let val = (self.0 >> 9usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Resume Detection Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_ENIRQRESUMEDETECT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 9usize)) | (((val as u32) & 0x01) << 9usize);
+    }
+    #[doc = "Resume Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RESUME_IRQ(&self) -> bool {
+        let val = (self.0 >> 10usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Resume Interrupt."]
+    #[inline(always)]
+    pub const fn set_RESUME_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val as u32) & 0x01) << 10usize);
+    }
+    #[doc = "Enable Interrupt for Nonstandard Resistive Plugged-In Detection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQDEVPLUGIN(&self) -> bool {
+        let val = (self.0 >> 11usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Interrupt for Nonstandard Resistive Plugged-In Detection."]
+    #[inline(always)]
+    pub const fn set_ENIRQDEVPLUGIN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val as u32) & 0x01) << 11usize);
+    }
+    #[doc = "Device Plug-In Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEVPLUGIN_IRQ(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Device Plug-In Interrupt."]
+    #[inline(always)]
+    pub const fn set_DEVPLUGIN_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "APB Clock Switch Option."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DATA_ON_LRADC(&self) -> bool {
+        let val = (self.0 >> 13usize) & 0x01;
+        val != 0
+    }
+    #[doc = "APB Clock Switch Option."]
+    #[inline(always)]
+    pub const fn set_DATA_ON_LRADC(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val as u32) & 0x01) << 13usize);
+    }
+    #[doc = "UTMI Level 2 Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENUTMILEVEL2(&self) -> bool {
+        let val = (self.0 >> 14usize) & 0x01;
+        val != 0
+    }
+    #[doc = "UTMI Level 2 Enable."]
+    #[inline(always)]
+    pub const fn set_ENUTMILEVEL2(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 14usize)) | (((val as u32) & 0x01) << 14usize);
+    }
+    #[doc = "UTMI Level 3 Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENUTMILEVEL3(&self) -> bool {
+        let val = (self.0 >> 15usize) & 0x01;
+        val != 0
+    }
+    #[doc = "UTMI Level 3 Enable."]
+    #[inline(always)]
+    pub const fn set_ENUTMILEVEL3(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 15usize)) | (((val as u32) & 0x01) << 15usize);
+    }
+    #[doc = "Wake-Up Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQWAKEUP(&self) -> bool {
+        let val = (self.0 >> 16usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Wake-Up Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_ENIRQWAKEUP(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val as u32) & 0x01) << 16usize);
+    }
+    #[doc = "Wake-Up Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WAKEUP_IRQ(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Wake-Up Interrupt."]
+    #[inline(always)]
+    pub const fn set_WAKEUP_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "Autoresume Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AUTORESUME_EN(&self) -> bool {
+        let val = (self.0 >> 18usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Autoresume Enable."]
+    #[inline(always)]
+    pub const fn set_AUTORESUME_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    }
+    #[doc = "Autoclear Clock Gate Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENAUTOCLR_CLKGATE(&self) -> bool {
+        let val = (self.0 >> 19usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Autoclear Clock Gate Enable."]
+    #[inline(always)]
+    pub const fn set_ENAUTOCLR_CLKGATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val as u32) & 0x01) << 19usize);
+    }
+    #[doc = "PHY PWD Autoclear Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENAUTOCLR_PHY_PWD(&self) -> bool {
+        let val = (self.0 >> 20usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PHY PWD Autoclear Enable."]
+    #[inline(always)]
+    pub const fn set_ENAUTOCLR_PHY_PWD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val as u32) & 0x01) << 20usize);
+    }
+    #[doc = "OTG ID Value."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OTG_ID_VALUE(&self) -> bool {
+        let val = (self.0 >> 27usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG ID Value."]
+    #[inline(always)]
+    pub const fn set_OTG_ID_VALUE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 27usize)) | (((val as u32) & 0x01) << 27usize);
+    }
+    #[doc = "UTMI Suspend."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn UTMI_SUSPENDM(&self) -> bool {
+        let val = (self.0 >> 29usize) & 0x01;
+        val != 0
+    }
+    #[doc = "UTMI Suspend."]
+    #[inline(always)]
+    pub const fn set_UTMI_SUSPENDM(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 29usize)) | (((val as u32) & 0x01) << 29usize);
+    }
+    #[doc = "UTMI Clock Gate."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CLKGATE(&self) -> bool {
+        let val = (self.0 >> 30usize) & 0x01;
+        val != 0
+    }
+    #[doc = "UTMI Clock Gate."]
+    #[inline(always)]
+    pub const fn set_CLKGATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val as u32) & 0x01) << 30usize);
+    }
+    #[doc = "Software Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SFTRST(&self) -> bool {
+        let val = (self.0 >> 31usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Software Reset."]
+    #[inline(always)]
+    pub const fn set_SFTRST(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for CTRL_SET {
+    #[inline(always)]
+    fn default() -> CTRL_SET {
+        CTRL_SET(0)
+    }
+}
+impl core::fmt::Debug for CTRL_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CTRL_SET")
+            .field("ENOTG_ID_CHG_IRQ", &self.ENOTG_ID_CHG_IRQ())
+            .field("ENHOSTDISCONDETECT", &self.ENHOSTDISCONDETECT())
+            .field("ENIRQHOSTDISCON", &self.ENIRQHOSTDISCON())
+            .field("HOSTDISCONDETECT_IRQ", &self.HOSTDISCONDETECT_IRQ())
+            .field("ENDEVPLUGINDETECT", &self.ENDEVPLUGINDETECT())
+            .field("DEVPLUGIN_POLARITY", &self.DEVPLUGIN_POLARITY())
+            .field("OTG_ID_CHG_IRQ", &self.OTG_ID_CHG_IRQ())
+            .field("ENOTGIDDETECT", &self.ENOTGIDDETECT())
+            .field("RESUMEIRQSTICKY", &self.RESUMEIRQSTICKY())
+            .field("ENIRQRESUMEDETECT", &self.ENIRQRESUMEDETECT())
+            .field("RESUME_IRQ", &self.RESUME_IRQ())
+            .field("ENIRQDEVPLUGIN", &self.ENIRQDEVPLUGIN())
+            .field("DEVPLUGIN_IRQ", &self.DEVPLUGIN_IRQ())
+            .field("DATA_ON_LRADC", &self.DATA_ON_LRADC())
+            .field("ENUTMILEVEL2", &self.ENUTMILEVEL2())
+            .field("ENUTMILEVEL3", &self.ENUTMILEVEL3())
+            .field("ENIRQWAKEUP", &self.ENIRQWAKEUP())
+            .field("WAKEUP_IRQ", &self.WAKEUP_IRQ())
+            .field("AUTORESUME_EN", &self.AUTORESUME_EN())
+            .field("ENAUTOCLR_CLKGATE", &self.ENAUTOCLR_CLKGATE())
+            .field("ENAUTOCLR_PHY_PWD", &self.ENAUTOCLR_PHY_PWD())
+            .field("OTG_ID_VALUE", &self.OTG_ID_VALUE())
+            .field("UTMI_SUSPENDM", &self.UTMI_SUSPENDM())
+            .field("CLKGATE", &self.CLKGATE())
+            .field("SFTRST", &self.SFTRST())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CTRL_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "CTRL_SET {{ ENOTG_ID_CHG_IRQ: {=bool:?}, ENHOSTDISCONDETECT: {=bool:?}, ENIRQHOSTDISCON: {=bool:?}, HOSTDISCONDETECT_IRQ: {=bool:?}, ENDEVPLUGINDETECT: {=bool:?}, DEVPLUGIN_POLARITY: {=bool:?}, OTG_ID_CHG_IRQ: {=bool:?}, ENOTGIDDETECT: {=bool:?}, RESUMEIRQSTICKY: {=bool:?}, ENIRQRESUMEDETECT: {=bool:?}, RESUME_IRQ: {=bool:?}, ENIRQDEVPLUGIN: {=bool:?}, DEVPLUGIN_IRQ: {=bool:?}, DATA_ON_LRADC: {=bool:?}, ENUTMILEVEL2: {=bool:?}, ENUTMILEVEL3: {=bool:?}, ENIRQWAKEUP: {=bool:?}, WAKEUP_IRQ: {=bool:?}, AUTORESUME_EN: {=bool:?}, ENAUTOCLR_CLKGATE: {=bool:?}, ENAUTOCLR_PHY_PWD: {=bool:?}, OTG_ID_VALUE: {=bool:?}, UTMI_SUSPENDM: {=bool:?}, CLKGATE: {=bool:?}, SFTRST: {=bool:?} }}",
+            self.ENOTG_ID_CHG_IRQ(),
+            self.ENHOSTDISCONDETECT(),
+            self.ENIRQHOSTDISCON(),
+            self.HOSTDISCONDETECT_IRQ(),
+            self.ENDEVPLUGINDETECT(),
+            self.DEVPLUGIN_POLARITY(),
+            self.OTG_ID_CHG_IRQ(),
+            self.ENOTGIDDETECT(),
+            self.RESUMEIRQSTICKY(),
+            self.ENIRQRESUMEDETECT(),
+            self.RESUME_IRQ(),
+            self.ENIRQDEVPLUGIN(),
+            self.DEVPLUGIN_IRQ(),
+            self.DATA_ON_LRADC(),
+            self.ENUTMILEVEL2(),
+            self.ENUTMILEVEL3(),
+            self.ENIRQWAKEUP(),
+            self.WAKEUP_IRQ(),
+            self.AUTORESUME_EN(),
+            self.ENAUTOCLR_CLKGATE(),
+            self.ENAUTOCLR_PHY_PWD(),
+            self.OTG_ID_VALUE(),
+            self.UTMI_SUSPENDM(),
+            self.CLKGATE(),
+            self.SFTRST()
+        )
+    }
+}
+#[doc = "General Purpose Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct CTRL_TOG(pub u32);
+impl CTRL_TOG {
+    #[doc = "OTG ID Change Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENOTG_ID_CHG_IRQ(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG ID Change Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_ENOTG_ID_CHG_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Host Disconnect Detection Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENHOSTDISCONDETECT(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Host Disconnect Detection Enable."]
+    #[inline(always)]
+    pub const fn set_ENHOSTDISCONDETECT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "Enable Interrupt for Host Disconnect."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQHOSTDISCON(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Interrupt for Host Disconnect."]
+    #[inline(always)]
+    pub const fn set_ENIRQHOSTDISCON(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "Host Disconnect Detection Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HOSTDISCONDETECT_IRQ(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Host Disconnect Detection Interrupt."]
+    #[inline(always)]
+    pub const fn set_HOSTDISCONDETECT_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Enable Nonstandard Resistive Plugged-In Detection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENDEVPLUGINDETECT(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Nonstandard Resistive Plugged-In Detection."]
+    #[inline(always)]
+    pub const fn set_ENDEVPLUGINDETECT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "Device Plug-In Polarity."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEVPLUGIN_POLARITY(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Device Plug-In Polarity."]
+    #[inline(always)]
+    pub const fn set_DEVPLUGIN_POLARITY(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+    #[doc = "OTG ID Change Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OTG_ID_CHG_IRQ(&self) -> bool {
+        let val = (self.0 >> 6usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG ID Change Interrupt."]
+    #[inline(always)]
+    pub const fn set_OTG_ID_CHG_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val as u32) & 0x01) << 6usize);
+    }
+    #[doc = "Enable Internal OTG ID Detector."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENOTGIDDETECT(&self) -> bool {
+        let val = (self.0 >> 7usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Internal OTG ID Detector."]
+    #[inline(always)]
+    pub const fn set_ENOTGIDDETECT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val as u32) & 0x01) << 7usize);
+    }
+    #[doc = "Resume Interrupt Sticky."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RESUMEIRQSTICKY(&self) -> bool {
+        let val = (self.0 >> 8usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Resume Interrupt Sticky."]
+    #[inline(always)]
+    pub const fn set_RESUMEIRQSTICKY(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val as u32) & 0x01) << 8usize);
+    }
+    #[doc = "Resume Detection Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQRESUMEDETECT(&self) -> bool {
+        let val = (self.0 >> 9usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Resume Detection Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_ENIRQRESUMEDETECT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 9usize)) | (((val as u32) & 0x01) << 9usize);
+    }
+    #[doc = "Resume Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RESUME_IRQ(&self) -> bool {
+        let val = (self.0 >> 10usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Resume Interrupt."]
+    #[inline(always)]
+    pub const fn set_RESUME_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val as u32) & 0x01) << 10usize);
+    }
+    #[doc = "Enable Interrupt for Nonstandard Resistive Plugged-In Detection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQDEVPLUGIN(&self) -> bool {
+        let val = (self.0 >> 11usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Interrupt for Nonstandard Resistive Plugged-In Detection."]
+    #[inline(always)]
+    pub const fn set_ENIRQDEVPLUGIN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val as u32) & 0x01) << 11usize);
+    }
+    #[doc = "Device Plug-In Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEVPLUGIN_IRQ(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Device Plug-In Interrupt."]
+    #[inline(always)]
+    pub const fn set_DEVPLUGIN_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "APB Clock Switch Option."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DATA_ON_LRADC(&self) -> bool {
+        let val = (self.0 >> 13usize) & 0x01;
+        val != 0
+    }
+    #[doc = "APB Clock Switch Option."]
+    #[inline(always)]
+    pub const fn set_DATA_ON_LRADC(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val as u32) & 0x01) << 13usize);
+    }
+    #[doc = "UTMI Level 2 Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENUTMILEVEL2(&self) -> bool {
+        let val = (self.0 >> 14usize) & 0x01;
+        val != 0
+    }
+    #[doc = "UTMI Level 2 Enable."]
+    #[inline(always)]
+    pub const fn set_ENUTMILEVEL2(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 14usize)) | (((val as u32) & 0x01) << 14usize);
+    }
+    #[doc = "UTMI Level 3 Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENUTMILEVEL3(&self) -> bool {
+        let val = (self.0 >> 15usize) & 0x01;
+        val != 0
+    }
+    #[doc = "UTMI Level 3 Enable."]
+    #[inline(always)]
+    pub const fn set_ENUTMILEVEL3(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 15usize)) | (((val as u32) & 0x01) << 15usize);
+    }
+    #[doc = "Wake-Up Interrupt Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENIRQWAKEUP(&self) -> bool {
+        let val = (self.0 >> 16usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Wake-Up Interrupt Enable."]
+    #[inline(always)]
+    pub const fn set_ENIRQWAKEUP(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val as u32) & 0x01) << 16usize);
+    }
+    #[doc = "Wake-Up Interrupt."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn WAKEUP_IRQ(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Wake-Up Interrupt."]
+    #[inline(always)]
+    pub const fn set_WAKEUP_IRQ(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "Autoresume Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AUTORESUME_EN(&self) -> bool {
+        let val = (self.0 >> 18usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Autoresume Enable."]
+    #[inline(always)]
+    pub const fn set_AUTORESUME_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    }
+    #[doc = "Autoclear Clock Gate Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENAUTOCLR_CLKGATE(&self) -> bool {
+        let val = (self.0 >> 19usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Autoclear Clock Gate Enable."]
+    #[inline(always)]
+    pub const fn set_ENAUTOCLR_CLKGATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val as u32) & 0x01) << 19usize);
+    }
+    #[doc = "PHY PWD Autoclear Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENAUTOCLR_PHY_PWD(&self) -> bool {
+        let val = (self.0 >> 20usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PHY PWD Autoclear Enable."]
+    #[inline(always)]
+    pub const fn set_ENAUTOCLR_PHY_PWD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val as u32) & 0x01) << 20usize);
+    }
+    #[doc = "OTG ID Value."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OTG_ID_VALUE(&self) -> bool {
+        let val = (self.0 >> 27usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG ID Value."]
+    #[inline(always)]
+    pub const fn set_OTG_ID_VALUE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 27usize)) | (((val as u32) & 0x01) << 27usize);
+    }
+    #[doc = "UTMI Suspend."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn UTMI_SUSPENDM(&self) -> bool {
+        let val = (self.0 >> 29usize) & 0x01;
+        val != 0
+    }
+    #[doc = "UTMI Suspend."]
+    #[inline(always)]
+    pub const fn set_UTMI_SUSPENDM(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 29usize)) | (((val as u32) & 0x01) << 29usize);
+    }
+    #[doc = "UTMI Clock Gate."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CLKGATE(&self) -> bool {
+        let val = (self.0 >> 30usize) & 0x01;
+        val != 0
+    }
+    #[doc = "UTMI Clock Gate."]
+    #[inline(always)]
+    pub const fn set_CLKGATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val as u32) & 0x01) << 30usize);
+    }
+    #[doc = "Software Reset."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SFTRST(&self) -> bool {
+        let val = (self.0 >> 31usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Software Reset."]
+    #[inline(always)]
+    pub const fn set_SFTRST(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for CTRL_TOG {
+    #[inline(always)]
+    fn default() -> CTRL_TOG {
+        CTRL_TOG(0)
+    }
+}
+impl core::fmt::Debug for CTRL_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CTRL_TOG")
+            .field("ENOTG_ID_CHG_IRQ", &self.ENOTG_ID_CHG_IRQ())
+            .field("ENHOSTDISCONDETECT", &self.ENHOSTDISCONDETECT())
+            .field("ENIRQHOSTDISCON", &self.ENIRQHOSTDISCON())
+            .field("HOSTDISCONDETECT_IRQ", &self.HOSTDISCONDETECT_IRQ())
+            .field("ENDEVPLUGINDETECT", &self.ENDEVPLUGINDETECT())
+            .field("DEVPLUGIN_POLARITY", &self.DEVPLUGIN_POLARITY())
+            .field("OTG_ID_CHG_IRQ", &self.OTG_ID_CHG_IRQ())
+            .field("ENOTGIDDETECT", &self.ENOTGIDDETECT())
+            .field("RESUMEIRQSTICKY", &self.RESUMEIRQSTICKY())
+            .field("ENIRQRESUMEDETECT", &self.ENIRQRESUMEDETECT())
+            .field("RESUME_IRQ", &self.RESUME_IRQ())
+            .field("ENIRQDEVPLUGIN", &self.ENIRQDEVPLUGIN())
+            .field("DEVPLUGIN_IRQ", &self.DEVPLUGIN_IRQ())
+            .field("DATA_ON_LRADC", &self.DATA_ON_LRADC())
+            .field("ENUTMILEVEL2", &self.ENUTMILEVEL2())
+            .field("ENUTMILEVEL3", &self.ENUTMILEVEL3())
+            .field("ENIRQWAKEUP", &self.ENIRQWAKEUP())
+            .field("WAKEUP_IRQ", &self.WAKEUP_IRQ())
+            .field("AUTORESUME_EN", &self.AUTORESUME_EN())
+            .field("ENAUTOCLR_CLKGATE", &self.ENAUTOCLR_CLKGATE())
+            .field("ENAUTOCLR_PHY_PWD", &self.ENAUTOCLR_PHY_PWD())
+            .field("OTG_ID_VALUE", &self.OTG_ID_VALUE())
+            .field("UTMI_SUSPENDM", &self.UTMI_SUSPENDM())
+            .field("CLKGATE", &self.CLKGATE())
+            .field("SFTRST", &self.SFTRST())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CTRL_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "CTRL_TOG {{ ENOTG_ID_CHG_IRQ: {=bool:?}, ENHOSTDISCONDETECT: {=bool:?}, ENIRQHOSTDISCON: {=bool:?}, HOSTDISCONDETECT_IRQ: {=bool:?}, ENDEVPLUGINDETECT: {=bool:?}, DEVPLUGIN_POLARITY: {=bool:?}, OTG_ID_CHG_IRQ: {=bool:?}, ENOTGIDDETECT: {=bool:?}, RESUMEIRQSTICKY: {=bool:?}, ENIRQRESUMEDETECT: {=bool:?}, RESUME_IRQ: {=bool:?}, ENIRQDEVPLUGIN: {=bool:?}, DEVPLUGIN_IRQ: {=bool:?}, DATA_ON_LRADC: {=bool:?}, ENUTMILEVEL2: {=bool:?}, ENUTMILEVEL3: {=bool:?}, ENIRQWAKEUP: {=bool:?}, WAKEUP_IRQ: {=bool:?}, AUTORESUME_EN: {=bool:?}, ENAUTOCLR_CLKGATE: {=bool:?}, ENAUTOCLR_PHY_PWD: {=bool:?}, OTG_ID_VALUE: {=bool:?}, UTMI_SUSPENDM: {=bool:?}, CLKGATE: {=bool:?}, SFTRST: {=bool:?} }}",
+            self.ENOTG_ID_CHG_IRQ(),
+            self.ENHOSTDISCONDETECT(),
+            self.ENIRQHOSTDISCON(),
+            self.HOSTDISCONDETECT_IRQ(),
+            self.ENDEVPLUGINDETECT(),
+            self.DEVPLUGIN_POLARITY(),
+            self.OTG_ID_CHG_IRQ(),
+            self.ENOTGIDDETECT(),
+            self.RESUMEIRQSTICKY(),
+            self.ENIRQRESUMEDETECT(),
+            self.RESUME_IRQ(),
+            self.ENIRQDEVPLUGIN(),
+            self.DEVPLUGIN_IRQ(),
+            self.DATA_ON_LRADC(),
+            self.ENUTMILEVEL2(),
+            self.ENUTMILEVEL3(),
+            self.ENIRQWAKEUP(),
+            self.WAKEUP_IRQ(),
+            self.AUTORESUME_EN(),
+            self.ENAUTOCLR_CLKGATE(),
+            self.ENAUTOCLR_PHY_PWD(),
+            self.OTG_ID_VALUE(),
+            self.UTMI_SUSPENDM(),
+            self.CLKGATE(),
+            self.SFTRST()
+        )
+    }
+}
+#[doc = "Debug 0."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct DEBUG0(pub u32);
+impl DEBUG0 {
+    #[doc = "Hold OTG_ID."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OTGIDPIOLOCK(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Hold OTG_ID."]
+    #[inline(always)]
+    pub const fn set_OTGIDPIOLOCK(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Host Pulldown Overdrive Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HSTPULLDOWN(&self) -> HSTPULLDOWN {
+        let val = (self.0 >> 2usize) & 0x03;
+        HSTPULLDOWN::from_bits(val as u8)
+    }
+    #[doc = "Host Pulldown Overdrive Mode."]
+    #[inline(always)]
+    pub const fn set_HSTPULLDOWN(&mut self, val: HSTPULLDOWN) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val.to_bits() as u32) & 0x03) << 2usize);
+    }
+    #[doc = "Enable Host Pulldown Overdrive Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENHSTPULLDOWN(&self) -> ENHSTPULLDOWN {
+        let val = (self.0 >> 4usize) & 0x03;
+        ENHSTPULLDOWN::from_bits(val as u8)
+    }
+    #[doc = "Enable Host Pulldown Overdrive Mode."]
+    #[inline(always)]
+    pub const fn set_ENHSTPULLDOWN(&mut self, val: ENHSTPULLDOWN) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val.to_bits() as u32) & 0x03) << 4usize);
+    }
+}
+impl Default for DEBUG0 {
+    #[inline(always)]
+    fn default() -> DEBUG0 {
+        DEBUG0(0)
+    }
+}
+impl core::fmt::Debug for DEBUG0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DEBUG0")
+            .field("OTGIDPIOLOCK", &self.OTGIDPIOLOCK())
+            .field("HSTPULLDOWN", &self.HSTPULLDOWN())
+            .field("ENHSTPULLDOWN", &self.ENHSTPULLDOWN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DEBUG0 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "DEBUG0 {{ OTGIDPIOLOCK: {=bool:?}, HSTPULLDOWN: {:?}, ENHSTPULLDOWN: {:?} }}",
+            self.OTGIDPIOLOCK(),
+            self.HSTPULLDOWN(),
+            self.ENHSTPULLDOWN()
+        )
+    }
+}
+#[doc = "Debug 0."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct DEBUG0_CLR(pub u32);
+impl DEBUG0_CLR {
+    #[doc = "Hold OTG_ID."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OTGIDPIOLOCK(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Hold OTG_ID."]
+    #[inline(always)]
+    pub const fn set_OTGIDPIOLOCK(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Host Pulldown Overdrive Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HSTPULLDOWN(&self) -> u8 {
+        let val = (self.0 >> 2usize) & 0x03;
+        val as u8
+    }
+    #[doc = "Host Pulldown Overdrive Mode."]
+    #[inline(always)]
+    pub const fn set_HSTPULLDOWN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val as u32) & 0x03) << 2usize);
+    }
+    #[doc = "Enable Host Pulldown Overdrive Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENHSTPULLDOWN(&self) -> u8 {
+        let val = (self.0 >> 4usize) & 0x03;
+        val as u8
+    }
+    #[doc = "Enable Host Pulldown Overdrive Mode."]
+    #[inline(always)]
+    pub const fn set_ENHSTPULLDOWN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val as u32) & 0x03) << 4usize);
+    }
+}
+impl Default for DEBUG0_CLR {
+    #[inline(always)]
+    fn default() -> DEBUG0_CLR {
+        DEBUG0_CLR(0)
+    }
+}
+impl core::fmt::Debug for DEBUG0_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DEBUG0_CLR")
+            .field("OTGIDPIOLOCK", &self.OTGIDPIOLOCK())
+            .field("HSTPULLDOWN", &self.HSTPULLDOWN())
+            .field("ENHSTPULLDOWN", &self.ENHSTPULLDOWN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DEBUG0_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "DEBUG0_CLR {{ OTGIDPIOLOCK: {=bool:?}, HSTPULLDOWN: {=u8:?}, ENHSTPULLDOWN: {=u8:?} }}",
+            self.OTGIDPIOLOCK(),
+            self.HSTPULLDOWN(),
+            self.ENHSTPULLDOWN()
+        )
+    }
+}
+#[doc = "Debug 0."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct DEBUG0_SET(pub u32);
+impl DEBUG0_SET {
+    #[doc = "Hold OTG_ID."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OTGIDPIOLOCK(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Hold OTG_ID."]
+    #[inline(always)]
+    pub const fn set_OTGIDPIOLOCK(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Host Pulldown Overdrive Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HSTPULLDOWN(&self) -> u8 {
+        let val = (self.0 >> 2usize) & 0x03;
+        val as u8
+    }
+    #[doc = "Host Pulldown Overdrive Mode."]
+    #[inline(always)]
+    pub const fn set_HSTPULLDOWN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val as u32) & 0x03) << 2usize);
+    }
+    #[doc = "Enable Host Pulldown Overdrive Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENHSTPULLDOWN(&self) -> u8 {
+        let val = (self.0 >> 4usize) & 0x03;
+        val as u8
+    }
+    #[doc = "Enable Host Pulldown Overdrive Mode."]
+    #[inline(always)]
+    pub const fn set_ENHSTPULLDOWN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val as u32) & 0x03) << 4usize);
+    }
+}
+impl Default for DEBUG0_SET {
+    #[inline(always)]
+    fn default() -> DEBUG0_SET {
+        DEBUG0_SET(0)
+    }
+}
+impl core::fmt::Debug for DEBUG0_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DEBUG0_SET")
+            .field("OTGIDPIOLOCK", &self.OTGIDPIOLOCK())
+            .field("HSTPULLDOWN", &self.HSTPULLDOWN())
+            .field("ENHSTPULLDOWN", &self.ENHSTPULLDOWN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DEBUG0_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "DEBUG0_SET {{ OTGIDPIOLOCK: {=bool:?}, HSTPULLDOWN: {=u8:?}, ENHSTPULLDOWN: {=u8:?} }}",
+            self.OTGIDPIOLOCK(),
+            self.HSTPULLDOWN(),
+            self.ENHSTPULLDOWN()
+        )
+    }
+}
+#[doc = "Debug 0."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct DEBUG0_TOG(pub u32);
+impl DEBUG0_TOG {
+    #[doc = "Hold OTG_ID."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OTGIDPIOLOCK(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Hold OTG_ID."]
+    #[inline(always)]
+    pub const fn set_OTGIDPIOLOCK(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Host Pulldown Overdrive Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HSTPULLDOWN(&self) -> u8 {
+        let val = (self.0 >> 2usize) & 0x03;
+        val as u8
+    }
+    #[doc = "Host Pulldown Overdrive Mode."]
+    #[inline(always)]
+    pub const fn set_HSTPULLDOWN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 2usize)) | (((val as u32) & 0x03) << 2usize);
+    }
+    #[doc = "Enable Host Pulldown Overdrive Mode."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENHSTPULLDOWN(&self) -> u8 {
+        let val = (self.0 >> 4usize) & 0x03;
+        val as u8
+    }
+    #[doc = "Enable Host Pulldown Overdrive Mode."]
+    #[inline(always)]
+    pub const fn set_ENHSTPULLDOWN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 4usize)) | (((val as u32) & 0x03) << 4usize);
+    }
+}
+impl Default for DEBUG0_TOG {
+    #[inline(always)]
+    fn default() -> DEBUG0_TOG {
+        DEBUG0_TOG(0)
+    }
+}
+impl core::fmt::Debug for DEBUG0_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DEBUG0_TOG")
+            .field("OTGIDPIOLOCK", &self.OTGIDPIOLOCK())
+            .field("HSTPULLDOWN", &self.HSTPULLDOWN())
+            .field("ENHSTPULLDOWN", &self.ENHSTPULLDOWN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DEBUG0_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "DEBUG0_TOG {{ OTGIDPIOLOCK: {=bool:?}, HSTPULLDOWN: {=u8:?}, ENHSTPULLDOWN: {=u8:?} }}",
+            self.OTGIDPIOLOCK(),
+            self.HSTPULLDOWN(),
+            self.ENHSTPULLDOWN()
+        )
+    }
+}
+#[doc = "IP Block."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct IP(pub u32);
+impl IP {
+    #[doc = "Power Control Suspend Option."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn POWER_CONTROL_SUSPEND_OPTION(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Control Suspend Option."]
+    #[inline(always)]
+    pub const fn set_POWER_CONTROL_SUSPEND_OPTION(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+}
+impl Default for IP {
+    #[inline(always)]
+    fn default() -> IP {
+        IP(0)
+    }
+}
+impl core::fmt::Debug for IP {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IP")
+            .field(
+                "POWER_CONTROL_SUSPEND_OPTION",
+                &self.POWER_CONTROL_SUSPEND_OPTION(),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IP {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "IP {{ POWER_CONTROL_SUSPEND_OPTION: {=bool:?} }}",
+            self.POWER_CONTROL_SUSPEND_OPTION()
+        )
+    }
+}
+#[doc = "IP Block."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct IP_CLR(pub u32);
+impl IP_CLR {
+    #[doc = "Power Control Suspend Option."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn POWER_CONTROL_SUSPEND_OPTION(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Control Suspend Option."]
+    #[inline(always)]
+    pub const fn set_POWER_CONTROL_SUSPEND_OPTION(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+}
+impl Default for IP_CLR {
+    #[inline(always)]
+    fn default() -> IP_CLR {
+        IP_CLR(0)
+    }
+}
+impl core::fmt::Debug for IP_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IP_CLR")
+            .field(
+                "POWER_CONTROL_SUSPEND_OPTION",
+                &self.POWER_CONTROL_SUSPEND_OPTION(),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IP_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "IP_CLR {{ POWER_CONTROL_SUSPEND_OPTION: {=bool:?} }}",
+            self.POWER_CONTROL_SUSPEND_OPTION()
+        )
+    }
+}
+#[doc = "IP Block."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct IP_SET(pub u32);
+impl IP_SET {
+    #[doc = "Power Control Suspend Option."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn POWER_CONTROL_SUSPEND_OPTION(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Control Suspend Option."]
+    #[inline(always)]
+    pub const fn set_POWER_CONTROL_SUSPEND_OPTION(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+}
+impl Default for IP_SET {
+    #[inline(always)]
+    fn default() -> IP_SET {
+        IP_SET(0)
+    }
+}
+impl core::fmt::Debug for IP_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IP_SET")
+            .field(
+                "POWER_CONTROL_SUSPEND_OPTION",
+                &self.POWER_CONTROL_SUSPEND_OPTION(),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IP_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "IP_SET {{ POWER_CONTROL_SUSPEND_OPTION: {=bool:?} }}",
+            self.POWER_CONTROL_SUSPEND_OPTION()
+        )
+    }
+}
+#[doc = "IP Block."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct IP_TOG(pub u32);
+impl IP_TOG {
+    #[doc = "Power Control Suspend Option."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn POWER_CONTROL_SUSPEND_OPTION(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Control Suspend Option."]
+    #[inline(always)]
+    pub const fn set_POWER_CONTROL_SUSPEND_OPTION(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+}
+impl Default for IP_TOG {
+    #[inline(always)]
+    fn default() -> IP_TOG {
+        IP_TOG(0)
+    }
+}
+impl core::fmt::Debug for IP_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IP_TOG")
+            .field(
+                "POWER_CONTROL_SUSPEND_OPTION",
+                &self.POWER_CONTROL_SUSPEND_OPTION(),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IP_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "IP_TOG {{ POWER_CONTROL_SUSPEND_OPTION: {=bool:?} }}",
+            self.POWER_CONTROL_SUSPEND_OPTION()
+        )
+    }
+}
+#[doc = "PFD A."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PFDA(pub u32);
+impl PFDA {
+    #[doc = "PFD0 Clock Gate."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD0_CLKGATE(&self) -> PFD0_CLKGATE {
+        let val = (self.0 >> 0usize) & 0x01;
+        PFD0_CLKGATE::from_bits(val as u8)
+    }
+    #[doc = "PFD0 Clock Gate."]
+    #[inline(always)]
+    pub const fn set_PFD0_CLKGATE(&mut self, val: PFD0_CLKGATE) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "PFD0 Fractional Divider."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD0_FRAC(&self) -> u8 {
+        let val = (self.0 >> 1usize) & 0x3f;
+        val as u8
+    }
+    #[doc = "PFD0 Fractional Divider."]
+    #[inline(always)]
+    pub const fn set_PFD0_FRAC(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x3f << 1usize)) | (((val as u32) & 0x3f) << 1usize);
+    }
+    #[doc = "PFD0 Stable Signal."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD0_STABLE(&self) -> PFD0_STABLE {
+        let val = (self.0 >> 7usize) & 0x01;
+        PFD0_STABLE::from_bits(val as u8)
+    }
+    #[doc = "PFD0 Stable Signal."]
+    #[inline(always)]
+    pub const fn set_PFD0_STABLE(&mut self, val: PFD0_STABLE) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val.to_bits() as u32) & 0x01) << 7usize);
+    }
+}
+impl Default for PFDA {
+    #[inline(always)]
+    fn default() -> PFDA {
+        PFDA(0)
+    }
+}
+impl core::fmt::Debug for PFDA {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PFDA")
+            .field("PFD0_CLKGATE", &self.PFD0_CLKGATE())
+            .field("PFD0_FRAC", &self.PFD0_FRAC())
+            .field("PFD0_STABLE", &self.PFD0_STABLE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PFDA {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PFDA {{ PFD0_CLKGATE: {:?}, PFD0_FRAC: {=u8:?}, PFD0_STABLE: {:?} }}",
+            self.PFD0_CLKGATE(),
+            self.PFD0_FRAC(),
+            self.PFD0_STABLE()
+        )
+    }
+}
+#[doc = "PFD A."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PFDA_CLR(pub u32);
+impl PFDA_CLR {
+    #[doc = "PFD0 Clock Gate."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD0_CLKGATE(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PFD0 Clock Gate."]
+    #[inline(always)]
+    pub const fn set_PFD0_CLKGATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "PFD0 Fractional Divider."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD0_FRAC(&self) -> u8 {
+        let val = (self.0 >> 1usize) & 0x3f;
+        val as u8
+    }
+    #[doc = "PFD0 Fractional Divider."]
+    #[inline(always)]
+    pub const fn set_PFD0_FRAC(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x3f << 1usize)) | (((val as u32) & 0x3f) << 1usize);
+    }
+    #[doc = "PFD0 Stable Signal."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD0_STABLE(&self) -> bool {
+        let val = (self.0 >> 7usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PFD0 Stable Signal."]
+    #[inline(always)]
+    pub const fn set_PFD0_STABLE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val as u32) & 0x01) << 7usize);
+    }
+}
+impl Default for PFDA_CLR {
+    #[inline(always)]
+    fn default() -> PFDA_CLR {
+        PFDA_CLR(0)
+    }
+}
+impl core::fmt::Debug for PFDA_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PFDA_CLR")
+            .field("PFD0_CLKGATE", &self.PFD0_CLKGATE())
+            .field("PFD0_FRAC", &self.PFD0_FRAC())
+            .field("PFD0_STABLE", &self.PFD0_STABLE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PFDA_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PFDA_CLR {{ PFD0_CLKGATE: {=bool:?}, PFD0_FRAC: {=u8:?}, PFD0_STABLE: {=bool:?} }}",
+            self.PFD0_CLKGATE(),
+            self.PFD0_FRAC(),
+            self.PFD0_STABLE()
+        )
+    }
+}
+#[doc = "PFD A."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PFDA_SET(pub u32);
+impl PFDA_SET {
+    #[doc = "PFD0 Clock Gate."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD0_CLKGATE(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PFD0 Clock Gate."]
+    #[inline(always)]
+    pub const fn set_PFD0_CLKGATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "PFD0 Fractional Divider."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD0_FRAC(&self) -> u8 {
+        let val = (self.0 >> 1usize) & 0x3f;
+        val as u8
+    }
+    #[doc = "PFD0 Fractional Divider."]
+    #[inline(always)]
+    pub const fn set_PFD0_FRAC(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x3f << 1usize)) | (((val as u32) & 0x3f) << 1usize);
+    }
+    #[doc = "PFD0 Stable Signal."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD0_STABLE(&self) -> bool {
+        let val = (self.0 >> 7usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PFD0 Stable Signal."]
+    #[inline(always)]
+    pub const fn set_PFD0_STABLE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val as u32) & 0x01) << 7usize);
+    }
+}
+impl Default for PFDA_SET {
+    #[inline(always)]
+    fn default() -> PFDA_SET {
+        PFDA_SET(0)
+    }
+}
+impl core::fmt::Debug for PFDA_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PFDA_SET")
+            .field("PFD0_CLKGATE", &self.PFD0_CLKGATE())
+            .field("PFD0_FRAC", &self.PFD0_FRAC())
+            .field("PFD0_STABLE", &self.PFD0_STABLE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PFDA_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PFDA_SET {{ PFD0_CLKGATE: {=bool:?}, PFD0_FRAC: {=u8:?}, PFD0_STABLE: {=bool:?} }}",
+            self.PFD0_CLKGATE(),
+            self.PFD0_FRAC(),
+            self.PFD0_STABLE()
+        )
+    }
+}
+#[doc = "PFD A."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PFDA_TOG(pub u32);
+impl PFDA_TOG {
+    #[doc = "PFD0 Clock Gate."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD0_CLKGATE(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PFD0 Clock Gate."]
+    #[inline(always)]
+    pub const fn set_PFD0_CLKGATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "PFD0 Fractional Divider."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD0_FRAC(&self) -> u8 {
+        let val = (self.0 >> 1usize) & 0x3f;
+        val as u8
+    }
+    #[doc = "PFD0 Fractional Divider."]
+    #[inline(always)]
+    pub const fn set_PFD0_FRAC(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x3f << 1usize)) | (((val as u32) & 0x3f) << 1usize);
+    }
+    #[doc = "PFD0 Stable Signal."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PFD0_STABLE(&self) -> bool {
+        let val = (self.0 >> 7usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PFD0 Stable Signal."]
+    #[inline(always)]
+    pub const fn set_PFD0_STABLE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val as u32) & 0x01) << 7usize);
+    }
+}
+impl Default for PFDA_TOG {
+    #[inline(always)]
+    fn default() -> PFDA_TOG {
+        PFDA_TOG(0)
+    }
+}
+impl core::fmt::Debug for PFDA_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PFDA_TOG")
+            .field("PFD0_CLKGATE", &self.PFD0_CLKGATE())
+            .field("PFD0_FRAC", &self.PFD0_FRAC())
+            .field("PFD0_STABLE", &self.PFD0_STABLE())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PFDA_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PFDA_TOG {{ PFD0_CLKGATE: {=bool:?}, PFD0_FRAC: {=u8:?}, PFD0_STABLE: {=bool:?} }}",
+            self.PFD0_CLKGATE(),
+            self.PFD0_FRAC(),
+            self.PFD0_STABLE()
+        )
+    }
+}
+#[doc = "PLL SIC."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PLL_SIC(pub u32);
+impl PLL_SIC {
+    #[doc = "Miscellaneous Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn MISC2_CONTROL0(&self) -> MISC2_CONTROL0 {
+        let val = (self.0 >> 5usize) & 0x01;
+        MISC2_CONTROL0::from_bits(val as u8)
+    }
+    #[doc = "Miscellaneous Control."]
+    #[inline(always)]
+    pub const fn set_MISC2_CONTROL0(&mut self, val: MISC2_CONTROL0) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val.to_bits() as u32) & 0x01) << 5usize);
+    }
+    #[doc = "PLL Multi-Phase Clock Outputs Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_EN_USB_CLKS(&self) -> PLL_EN_USB_CLKS {
+        let val = (self.0 >> 6usize) & 0x01;
+        PLL_EN_USB_CLKS::from_bits(val as u8)
+    }
+    #[doc = "PLL Multi-Phase Clock Outputs Enable."]
+    #[inline(always)]
+    pub const fn set_PLL_EN_USB_CLKS(&mut self, val: PLL_EN_USB_CLKS) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "USB PLL Powerup Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_POWER(&self) -> PLL_POWER {
+        let val = (self.0 >> 12usize) & 0x01;
+        PLL_POWER::from_bits(val as u8)
+    }
+    #[doc = "USB PLL Powerup Control."]
+    #[inline(always)]
+    pub const fn set_PLL_POWER(&mut self, val: PLL_POWER) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val.to_bits() as u32) & 0x01) << 12usize);
+    }
+    #[doc = "PLL Output Clock Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_ENABLE(&self) -> PLL_ENABLE {
+        let val = (self.0 >> 13usize) & 0x01;
+        PLL_ENABLE::from_bits(val as u8)
+    }
+    #[doc = "PLL Output Clock Enable."]
+    #[inline(always)]
+    pub const fn set_PLL_ENABLE(&mut self, val: PLL_ENABLE) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val.to_bits() as u32) & 0x01) << 13usize);
+    }
+    #[doc = "Bypass USB PLL."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_BYPASS(&self) -> PLL_BYPASS {
+        let val = (self.0 >> 16usize) & 0x01;
+        PLL_BYPASS::from_bits(val as u8)
+    }
+    #[doc = "Bypass USB PLL."]
+    #[inline(always)]
+    pub const fn set_PLL_BYPASS(&mut self, val: PLL_BYPASS) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val.to_bits() as u32) & 0x01) << 16usize);
+    }
+    #[doc = "Reference Bias Power Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn REFBIAS_PWD_SEL(&self) -> REFBIAS_PWD_SEL {
+        let val = (self.0 >> 19usize) & 0x01;
+        REFBIAS_PWD_SEL::from_bits(val as u8)
+    }
+    #[doc = "Reference Bias Power Control."]
+    #[inline(always)]
+    pub const fn set_REFBIAS_PWD_SEL(&mut self, val: REFBIAS_PWD_SEL) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val.to_bits() as u32) & 0x01) << 19usize);
+    }
+    #[doc = "Power Down Reference Bias."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn REFBIAS_PWD(&self) -> REFBIAS_PWD {
+        let val = (self.0 >> 20usize) & 0x01;
+        REFBIAS_PWD::from_bits(val as u8)
+    }
+    #[doc = "Power Down Reference Bias."]
+    #[inline(always)]
+    pub const fn set_REFBIAS_PWD(&mut self, val: REFBIAS_PWD) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val.to_bits() as u32) & 0x01) << 20usize);
+    }
+    #[doc = "Enable PLL Regulator."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_REG_ENABLE(&self) -> PLL_REG_ENABLE {
+        let val = (self.0 >> 21usize) & 0x01;
+        PLL_REG_ENABLE::from_bits(val as u8)
+    }
+    #[doc = "Enable PLL Regulator."]
+    #[inline(always)]
+    pub const fn set_PLL_REG_ENABLE(&mut self, val: PLL_REG_ENABLE) {
+        self.0 = (self.0 & !(0x01 << 21usize)) | (((val.to_bits() as u32) & 0x01) << 21usize);
+    }
+    #[doc = "PLL Divider Value Configuration."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_DIV_SEL(&self) -> PLL_DIV_SEL {
+        let val = (self.0 >> 22usize) & 0x07;
+        PLL_DIV_SEL::from_bits(val as u8)
+    }
+    #[doc = "PLL Divider Value Configuration."]
+    #[inline(always)]
+    pub const fn set_PLL_DIV_SEL(&mut self, val: PLL_DIV_SEL) {
+        self.0 = (self.0 & !(0x07 << 22usize)) | (((val.to_bits() as u32) & 0x07) << 22usize);
+    }
+    #[doc = "PLL Pre-Divider."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_PREDIV(&self) -> PLL_PREDIV {
+        let val = (self.0 >> 30usize) & 0x01;
+        PLL_PREDIV::from_bits(val as u8)
+    }
+    #[doc = "PLL Pre-Divider."]
+    #[inline(always)]
+    pub const fn set_PLL_PREDIV(&mut self, val: PLL_PREDIV) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val.to_bits() as u32) & 0x01) << 30usize);
+    }
+    #[doc = "USB PLL Lock Status Indicator."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_LOCK(&self) -> PLL_LOCK {
+        let val = (self.0 >> 31usize) & 0x01;
+        PLL_LOCK::from_bits(val as u8)
+    }
+    #[doc = "USB PLL Lock Status Indicator."]
+    #[inline(always)]
+    pub const fn set_PLL_LOCK(&mut self, val: PLL_LOCK) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val.to_bits() as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for PLL_SIC {
+    #[inline(always)]
+    fn default() -> PLL_SIC {
+        PLL_SIC(0)
+    }
+}
+impl core::fmt::Debug for PLL_SIC {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PLL_SIC")
+            .field("MISC2_CONTROL0", &self.MISC2_CONTROL0())
+            .field("PLL_EN_USB_CLKS", &self.PLL_EN_USB_CLKS())
+            .field("PLL_POWER", &self.PLL_POWER())
+            .field("PLL_ENABLE", &self.PLL_ENABLE())
+            .field("PLL_BYPASS", &self.PLL_BYPASS())
+            .field("REFBIAS_PWD_SEL", &self.REFBIAS_PWD_SEL())
+            .field("REFBIAS_PWD", &self.REFBIAS_PWD())
+            .field("PLL_REG_ENABLE", &self.PLL_REG_ENABLE())
+            .field("PLL_DIV_SEL", &self.PLL_DIV_SEL())
+            .field("PLL_PREDIV", &self.PLL_PREDIV())
+            .field("PLL_LOCK", &self.PLL_LOCK())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PLL_SIC {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PLL_SIC {{ MISC2_CONTROL0: {:?}, PLL_EN_USB_CLKS: {:?}, PLL_POWER: {:?}, PLL_ENABLE: {:?}, PLL_BYPASS: {:?}, REFBIAS_PWD_SEL: {:?}, REFBIAS_PWD: {:?}, PLL_REG_ENABLE: {:?}, PLL_DIV_SEL: {:?}, PLL_PREDIV: {:?}, PLL_LOCK: {:?} }}",
+            self.MISC2_CONTROL0(),
+            self.PLL_EN_USB_CLKS(),
+            self.PLL_POWER(),
+            self.PLL_ENABLE(),
+            self.PLL_BYPASS(),
+            self.REFBIAS_PWD_SEL(),
+            self.REFBIAS_PWD(),
+            self.PLL_REG_ENABLE(),
+            self.PLL_DIV_SEL(),
+            self.PLL_PREDIV(),
+            self.PLL_LOCK()
+        )
+    }
+}
+#[doc = "PLL SIC."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PLL_SIC_CLR(pub u32);
+impl PLL_SIC_CLR {
+    #[doc = "Miscellaneous Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn MISC2_CONTROL0(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Miscellaneous Control."]
+    #[inline(always)]
+    pub const fn set_MISC2_CONTROL0(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+    #[doc = "PLL Multi-Phase Clock Outputs Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_EN_USB_CLKS(&self) -> bool {
+        let val = (self.0 >> 6usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PLL Multi-Phase Clock Outputs Enable."]
+    #[inline(always)]
+    pub const fn set_PLL_EN_USB_CLKS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val as u32) & 0x01) << 6usize);
+    }
+    #[doc = "USB PLL Powerup Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_POWER(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "USB PLL Powerup Control."]
+    #[inline(always)]
+    pub const fn set_PLL_POWER(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "PLL Output Clock Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_ENABLE(&self) -> bool {
+        let val = (self.0 >> 13usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PLL Output Clock Enable."]
+    #[inline(always)]
+    pub const fn set_PLL_ENABLE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val as u32) & 0x01) << 13usize);
+    }
+    #[doc = "Bypass USB PLL."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_BYPASS(&self) -> bool {
+        let val = (self.0 >> 16usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Bypass USB PLL."]
+    #[inline(always)]
+    pub const fn set_PLL_BYPASS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val as u32) & 0x01) << 16usize);
+    }
+    #[doc = "Reference Bias Power Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn REFBIAS_PWD_SEL(&self) -> bool {
+        let val = (self.0 >> 19usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Reference Bias Power Control."]
+    #[inline(always)]
+    pub const fn set_REFBIAS_PWD_SEL(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val as u32) & 0x01) << 19usize);
+    }
+    #[doc = "Power Down Reference Bias."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn REFBIAS_PWD(&self) -> bool {
+        let val = (self.0 >> 20usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down Reference Bias."]
+    #[inline(always)]
+    pub const fn set_REFBIAS_PWD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val as u32) & 0x01) << 20usize);
+    }
+    #[doc = "Enable PLL Regulator."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_REG_ENABLE(&self) -> bool {
+        let val = (self.0 >> 21usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable PLL Regulator."]
+    #[inline(always)]
+    pub const fn set_PLL_REG_ENABLE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 21usize)) | (((val as u32) & 0x01) << 21usize);
+    }
+    #[doc = "PLL Divider Value Configuration."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_DIV_SEL(&self) -> u8 {
+        let val = (self.0 >> 22usize) & 0x07;
+        val as u8
+    }
+    #[doc = "PLL Divider Value Configuration."]
+    #[inline(always)]
+    pub const fn set_PLL_DIV_SEL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 22usize)) | (((val as u32) & 0x07) << 22usize);
+    }
+    #[doc = "PLL Pre-Divider."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_PREDIV(&self) -> bool {
+        let val = (self.0 >> 30usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PLL Pre-Divider."]
+    #[inline(always)]
+    pub const fn set_PLL_PREDIV(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val as u32) & 0x01) << 30usize);
+    }
+    #[doc = "USB PLL Lock Status Indicator."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_LOCK(&self) -> bool {
+        let val = (self.0 >> 31usize) & 0x01;
+        val != 0
+    }
+    #[doc = "USB PLL Lock Status Indicator."]
+    #[inline(always)]
+    pub const fn set_PLL_LOCK(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for PLL_SIC_CLR {
+    #[inline(always)]
+    fn default() -> PLL_SIC_CLR {
+        PLL_SIC_CLR(0)
+    }
+}
+impl core::fmt::Debug for PLL_SIC_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PLL_SIC_CLR")
+            .field("MISC2_CONTROL0", &self.MISC2_CONTROL0())
+            .field("PLL_EN_USB_CLKS", &self.PLL_EN_USB_CLKS())
+            .field("PLL_POWER", &self.PLL_POWER())
+            .field("PLL_ENABLE", &self.PLL_ENABLE())
+            .field("PLL_BYPASS", &self.PLL_BYPASS())
+            .field("REFBIAS_PWD_SEL", &self.REFBIAS_PWD_SEL())
+            .field("REFBIAS_PWD", &self.REFBIAS_PWD())
+            .field("PLL_REG_ENABLE", &self.PLL_REG_ENABLE())
+            .field("PLL_DIV_SEL", &self.PLL_DIV_SEL())
+            .field("PLL_PREDIV", &self.PLL_PREDIV())
+            .field("PLL_LOCK", &self.PLL_LOCK())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PLL_SIC_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PLL_SIC_CLR {{ MISC2_CONTROL0: {=bool:?}, PLL_EN_USB_CLKS: {=bool:?}, PLL_POWER: {=bool:?}, PLL_ENABLE: {=bool:?}, PLL_BYPASS: {=bool:?}, REFBIAS_PWD_SEL: {=bool:?}, REFBIAS_PWD: {=bool:?}, PLL_REG_ENABLE: {=bool:?}, PLL_DIV_SEL: {=u8:?}, PLL_PREDIV: {=bool:?}, PLL_LOCK: {=bool:?} }}",
+            self.MISC2_CONTROL0(),
+            self.PLL_EN_USB_CLKS(),
+            self.PLL_POWER(),
+            self.PLL_ENABLE(),
+            self.PLL_BYPASS(),
+            self.REFBIAS_PWD_SEL(),
+            self.REFBIAS_PWD(),
+            self.PLL_REG_ENABLE(),
+            self.PLL_DIV_SEL(),
+            self.PLL_PREDIV(),
+            self.PLL_LOCK()
+        )
+    }
+}
+#[doc = "PLL SIC."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PLL_SIC_SET(pub u32);
+impl PLL_SIC_SET {
+    #[doc = "Miscellaneous Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn MISC2_CONTROL0(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Miscellaneous Control."]
+    #[inline(always)]
+    pub const fn set_MISC2_CONTROL0(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+    #[doc = "PLL Multi-Phase Clock Outputs Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_EN_USB_CLKS(&self) -> bool {
+        let val = (self.0 >> 6usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PLL Multi-Phase Clock Outputs Enable."]
+    #[inline(always)]
+    pub const fn set_PLL_EN_USB_CLKS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val as u32) & 0x01) << 6usize);
+    }
+    #[doc = "USB PLL Powerup Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_POWER(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "USB PLL Powerup Control."]
+    #[inline(always)]
+    pub const fn set_PLL_POWER(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "PLL Output Clock Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_ENABLE(&self) -> bool {
+        let val = (self.0 >> 13usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PLL Output Clock Enable."]
+    #[inline(always)]
+    pub const fn set_PLL_ENABLE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val as u32) & 0x01) << 13usize);
+    }
+    #[doc = "Bypass USB PLL."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_BYPASS(&self) -> bool {
+        let val = (self.0 >> 16usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Bypass USB PLL."]
+    #[inline(always)]
+    pub const fn set_PLL_BYPASS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val as u32) & 0x01) << 16usize);
+    }
+    #[doc = "Reference Bias Power Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn REFBIAS_PWD_SEL(&self) -> bool {
+        let val = (self.0 >> 19usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Reference Bias Power Control."]
+    #[inline(always)]
+    pub const fn set_REFBIAS_PWD_SEL(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val as u32) & 0x01) << 19usize);
+    }
+    #[doc = "Power Down Reference Bias."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn REFBIAS_PWD(&self) -> bool {
+        let val = (self.0 >> 20usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down Reference Bias."]
+    #[inline(always)]
+    pub const fn set_REFBIAS_PWD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val as u32) & 0x01) << 20usize);
+    }
+    #[doc = "Enable PLL Regulator."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_REG_ENABLE(&self) -> bool {
+        let val = (self.0 >> 21usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable PLL Regulator."]
+    #[inline(always)]
+    pub const fn set_PLL_REG_ENABLE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 21usize)) | (((val as u32) & 0x01) << 21usize);
+    }
+    #[doc = "PLL Divider Value Configuration."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_DIV_SEL(&self) -> u8 {
+        let val = (self.0 >> 22usize) & 0x07;
+        val as u8
+    }
+    #[doc = "PLL Divider Value Configuration."]
+    #[inline(always)]
+    pub const fn set_PLL_DIV_SEL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 22usize)) | (((val as u32) & 0x07) << 22usize);
+    }
+    #[doc = "PLL Pre-Divider."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_PREDIV(&self) -> bool {
+        let val = (self.0 >> 30usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PLL Pre-Divider."]
+    #[inline(always)]
+    pub const fn set_PLL_PREDIV(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val as u32) & 0x01) << 30usize);
+    }
+    #[doc = "USB PLL Lock Status Indicator."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_LOCK(&self) -> bool {
+        let val = (self.0 >> 31usize) & 0x01;
+        val != 0
+    }
+    #[doc = "USB PLL Lock Status Indicator."]
+    #[inline(always)]
+    pub const fn set_PLL_LOCK(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for PLL_SIC_SET {
+    #[inline(always)]
+    fn default() -> PLL_SIC_SET {
+        PLL_SIC_SET(0)
+    }
+}
+impl core::fmt::Debug for PLL_SIC_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PLL_SIC_SET")
+            .field("MISC2_CONTROL0", &self.MISC2_CONTROL0())
+            .field("PLL_EN_USB_CLKS", &self.PLL_EN_USB_CLKS())
+            .field("PLL_POWER", &self.PLL_POWER())
+            .field("PLL_ENABLE", &self.PLL_ENABLE())
+            .field("PLL_BYPASS", &self.PLL_BYPASS())
+            .field("REFBIAS_PWD_SEL", &self.REFBIAS_PWD_SEL())
+            .field("REFBIAS_PWD", &self.REFBIAS_PWD())
+            .field("PLL_REG_ENABLE", &self.PLL_REG_ENABLE())
+            .field("PLL_DIV_SEL", &self.PLL_DIV_SEL())
+            .field("PLL_PREDIV", &self.PLL_PREDIV())
+            .field("PLL_LOCK", &self.PLL_LOCK())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PLL_SIC_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PLL_SIC_SET {{ MISC2_CONTROL0: {=bool:?}, PLL_EN_USB_CLKS: {=bool:?}, PLL_POWER: {=bool:?}, PLL_ENABLE: {=bool:?}, PLL_BYPASS: {=bool:?}, REFBIAS_PWD_SEL: {=bool:?}, REFBIAS_PWD: {=bool:?}, PLL_REG_ENABLE: {=bool:?}, PLL_DIV_SEL: {=u8:?}, PLL_PREDIV: {=bool:?}, PLL_LOCK: {=bool:?} }}",
+            self.MISC2_CONTROL0(),
+            self.PLL_EN_USB_CLKS(),
+            self.PLL_POWER(),
+            self.PLL_ENABLE(),
+            self.PLL_BYPASS(),
+            self.REFBIAS_PWD_SEL(),
+            self.REFBIAS_PWD(),
+            self.PLL_REG_ENABLE(),
+            self.PLL_DIV_SEL(),
+            self.PLL_PREDIV(),
+            self.PLL_LOCK()
+        )
+    }
+}
+#[doc = "PLL SIC."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PLL_SIC_TOG(pub u32);
+impl PLL_SIC_TOG {
+    #[doc = "Miscellaneous Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn MISC2_CONTROL0(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Miscellaneous Control."]
+    #[inline(always)]
+    pub const fn set_MISC2_CONTROL0(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+    #[doc = "PLL Multi-Phase Clock Outputs Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_EN_USB_CLKS(&self) -> bool {
+        let val = (self.0 >> 6usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PLL Multi-Phase Clock Outputs Enable."]
+    #[inline(always)]
+    pub const fn set_PLL_EN_USB_CLKS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val as u32) & 0x01) << 6usize);
+    }
+    #[doc = "USB PLL Powerup Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_POWER(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "USB PLL Powerup Control."]
+    #[inline(always)]
+    pub const fn set_PLL_POWER(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "PLL Output Clock Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_ENABLE(&self) -> bool {
+        let val = (self.0 >> 13usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PLL Output Clock Enable."]
+    #[inline(always)]
+    pub const fn set_PLL_ENABLE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val as u32) & 0x01) << 13usize);
+    }
+    #[doc = "Bypass USB PLL."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_BYPASS(&self) -> bool {
+        let val = (self.0 >> 16usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Bypass USB PLL."]
+    #[inline(always)]
+    pub const fn set_PLL_BYPASS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 16usize)) | (((val as u32) & 0x01) << 16usize);
+    }
+    #[doc = "Reference Bias Power Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn REFBIAS_PWD_SEL(&self) -> bool {
+        let val = (self.0 >> 19usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Reference Bias Power Control."]
+    #[inline(always)]
+    pub const fn set_REFBIAS_PWD_SEL(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val as u32) & 0x01) << 19usize);
+    }
+    #[doc = "Power Down Reference Bias."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn REFBIAS_PWD(&self) -> bool {
+        let val = (self.0 >> 20usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down Reference Bias."]
+    #[inline(always)]
+    pub const fn set_REFBIAS_PWD(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val as u32) & 0x01) << 20usize);
+    }
+    #[doc = "Enable PLL Regulator."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_REG_ENABLE(&self) -> bool {
+        let val = (self.0 >> 21usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable PLL Regulator."]
+    #[inline(always)]
+    pub const fn set_PLL_REG_ENABLE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 21usize)) | (((val as u32) & 0x01) << 21usize);
+    }
+    #[doc = "PLL Divider Value Configuration."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_DIV_SEL(&self) -> u8 {
+        let val = (self.0 >> 22usize) & 0x07;
+        val as u8
+    }
+    #[doc = "PLL Divider Value Configuration."]
+    #[inline(always)]
+    pub const fn set_PLL_DIV_SEL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 22usize)) | (((val as u32) & 0x07) << 22usize);
+    }
+    #[doc = "PLL Pre-Divider."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_PREDIV(&self) -> bool {
+        let val = (self.0 >> 30usize) & 0x01;
+        val != 0
+    }
+    #[doc = "PLL Pre-Divider."]
+    #[inline(always)]
+    pub const fn set_PLL_PREDIV(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 30usize)) | (((val as u32) & 0x01) << 30usize);
+    }
+    #[doc = "USB PLL Lock Status Indicator."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_LOCK(&self) -> bool {
+        let val = (self.0 >> 31usize) & 0x01;
+        val != 0
+    }
+    #[doc = "USB PLL Lock Status Indicator."]
+    #[inline(always)]
+    pub const fn set_PLL_LOCK(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for PLL_SIC_TOG {
+    #[inline(always)]
+    fn default() -> PLL_SIC_TOG {
+        PLL_SIC_TOG(0)
+    }
+}
+impl core::fmt::Debug for PLL_SIC_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PLL_SIC_TOG")
+            .field("MISC2_CONTROL0", &self.MISC2_CONTROL0())
+            .field("PLL_EN_USB_CLKS", &self.PLL_EN_USB_CLKS())
+            .field("PLL_POWER", &self.PLL_POWER())
+            .field("PLL_ENABLE", &self.PLL_ENABLE())
+            .field("PLL_BYPASS", &self.PLL_BYPASS())
+            .field("REFBIAS_PWD_SEL", &self.REFBIAS_PWD_SEL())
+            .field("REFBIAS_PWD", &self.REFBIAS_PWD())
+            .field("PLL_REG_ENABLE", &self.PLL_REG_ENABLE())
+            .field("PLL_DIV_SEL", &self.PLL_DIV_SEL())
+            .field("PLL_PREDIV", &self.PLL_PREDIV())
+            .field("PLL_LOCK", &self.PLL_LOCK())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PLL_SIC_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PLL_SIC_TOG {{ MISC2_CONTROL0: {=bool:?}, PLL_EN_USB_CLKS: {=bool:?}, PLL_POWER: {=bool:?}, PLL_ENABLE: {=bool:?}, PLL_BYPASS: {=bool:?}, REFBIAS_PWD_SEL: {=bool:?}, REFBIAS_PWD: {=bool:?}, PLL_REG_ENABLE: {=bool:?}, PLL_DIV_SEL: {=u8:?}, PLL_PREDIV: {=bool:?}, PLL_LOCK: {=bool:?} }}",
+            self.MISC2_CONTROL0(),
+            self.PLL_EN_USB_CLKS(),
+            self.PLL_POWER(),
+            self.PLL_ENABLE(),
+            self.PLL_BYPASS(),
+            self.REFBIAS_PWD_SEL(),
+            self.REFBIAS_PWD(),
+            self.PLL_REG_ENABLE(),
+            self.PLL_DIV_SEL(),
+            self.PLL_PREDIV(),
+            self.PLL_LOCK()
+        )
+    }
+}
+#[doc = "Power Down."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PWD(pub u32);
+impl PWD {
+    #[doc = "Power Down USB FS TX Drivers."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXPWDFS(&self) -> TXPWDFS {
+        let val = (self.0 >> 10usize) & 0x01;
+        TXPWDFS::from_bits(val as u8)
+    }
+    #[doc = "Power Down USB FS TX Drivers."]
+    #[inline(always)]
+    pub const fn set_TXPWDFS(&mut self, val: TXPWDFS) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val.to_bits() as u32) & 0x01) << 10usize);
+    }
+    #[doc = "Power Down USBPHY TX Current Bias Block."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXPWDIBIAS(&self) -> TXPWDIBIAS {
+        let val = (self.0 >> 11usize) & 0x01;
+        TXPWDIBIAS::from_bits(val as u8)
+    }
+    #[doc = "Power Down USBPHY TX Current Bias Block."]
+    #[inline(always)]
+    pub const fn set_TXPWDIBIAS(&mut self, val: TXPWDIBIAS) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val.to_bits() as u32) & 0x01) << 11usize);
+    }
+    #[doc = "Power Down USBPHY TX V-I Converter and Current Mirror."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXPWDV2I(&self) -> TXPWDV2I {
+        let val = (self.0 >> 12usize) & 0x01;
+        TXPWDV2I::from_bits(val as u8)
+    }
+    #[doc = "Power Down USBPHY TX V-I Converter and Current Mirror."]
+    #[inline(always)]
+    pub const fn set_TXPWDV2I(&mut self, val: TXPWDV2I) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val.to_bits() as u32) & 0x01) << 12usize);
+    }
+    #[doc = "Power Down USB HS RX Envelope Detector."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWDENV(&self) -> RXPWDENV {
+        let val = (self.0 >> 17usize) & 0x01;
+        RXPWDENV::from_bits(val as u8)
+    }
+    #[doc = "Power Down USB HS RX Envelope Detector."]
+    #[inline(always)]
+    pub const fn set_RXPWDENV(&mut self, val: RXPWDENV) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val.to_bits() as u32) & 0x01) << 17usize);
+    }
+    #[doc = "Power Down USB FS Differential Receiver."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWD1PT1(&self) -> RXPWD1PT1 {
+        let val = (self.0 >> 18usize) & 0x01;
+        RXPWD1PT1::from_bits(val as u8)
+    }
+    #[doc = "Power Down USB FS Differential Receiver."]
+    #[inline(always)]
+    pub const fn set_RXPWD1PT1(&mut self, val: RXPWD1PT1) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val.to_bits() as u32) & 0x01) << 18usize);
+    }
+    #[doc = "Power Down USB HS Differential Receiver."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWDDIFF(&self) -> RXPWDDIFF {
+        let val = (self.0 >> 19usize) & 0x01;
+        RXPWDDIFF::from_bits(val as u8)
+    }
+    #[doc = "Power Down USB HS Differential Receiver."]
+    #[inline(always)]
+    pub const fn set_RXPWDDIFF(&mut self, val: RXPWDDIFF) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val.to_bits() as u32) & 0x01) << 19usize);
+    }
+    #[doc = "Power Down USBPHY Receiver Circuits."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWDRX(&self) -> RXPWDRX {
+        let val = (self.0 >> 20usize) & 0x01;
+        RXPWDRX::from_bits(val as u8)
+    }
+    #[doc = "Power Down USBPHY Receiver Circuits."]
+    #[inline(always)]
+    pub const fn set_RXPWDRX(&mut self, val: RXPWDRX) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val.to_bits() as u32) & 0x01) << 20usize);
+    }
+}
+impl Default for PWD {
+    #[inline(always)]
+    fn default() -> PWD {
+        PWD(0)
+    }
+}
+impl core::fmt::Debug for PWD {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PWD")
+            .field("TXPWDFS", &self.TXPWDFS())
+            .field("TXPWDIBIAS", &self.TXPWDIBIAS())
+            .field("TXPWDV2I", &self.TXPWDV2I())
+            .field("RXPWDENV", &self.RXPWDENV())
+            .field("RXPWD1PT1", &self.RXPWD1PT1())
+            .field("RXPWDDIFF", &self.RXPWDDIFF())
+            .field("RXPWDRX", &self.RXPWDRX())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PWD {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PWD {{ TXPWDFS: {:?}, TXPWDIBIAS: {:?}, TXPWDV2I: {:?}, RXPWDENV: {:?}, RXPWD1PT1: {:?}, RXPWDDIFF: {:?}, RXPWDRX: {:?} }}",
+            self.TXPWDFS(),
+            self.TXPWDIBIAS(),
+            self.TXPWDV2I(),
+            self.RXPWDENV(),
+            self.RXPWD1PT1(),
+            self.RXPWDDIFF(),
+            self.RXPWDRX()
+        )
+    }
+}
+#[doc = "Power Down."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PWD_CLR(pub u32);
+impl PWD_CLR {
+    #[doc = "Power Down USB FS TX Drivers."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXPWDFS(&self) -> bool {
+        let val = (self.0 >> 10usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USB FS TX Drivers."]
+    #[inline(always)]
+    pub const fn set_TXPWDFS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val as u32) & 0x01) << 10usize);
+    }
+    #[doc = "Power Down USBPHY TX Current Bias Block."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXPWDIBIAS(&self) -> bool {
+        let val = (self.0 >> 11usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USBPHY TX Current Bias Block."]
+    #[inline(always)]
+    pub const fn set_TXPWDIBIAS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val as u32) & 0x01) << 11usize);
+    }
+    #[doc = "Power Down USBPHY TX V-I Converter and Current Mirror."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXPWDV2I(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USBPHY TX V-I Converter and Current Mirror."]
+    #[inline(always)]
+    pub const fn set_TXPWDV2I(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "Power Down USB HS RX Envelope Detector."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWDENV(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USB HS RX Envelope Detector."]
+    #[inline(always)]
+    pub const fn set_RXPWDENV(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "Power Down USB FS Differential Receiver."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWD1PT1(&self) -> bool {
+        let val = (self.0 >> 18usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USB FS Differential Receiver."]
+    #[inline(always)]
+    pub const fn set_RXPWD1PT1(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    }
+    #[doc = "Power Down USB HS Differential Receiver."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWDDIFF(&self) -> bool {
+        let val = (self.0 >> 19usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USB HS Differential Receiver."]
+    #[inline(always)]
+    pub const fn set_RXPWDDIFF(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val as u32) & 0x01) << 19usize);
+    }
+    #[doc = "Power Down USBPHY Receiver Circuits."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWDRX(&self) -> bool {
+        let val = (self.0 >> 20usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USBPHY Receiver Circuits."]
+    #[inline(always)]
+    pub const fn set_RXPWDRX(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val as u32) & 0x01) << 20usize);
+    }
+}
+impl Default for PWD_CLR {
+    #[inline(always)]
+    fn default() -> PWD_CLR {
+        PWD_CLR(0)
+    }
+}
+impl core::fmt::Debug for PWD_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PWD_CLR")
+            .field("TXPWDFS", &self.TXPWDFS())
+            .field("TXPWDIBIAS", &self.TXPWDIBIAS())
+            .field("TXPWDV2I", &self.TXPWDV2I())
+            .field("RXPWDENV", &self.RXPWDENV())
+            .field("RXPWD1PT1", &self.RXPWD1PT1())
+            .field("RXPWDDIFF", &self.RXPWDDIFF())
+            .field("RXPWDRX", &self.RXPWDRX())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PWD_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PWD_CLR {{ TXPWDFS: {=bool:?}, TXPWDIBIAS: {=bool:?}, TXPWDV2I: {=bool:?}, RXPWDENV: {=bool:?}, RXPWD1PT1: {=bool:?}, RXPWDDIFF: {=bool:?}, RXPWDRX: {=bool:?} }}",
+            self.TXPWDFS(),
+            self.TXPWDIBIAS(),
+            self.TXPWDV2I(),
+            self.RXPWDENV(),
+            self.RXPWD1PT1(),
+            self.RXPWDDIFF(),
+            self.RXPWDRX()
+        )
+    }
+}
+#[doc = "Power Down."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PWD_SET(pub u32);
+impl PWD_SET {
+    #[doc = "Power Down USB FS TX Drivers."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXPWDFS(&self) -> bool {
+        let val = (self.0 >> 10usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USB FS TX Drivers."]
+    #[inline(always)]
+    pub const fn set_TXPWDFS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val as u32) & 0x01) << 10usize);
+    }
+    #[doc = "Power Down USBPHY TX Current Bias Block."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXPWDIBIAS(&self) -> bool {
+        let val = (self.0 >> 11usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USBPHY TX Current Bias Block."]
+    #[inline(always)]
+    pub const fn set_TXPWDIBIAS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val as u32) & 0x01) << 11usize);
+    }
+    #[doc = "Power Down USBPHY TX V-I Converter and Current Mirror."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXPWDV2I(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USBPHY TX V-I Converter and Current Mirror."]
+    #[inline(always)]
+    pub const fn set_TXPWDV2I(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "Power Down USB HS RX Envelope Detector."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWDENV(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USB HS RX Envelope Detector."]
+    #[inline(always)]
+    pub const fn set_RXPWDENV(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "Power Down USB FS Differential Receiver."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWD1PT1(&self) -> bool {
+        let val = (self.0 >> 18usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USB FS Differential Receiver."]
+    #[inline(always)]
+    pub const fn set_RXPWD1PT1(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    }
+    #[doc = "Power Down USB HS Differential Receiver."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWDDIFF(&self) -> bool {
+        let val = (self.0 >> 19usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USB HS Differential Receiver."]
+    #[inline(always)]
+    pub const fn set_RXPWDDIFF(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val as u32) & 0x01) << 19usize);
+    }
+    #[doc = "Power Down USBPHY Receiver Circuits."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWDRX(&self) -> bool {
+        let val = (self.0 >> 20usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USBPHY Receiver Circuits."]
+    #[inline(always)]
+    pub const fn set_RXPWDRX(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val as u32) & 0x01) << 20usize);
+    }
+}
+impl Default for PWD_SET {
+    #[inline(always)]
+    fn default() -> PWD_SET {
+        PWD_SET(0)
+    }
+}
+impl core::fmt::Debug for PWD_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PWD_SET")
+            .field("TXPWDFS", &self.TXPWDFS())
+            .field("TXPWDIBIAS", &self.TXPWDIBIAS())
+            .field("TXPWDV2I", &self.TXPWDV2I())
+            .field("RXPWDENV", &self.RXPWDENV())
+            .field("RXPWD1PT1", &self.RXPWD1PT1())
+            .field("RXPWDDIFF", &self.RXPWDDIFF())
+            .field("RXPWDRX", &self.RXPWDRX())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PWD_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PWD_SET {{ TXPWDFS: {=bool:?}, TXPWDIBIAS: {=bool:?}, TXPWDV2I: {=bool:?}, RXPWDENV: {=bool:?}, RXPWD1PT1: {=bool:?}, RXPWDDIFF: {=bool:?}, RXPWDRX: {=bool:?} }}",
+            self.TXPWDFS(),
+            self.TXPWDIBIAS(),
+            self.TXPWDV2I(),
+            self.RXPWDENV(),
+            self.RXPWD1PT1(),
+            self.RXPWDDIFF(),
+            self.RXPWDRX()
+        )
+    }
+}
+#[doc = "Power Down."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PWD_TOG(pub u32);
+impl PWD_TOG {
+    #[doc = "Power Down USB FS TX Drivers."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXPWDFS(&self) -> bool {
+        let val = (self.0 >> 10usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USB FS TX Drivers."]
+    #[inline(always)]
+    pub const fn set_TXPWDFS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val as u32) & 0x01) << 10usize);
+    }
+    #[doc = "Power Down USBPHY TX Current Bias Block."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXPWDIBIAS(&self) -> bool {
+        let val = (self.0 >> 11usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USBPHY TX Current Bias Block."]
+    #[inline(always)]
+    pub const fn set_TXPWDIBIAS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val as u32) & 0x01) << 11usize);
+    }
+    #[doc = "Power Down USBPHY TX V-I Converter and Current Mirror."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXPWDV2I(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USBPHY TX V-I Converter and Current Mirror."]
+    #[inline(always)]
+    pub const fn set_TXPWDV2I(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "Power Down USB HS RX Envelope Detector."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWDENV(&self) -> bool {
+        let val = (self.0 >> 17usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USB HS RX Envelope Detector."]
+    #[inline(always)]
+    pub const fn set_RXPWDENV(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 17usize)) | (((val as u32) & 0x01) << 17usize);
+    }
+    #[doc = "Power Down USB FS Differential Receiver."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWD1PT1(&self) -> bool {
+        let val = (self.0 >> 18usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USB FS Differential Receiver."]
+    #[inline(always)]
+    pub const fn set_RXPWD1PT1(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    }
+    #[doc = "Power Down USB HS Differential Receiver."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWDDIFF(&self) -> bool {
+        let val = (self.0 >> 19usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USB HS Differential Receiver."]
+    #[inline(always)]
+    pub const fn set_RXPWDDIFF(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val as u32) & 0x01) << 19usize);
+    }
+    #[doc = "Power Down USBPHY Receiver Circuits."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RXPWDRX(&self) -> bool {
+        let val = (self.0 >> 20usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Power Down USBPHY Receiver Circuits."]
+    #[inline(always)]
+    pub const fn set_RXPWDRX(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val as u32) & 0x01) << 20usize);
+    }
+}
+impl Default for PWD_TOG {
+    #[inline(always)]
+    fn default() -> PWD_TOG {
+        PWD_TOG(0)
+    }
+}
+impl core::fmt::Debug for PWD_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PWD_TOG")
+            .field("TXPWDFS", &self.TXPWDFS())
+            .field("TXPWDIBIAS", &self.TXPWDIBIAS())
+            .field("TXPWDV2I", &self.TXPWDV2I())
+            .field("RXPWDENV", &self.RXPWDENV())
+            .field("RXPWD1PT1", &self.RXPWD1PT1())
+            .field("RXPWDDIFF", &self.RXPWDDIFF())
+            .field("RXPWDRX", &self.RXPWDRX())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PWD_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "PWD_TOG {{ TXPWDFS: {=bool:?}, TXPWDIBIAS: {=bool:?}, TXPWDV2I: {=bool:?}, RXPWDENV: {=bool:?}, RXPWD1PT1: {=bool:?}, RXPWDDIFF: {=bool:?}, RXPWDRX: {=bool:?} }}",
+            self.TXPWDFS(),
+            self.TXPWDIBIAS(),
+            self.TXPWDV2I(),
+            self.RXPWDENV(),
+            self.RXPWD1PT1(),
+            self.RXPWDDIFF(),
+            self.RXPWDRX()
+        )
+    }
+}
+#[doc = "RX Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct RX(pub u32);
+impl RX {
+    #[doc = "Envelope Detector Trip Point."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENVADJ(&self) -> ENVADJ {
+        let val = (self.0 >> 0usize) & 0x07;
+        ENVADJ::from_bits(val as u8)
+    }
+    #[doc = "Envelope Detector Trip Point."]
+    #[inline(always)]
+    pub const fn set_ENVADJ(&mut self, val: ENVADJ) {
+        self.0 = (self.0 & !(0x07 << 0usize)) | (((val.to_bits() as u32) & 0x07) << 0usize);
+    }
+    #[doc = "Disconnect Detector Trip Point."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DISCONADJ(&self) -> DISCONADJ {
+        let val = (self.0 >> 4usize) & 0x07;
+        DISCONADJ::from_bits(val as u8)
+    }
+    #[doc = "Disconnect Detector Trip Point."]
+    #[inline(always)]
+    pub const fn set_DISCONADJ(&mut self, val: DISCONADJ) {
+        self.0 = (self.0 & !(0x07 << 4usize)) | (((val.to_bits() as u32) & 0x07) << 4usize);
+    }
+}
+impl Default for RX {
+    #[inline(always)]
+    fn default() -> RX {
+        RX(0)
+    }
+}
+impl core::fmt::Debug for RX {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RX")
+            .field("ENVADJ", &self.ENVADJ())
+            .field("DISCONADJ", &self.DISCONADJ())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RX {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "RX {{ ENVADJ: {:?}, DISCONADJ: {:?} }}",
+            self.ENVADJ(),
+            self.DISCONADJ()
+        )
+    }
+}
+#[doc = "RX Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct RX_CLR(pub u32);
+impl RX_CLR {
+    #[doc = "Envelope Detector Trip Point."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENVADJ(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0x07;
+        val as u8
+    }
+    #[doc = "Envelope Detector Trip Point."]
+    #[inline(always)]
+    pub const fn set_ENVADJ(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 0usize)) | (((val as u32) & 0x07) << 0usize);
+    }
+    #[doc = "Disconnect Detector Trip Point."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DISCONADJ(&self) -> u8 {
+        let val = (self.0 >> 4usize) & 0x07;
+        val as u8
+    }
+    #[doc = "Disconnect Detector Trip Point."]
+    #[inline(always)]
+    pub const fn set_DISCONADJ(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 4usize)) | (((val as u32) & 0x07) << 4usize);
+    }
+}
+impl Default for RX_CLR {
+    #[inline(always)]
+    fn default() -> RX_CLR {
+        RX_CLR(0)
+    }
+}
+impl core::fmt::Debug for RX_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RX_CLR")
+            .field("ENVADJ", &self.ENVADJ())
+            .field("DISCONADJ", &self.DISCONADJ())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RX_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "RX_CLR {{ ENVADJ: {=u8:?}, DISCONADJ: {=u8:?} }}",
+            self.ENVADJ(),
+            self.DISCONADJ()
+        )
+    }
+}
+#[doc = "RX Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct RX_SET(pub u32);
+impl RX_SET {
+    #[doc = "Envelope Detector Trip Point."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENVADJ(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0x07;
+        val as u8
+    }
+    #[doc = "Envelope Detector Trip Point."]
+    #[inline(always)]
+    pub const fn set_ENVADJ(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 0usize)) | (((val as u32) & 0x07) << 0usize);
+    }
+    #[doc = "Disconnect Detector Trip Point."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DISCONADJ(&self) -> u8 {
+        let val = (self.0 >> 4usize) & 0x07;
+        val as u8
+    }
+    #[doc = "Disconnect Detector Trip Point."]
+    #[inline(always)]
+    pub const fn set_DISCONADJ(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 4usize)) | (((val as u32) & 0x07) << 4usize);
+    }
+}
+impl Default for RX_SET {
+    #[inline(always)]
+    fn default() -> RX_SET {
+        RX_SET(0)
+    }
+}
+impl core::fmt::Debug for RX_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RX_SET")
+            .field("ENVADJ", &self.ENVADJ())
+            .field("DISCONADJ", &self.DISCONADJ())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RX_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "RX_SET {{ ENVADJ: {=u8:?}, DISCONADJ: {=u8:?} }}",
+            self.ENVADJ(),
+            self.DISCONADJ()
+        )
+    }
+}
+#[doc = "RX Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct RX_TOG(pub u32);
+impl RX_TOG {
+    #[doc = "Envelope Detector Trip Point."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ENVADJ(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0x07;
+        val as u8
+    }
+    #[doc = "Envelope Detector Trip Point."]
+    #[inline(always)]
+    pub const fn set_ENVADJ(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 0usize)) | (((val as u32) & 0x07) << 0usize);
+    }
+    #[doc = "Disconnect Detector Trip Point."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DISCONADJ(&self) -> u8 {
+        let val = (self.0 >> 4usize) & 0x07;
+        val as u8
+    }
+    #[doc = "Disconnect Detector Trip Point."]
+    #[inline(always)]
+    pub const fn set_DISCONADJ(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 4usize)) | (((val as u32) & 0x07) << 4usize);
+    }
+}
+impl Default for RX_TOG {
+    #[inline(always)]
+    fn default() -> RX_TOG {
+        RX_TOG(0)
+    }
+}
+impl core::fmt::Debug for RX_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RX_TOG")
+            .field("ENVADJ", &self.ENVADJ())
+            .field("DISCONADJ", &self.DISCONADJ())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RX_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "RX_TOG {{ ENVADJ: {=u8:?}, DISCONADJ: {=u8:?} }}",
+            self.ENVADJ(),
+            self.DISCONADJ()
+        )
+    }
+}
+#[doc = "Status."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct STATUS(pub u32);
+impl STATUS {
+    #[doc = "USB 3.3 V and 1.8 V Supply Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OK_STATUS_3V(&self) -> OK_STATUS_3V {
+        let val = (self.0 >> 0usize) & 0x01;
+        OK_STATUS_3V::from_bits(val as u8)
+    }
+    #[doc = "USB 3.3 V and 1.8 V Supply Status."]
+    #[inline(always)]
+    pub const fn set_OK_STATUS_3V(&mut self, val: OK_STATUS_3V) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Host Disconnect Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn HOSTDISCONDETECT_STATUS(&self) -> HOSTDISCONDETECT_STATUS {
+        let val = (self.0 >> 3usize) & 0x01;
+        HOSTDISCONDETECT_STATUS::from_bits(val as u8)
+    }
+    #[doc = "Host Disconnect Status."]
+    #[inline(always)]
+    pub const fn set_HOSTDISCONDETECT_STATUS(&mut self, val: HOSTDISCONDETECT_STATUS) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val.to_bits() as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Status Indicator for Nonstandard Resistive Plugged-In Detection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DEVPLUGIN_STATUS(&self) -> DEVPLUGIN_STATUS {
+        let val = (self.0 >> 6usize) & 0x01;
+        DEVPLUGIN_STATUS::from_bits(val as u8)
+    }
+    #[doc = "Status Indicator for Nonstandard Resistive Plugged-In Detection."]
+    #[inline(always)]
+    pub const fn set_DEVPLUGIN_STATUS(&mut self, val: DEVPLUGIN_STATUS) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val.to_bits() as u32) & 0x01) << 6usize);
+    }
+    #[doc = "OTG ID Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn OTGID_STATUS(&self) -> OTGID_STATUS {
+        let val = (self.0 >> 8usize) & 0x01;
+        OTGID_STATUS::from_bits(val as u8)
+    }
+    #[doc = "OTG ID Status."]
+    #[inline(always)]
+    pub const fn set_OTGID_STATUS(&mut self, val: OTGID_STATUS) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val.to_bits() as u32) & 0x01) << 8usize);
+    }
+    #[doc = "Resume Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn RESUME_STATUS(&self) -> bool {
+        let val = (self.0 >> 10usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Resume Status."]
+    #[inline(always)]
+    pub const fn set_RESUME_STATUS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val as u32) & 0x01) << 10usize);
+    }
+}
+impl Default for STATUS {
+    #[inline(always)]
+    fn default() -> STATUS {
+        STATUS(0)
+    }
+}
+impl core::fmt::Debug for STATUS {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("STATUS")
+            .field("OK_STATUS_3V", &self.OK_STATUS_3V())
+            .field("HOSTDISCONDETECT_STATUS", &self.HOSTDISCONDETECT_STATUS())
+            .field("DEVPLUGIN_STATUS", &self.DEVPLUGIN_STATUS())
+            .field("OTGID_STATUS", &self.OTGID_STATUS())
+            .field("RESUME_STATUS", &self.RESUME_STATUS())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for STATUS {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "STATUS {{ OK_STATUS_3V: {:?}, HOSTDISCONDETECT_STATUS: {:?}, DEVPLUGIN_STATUS: {:?}, OTGID_STATUS: {:?}, RESUME_STATUS: {=bool:?} }}",
+            self.OK_STATUS_3V(),
+            self.HOSTDISCONDETECT_STATUS(),
+            self.DEVPLUGIN_STATUS(),
+            self.OTGID_STATUS(),
+            self.RESUME_STATUS()
+        )
+    }
+}
+#[doc = "Trim."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct TRIM_OVERRIDE_EN(pub u32);
+impl TRIM_OVERRIDE_EN {
+    #[doc = "Override Enable for PLL Divider Value."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DIV_SEL_OVERRIDE(&self) -> DIV_SEL_OVERRIDE {
+        let val = (self.0 >> 0usize) & 0x01;
+        DIV_SEL_OVERRIDE::from_bits(val as u8)
+    }
+    #[doc = "Override Enable for PLL Divider Value."]
+    #[inline(always)]
+    pub const fn set_DIV_SEL_OVERRIDE(&mut self, val: DIV_SEL_OVERRIDE) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Override Enable for HS TX Output Current Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TX_D_CAL_OVERRIDE(&self) -> TX_D_CAL_OVERRIDE {
+        let val = (self.0 >> 2usize) & 0x01;
+        TX_D_CAL_OVERRIDE::from_bits(val as u8)
+    }
+    #[doc = "Override Enable for HS TX Output Current Trim."]
+    #[inline(always)]
+    pub const fn set_TX_D_CAL_OVERRIDE(&mut self, val: TX_D_CAL_OVERRIDE) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val.to_bits() as u32) & 0x01) << 2usize);
+    }
+    #[doc = "Override Enable for USB_DP Series Termination Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TX_CAL45DP_OVERRIDE(&self) -> TX_CAL45DP_OVERRIDE {
+        let val = (self.0 >> 3usize) & 0x01;
+        TX_CAL45DP_OVERRIDE::from_bits(val as u8)
+    }
+    #[doc = "Override Enable for USB_DP Series Termination Trim."]
+    #[inline(always)]
+    pub const fn set_TX_CAL45DP_OVERRIDE(&mut self, val: TX_CAL45DP_OVERRIDE) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val.to_bits() as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Override Enable for USB_DM Series Termination Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TX_CAL45DM_OVERRIDE(&self) -> TX_CAL45DM_OVERRIDE {
+        let val = (self.0 >> 4usize) & 0x01;
+        TX_CAL45DM_OVERRIDE::from_bits(val as u8)
+    }
+    #[doc = "Override Enable for USB_DM Series Termination Trim."]
+    #[inline(always)]
+    pub const fn set_TX_CAL45DM_OVERRIDE(&mut self, val: TX_CAL45DM_OVERRIDE) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u32) & 0x01) << 4usize);
+    }
+    #[doc = "PLL Divider Value Configuration Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_CTRL0_DIV_SEL(&self) -> u8 {
+        let val = (self.0 >> 15usize) & 0x07;
+        val as u8
+    }
+    #[doc = "PLL Divider Value Configuration Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_PLL_CTRL0_DIV_SEL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 15usize)) | (((val as u32) & 0x07) << 15usize);
+    }
+    #[doc = "HS TX Output Current Trim Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBPHY_TX_D_CAL(&self) -> USBPHY_TX_D_CAL {
+        let val = (self.0 >> 20usize) & 0x0f;
+        USBPHY_TX_D_CAL::from_bits(val as u8)
+    }
+    #[doc = "HS TX Output Current Trim Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_USBPHY_TX_D_CAL(&mut self, val: USBPHY_TX_D_CAL) {
+        self.0 = (self.0 & !(0x0f << 20usize)) | (((val.to_bits() as u32) & 0x0f) << 20usize);
+    }
+    #[doc = "DP Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBPHY_TX_CAL45DP(&self) -> u8 {
+        let val = (self.0 >> 24usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DP Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_USBPHY_TX_CAL45DP(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 24usize)) | (((val as u32) & 0x0f) << 24usize);
+    }
+    #[doc = "DM Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBPHY_TX_CAL45DN(&self) -> u8 {
+        let val = (self.0 >> 28usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DM Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_USBPHY_TX_CAL45DN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 28usize)) | (((val as u32) & 0x0f) << 28usize);
+    }
+}
+impl Default for TRIM_OVERRIDE_EN {
+    #[inline(always)]
+    fn default() -> TRIM_OVERRIDE_EN {
+        TRIM_OVERRIDE_EN(0)
+    }
+}
+impl core::fmt::Debug for TRIM_OVERRIDE_EN {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TRIM_OVERRIDE_EN")
+            .field("DIV_SEL_OVERRIDE", &self.DIV_SEL_OVERRIDE())
+            .field("TX_D_CAL_OVERRIDE", &self.TX_D_CAL_OVERRIDE())
+            .field("TX_CAL45DP_OVERRIDE", &self.TX_CAL45DP_OVERRIDE())
+            .field("TX_CAL45DM_OVERRIDE", &self.TX_CAL45DM_OVERRIDE())
+            .field("PLL_CTRL0_DIV_SEL", &self.PLL_CTRL0_DIV_SEL())
+            .field("USBPHY_TX_D_CAL", &self.USBPHY_TX_D_CAL())
+            .field("USBPHY_TX_CAL45DP", &self.USBPHY_TX_CAL45DP())
+            .field("USBPHY_TX_CAL45DN", &self.USBPHY_TX_CAL45DN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TRIM_OVERRIDE_EN {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "TRIM_OVERRIDE_EN {{ DIV_SEL_OVERRIDE: {:?}, TX_D_CAL_OVERRIDE: {:?}, TX_CAL45DP_OVERRIDE: {:?}, TX_CAL45DM_OVERRIDE: {:?}, PLL_CTRL0_DIV_SEL: {=u8:?}, USBPHY_TX_D_CAL: {:?}, USBPHY_TX_CAL45DP: {=u8:?}, USBPHY_TX_CAL45DN: {=u8:?} }}",
+            self.DIV_SEL_OVERRIDE(),
+            self.TX_D_CAL_OVERRIDE(),
+            self.TX_CAL45DP_OVERRIDE(),
+            self.TX_CAL45DM_OVERRIDE(),
+            self.PLL_CTRL0_DIV_SEL(),
+            self.USBPHY_TX_D_CAL(),
+            self.USBPHY_TX_CAL45DP(),
+            self.USBPHY_TX_CAL45DN()
+        )
+    }
+}
+#[doc = "Trim."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct TRIM_OVERRIDE_EN_CLR(pub u32);
+impl TRIM_OVERRIDE_EN_CLR {
+    #[doc = "Override Enable for PLL Divider Value."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DIV_SEL_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Enable for PLL Divider Value."]
+    #[inline(always)]
+    pub const fn set_DIV_SEL_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Override Enable for HS TX Output Current Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TX_D_CAL_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Enable for HS TX Output Current Trim."]
+    #[inline(always)]
+    pub const fn set_TX_D_CAL_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "Override Enable for USB_DP Series Termination Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TX_CAL45DP_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Enable for USB_DP Series Termination Trim."]
+    #[inline(always)]
+    pub const fn set_TX_CAL45DP_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Override Enable for USB_DM Series Termination Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TX_CAL45DM_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Enable for USB_DM Series Termination Trim."]
+    #[inline(always)]
+    pub const fn set_TX_CAL45DM_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "PLL Divider Value Configuration Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_CTRL0_DIV_SEL(&self) -> u8 {
+        let val = (self.0 >> 15usize) & 0x07;
+        val as u8
+    }
+    #[doc = "PLL Divider Value Configuration Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_PLL_CTRL0_DIV_SEL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 15usize)) | (((val as u32) & 0x07) << 15usize);
+    }
+    #[doc = "HS TX Output Current Trim Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBPHY_TX_D_CAL(&self) -> u8 {
+        let val = (self.0 >> 20usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "HS TX Output Current Trim Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_USBPHY_TX_D_CAL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 20usize)) | (((val as u32) & 0x0f) << 20usize);
+    }
+    #[doc = "DP Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBPHY_TX_CAL45DP(&self) -> u8 {
+        let val = (self.0 >> 24usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DP Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_USBPHY_TX_CAL45DP(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 24usize)) | (((val as u32) & 0x0f) << 24usize);
+    }
+    #[doc = "DM Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBPHY_TX_CAL45DN(&self) -> u8 {
+        let val = (self.0 >> 28usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DM Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_USBPHY_TX_CAL45DN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 28usize)) | (((val as u32) & 0x0f) << 28usize);
+    }
+}
+impl Default for TRIM_OVERRIDE_EN_CLR {
+    #[inline(always)]
+    fn default() -> TRIM_OVERRIDE_EN_CLR {
+        TRIM_OVERRIDE_EN_CLR(0)
+    }
+}
+impl core::fmt::Debug for TRIM_OVERRIDE_EN_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TRIM_OVERRIDE_EN_CLR")
+            .field("DIV_SEL_OVERRIDE", &self.DIV_SEL_OVERRIDE())
+            .field("TX_D_CAL_OVERRIDE", &self.TX_D_CAL_OVERRIDE())
+            .field("TX_CAL45DP_OVERRIDE", &self.TX_CAL45DP_OVERRIDE())
+            .field("TX_CAL45DM_OVERRIDE", &self.TX_CAL45DM_OVERRIDE())
+            .field("PLL_CTRL0_DIV_SEL", &self.PLL_CTRL0_DIV_SEL())
+            .field("USBPHY_TX_D_CAL", &self.USBPHY_TX_D_CAL())
+            .field("USBPHY_TX_CAL45DP", &self.USBPHY_TX_CAL45DP())
+            .field("USBPHY_TX_CAL45DN", &self.USBPHY_TX_CAL45DN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TRIM_OVERRIDE_EN_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "TRIM_OVERRIDE_EN_CLR {{ DIV_SEL_OVERRIDE: {=bool:?}, TX_D_CAL_OVERRIDE: {=bool:?}, TX_CAL45DP_OVERRIDE: {=bool:?}, TX_CAL45DM_OVERRIDE: {=bool:?}, PLL_CTRL0_DIV_SEL: {=u8:?}, USBPHY_TX_D_CAL: {=u8:?}, USBPHY_TX_CAL45DP: {=u8:?}, USBPHY_TX_CAL45DN: {=u8:?} }}",
+            self.DIV_SEL_OVERRIDE(),
+            self.TX_D_CAL_OVERRIDE(),
+            self.TX_CAL45DP_OVERRIDE(),
+            self.TX_CAL45DM_OVERRIDE(),
+            self.PLL_CTRL0_DIV_SEL(),
+            self.USBPHY_TX_D_CAL(),
+            self.USBPHY_TX_CAL45DP(),
+            self.USBPHY_TX_CAL45DN()
+        )
+    }
+}
+#[doc = "Trim."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct TRIM_OVERRIDE_EN_SET(pub u32);
+impl TRIM_OVERRIDE_EN_SET {
+    #[doc = "Override Enable for PLL Divider Value."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DIV_SEL_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Enable for PLL Divider Value."]
+    #[inline(always)]
+    pub const fn set_DIV_SEL_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Override Enable for HS TX Output Current Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TX_D_CAL_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Enable for HS TX Output Current Trim."]
+    #[inline(always)]
+    pub const fn set_TX_D_CAL_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "Override Enable for USB_DP Series Termination Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TX_CAL45DP_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Enable for USB_DP Series Termination Trim."]
+    #[inline(always)]
+    pub const fn set_TX_CAL45DP_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Override Enable for USB_DM Series Termination Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TX_CAL45DM_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Enable for USB_DM Series Termination Trim."]
+    #[inline(always)]
+    pub const fn set_TX_CAL45DM_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "PLL Divider Value Configuration Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_CTRL0_DIV_SEL(&self) -> u8 {
+        let val = (self.0 >> 15usize) & 0x07;
+        val as u8
+    }
+    #[doc = "PLL Divider Value Configuration Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_PLL_CTRL0_DIV_SEL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 15usize)) | (((val as u32) & 0x07) << 15usize);
+    }
+    #[doc = "HS TX Output Current Trim Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBPHY_TX_D_CAL(&self) -> u8 {
+        let val = (self.0 >> 20usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "HS TX Output Current Trim Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_USBPHY_TX_D_CAL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 20usize)) | (((val as u32) & 0x0f) << 20usize);
+    }
+    #[doc = "DP Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBPHY_TX_CAL45DP(&self) -> u8 {
+        let val = (self.0 >> 24usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DP Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_USBPHY_TX_CAL45DP(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 24usize)) | (((val as u32) & 0x0f) << 24usize);
+    }
+    #[doc = "DM Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBPHY_TX_CAL45DN(&self) -> u8 {
+        let val = (self.0 >> 28usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DM Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_USBPHY_TX_CAL45DN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 28usize)) | (((val as u32) & 0x0f) << 28usize);
+    }
+}
+impl Default for TRIM_OVERRIDE_EN_SET {
+    #[inline(always)]
+    fn default() -> TRIM_OVERRIDE_EN_SET {
+        TRIM_OVERRIDE_EN_SET(0)
+    }
+}
+impl core::fmt::Debug for TRIM_OVERRIDE_EN_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TRIM_OVERRIDE_EN_SET")
+            .field("DIV_SEL_OVERRIDE", &self.DIV_SEL_OVERRIDE())
+            .field("TX_D_CAL_OVERRIDE", &self.TX_D_CAL_OVERRIDE())
+            .field("TX_CAL45DP_OVERRIDE", &self.TX_CAL45DP_OVERRIDE())
+            .field("TX_CAL45DM_OVERRIDE", &self.TX_CAL45DM_OVERRIDE())
+            .field("PLL_CTRL0_DIV_SEL", &self.PLL_CTRL0_DIV_SEL())
+            .field("USBPHY_TX_D_CAL", &self.USBPHY_TX_D_CAL())
+            .field("USBPHY_TX_CAL45DP", &self.USBPHY_TX_CAL45DP())
+            .field("USBPHY_TX_CAL45DN", &self.USBPHY_TX_CAL45DN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TRIM_OVERRIDE_EN_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "TRIM_OVERRIDE_EN_SET {{ DIV_SEL_OVERRIDE: {=bool:?}, TX_D_CAL_OVERRIDE: {=bool:?}, TX_CAL45DP_OVERRIDE: {=bool:?}, TX_CAL45DM_OVERRIDE: {=bool:?}, PLL_CTRL0_DIV_SEL: {=u8:?}, USBPHY_TX_D_CAL: {=u8:?}, USBPHY_TX_CAL45DP: {=u8:?}, USBPHY_TX_CAL45DN: {=u8:?} }}",
+            self.DIV_SEL_OVERRIDE(),
+            self.TX_D_CAL_OVERRIDE(),
+            self.TX_CAL45DP_OVERRIDE(),
+            self.TX_CAL45DM_OVERRIDE(),
+            self.PLL_CTRL0_DIV_SEL(),
+            self.USBPHY_TX_D_CAL(),
+            self.USBPHY_TX_CAL45DP(),
+            self.USBPHY_TX_CAL45DN()
+        )
+    }
+}
+#[doc = "Trim."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct TRIM_OVERRIDE_EN_TOG(pub u32);
+impl TRIM_OVERRIDE_EN_TOG {
+    #[doc = "Override Enable for PLL Divider Value."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DIV_SEL_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Enable for PLL Divider Value."]
+    #[inline(always)]
+    pub const fn set_DIV_SEL_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Override Enable for HS TX Output Current Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TX_D_CAL_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Enable for HS TX Output Current Trim."]
+    #[inline(always)]
+    pub const fn set_TX_D_CAL_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "Override Enable for USB_DP Series Termination Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TX_CAL45DP_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Enable for USB_DP Series Termination Trim."]
+    #[inline(always)]
+    pub const fn set_TX_CAL45DP_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Override Enable for USB_DM Series Termination Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TX_CAL45DM_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Enable for USB_DM Series Termination Trim."]
+    #[inline(always)]
+    pub const fn set_TX_CAL45DM_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "PLL Divider Value Configuration Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLL_CTRL0_DIV_SEL(&self) -> u8 {
+        let val = (self.0 >> 15usize) & 0x07;
+        val as u8
+    }
+    #[doc = "PLL Divider Value Configuration Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_PLL_CTRL0_DIV_SEL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 15usize)) | (((val as u32) & 0x07) << 15usize);
+    }
+    #[doc = "HS TX Output Current Trim Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBPHY_TX_D_CAL(&self) -> u8 {
+        let val = (self.0 >> 20usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "HS TX Output Current Trim Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_USBPHY_TX_D_CAL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 20usize)) | (((val as u32) & 0x0f) << 20usize);
+    }
+    #[doc = "DP Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBPHY_TX_CAL45DP(&self) -> u8 {
+        let val = (self.0 >> 24usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DP Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_USBPHY_TX_CAL45DP(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 24usize)) | (((val as u32) & 0x0f) << 24usize);
+    }
+    #[doc = "DM Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn USBPHY_TX_CAL45DN(&self) -> u8 {
+        let val = (self.0 >> 28usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DM Series Termination Resistance Trim Bits from Outside USBPHY."]
+    #[inline(always)]
+    pub const fn set_USBPHY_TX_CAL45DN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 28usize)) | (((val as u32) & 0x0f) << 28usize);
+    }
+}
+impl Default for TRIM_OVERRIDE_EN_TOG {
+    #[inline(always)]
+    fn default() -> TRIM_OVERRIDE_EN_TOG {
+        TRIM_OVERRIDE_EN_TOG(0)
+    }
+}
+impl core::fmt::Debug for TRIM_OVERRIDE_EN_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TRIM_OVERRIDE_EN_TOG")
+            .field("DIV_SEL_OVERRIDE", &self.DIV_SEL_OVERRIDE())
+            .field("TX_D_CAL_OVERRIDE", &self.TX_D_CAL_OVERRIDE())
+            .field("TX_CAL45DP_OVERRIDE", &self.TX_CAL45DP_OVERRIDE())
+            .field("TX_CAL45DM_OVERRIDE", &self.TX_CAL45DM_OVERRIDE())
+            .field("PLL_CTRL0_DIV_SEL", &self.PLL_CTRL0_DIV_SEL())
+            .field("USBPHY_TX_D_CAL", &self.USBPHY_TX_D_CAL())
+            .field("USBPHY_TX_CAL45DP", &self.USBPHY_TX_CAL45DP())
+            .field("USBPHY_TX_CAL45DN", &self.USBPHY_TX_CAL45DN())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TRIM_OVERRIDE_EN_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "TRIM_OVERRIDE_EN_TOG {{ DIV_SEL_OVERRIDE: {=bool:?}, TX_D_CAL_OVERRIDE: {=bool:?}, TX_CAL45DP_OVERRIDE: {=bool:?}, TX_CAL45DM_OVERRIDE: {=bool:?}, PLL_CTRL0_DIV_SEL: {=u8:?}, USBPHY_TX_D_CAL: {=u8:?}, USBPHY_TX_CAL45DP: {=u8:?}, USBPHY_TX_CAL45DN: {=u8:?} }}",
+            self.DIV_SEL_OVERRIDE(),
+            self.TX_D_CAL_OVERRIDE(),
+            self.TX_CAL45DP_OVERRIDE(),
+            self.TX_CAL45DM_OVERRIDE(),
+            self.PLL_CTRL0_DIV_SEL(),
+            self.USBPHY_TX_D_CAL(),
+            self.USBPHY_TX_CAL45DP(),
+            self.USBPHY_TX_CAL45DN()
+        )
+    }
+}
+#[doc = "TX Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct TX(pub u32);
+impl TX {
+    #[doc = "HS TX Output Current Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn D_CAL(&self) -> D_CAL {
+        let val = (self.0 >> 0usize) & 0x0f;
+        D_CAL::from_bits(val as u8)
+    }
+    #[doc = "HS TX Output Current Trim."]
+    #[inline(always)]
+    pub const fn set_D_CAL(&mut self, val: D_CAL) {
+        self.0 = (self.0 & !(0x0f << 0usize)) | (((val.to_bits() as u32) & 0x0f) << 0usize);
+    }
+    #[doc = "DM Series Termination Resistance Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXCAL45DN(&self) -> u8 {
+        let val = (self.0 >> 8usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DM Series Termination Resistance Trim."]
+    #[inline(always)]
+    pub const fn set_TXCAL45DN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 8usize)) | (((val as u32) & 0x0f) << 8usize);
+    }
+    #[doc = "DP Series Termination Resistance Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXCAL45DP(&self) -> u8 {
+        let val = (self.0 >> 16usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DP Series Termination Resistance Trim."]
+    #[inline(always)]
+    pub const fn set_TXCAL45DP(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 16usize)) | (((val as u32) & 0x0f) << 16usize);
+    }
+}
+impl Default for TX {
+    #[inline(always)]
+    fn default() -> TX {
+        TX(0)
+    }
+}
+impl core::fmt::Debug for TX {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TX")
+            .field("D_CAL", &self.D_CAL())
+            .field("TXCAL45DN", &self.TXCAL45DN())
+            .field("TXCAL45DP", &self.TXCAL45DP())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TX {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "TX {{ D_CAL: {:?}, TXCAL45DN: {=u8:?}, TXCAL45DP: {=u8:?} }}",
+            self.D_CAL(),
+            self.TXCAL45DN(),
+            self.TXCAL45DP()
+        )
+    }
+}
+#[doc = "TX Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct TX_CLR(pub u32);
+impl TX_CLR {
+    #[doc = "HS TX Output Current Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn D_CAL(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "HS TX Output Current Trim."]
+    #[inline(always)]
+    pub const fn set_D_CAL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 0usize)) | (((val as u32) & 0x0f) << 0usize);
+    }
+    #[doc = "DM Series Termination Resistance Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXCAL45DN(&self) -> u8 {
+        let val = (self.0 >> 8usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DM Series Termination Resistance Trim."]
+    #[inline(always)]
+    pub const fn set_TXCAL45DN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 8usize)) | (((val as u32) & 0x0f) << 8usize);
+    }
+    #[doc = "DP Series Termination Resistance Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXCAL45DP(&self) -> u8 {
+        let val = (self.0 >> 16usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DP Series Termination Resistance Trim."]
+    #[inline(always)]
+    pub const fn set_TXCAL45DP(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 16usize)) | (((val as u32) & 0x0f) << 16usize);
+    }
+}
+impl Default for TX_CLR {
+    #[inline(always)]
+    fn default() -> TX_CLR {
+        TX_CLR(0)
+    }
+}
+impl core::fmt::Debug for TX_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TX_CLR")
+            .field("D_CAL", &self.D_CAL())
+            .field("TXCAL45DN", &self.TXCAL45DN())
+            .field("TXCAL45DP", &self.TXCAL45DP())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TX_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "TX_CLR {{ D_CAL: {=u8:?}, TXCAL45DN: {=u8:?}, TXCAL45DP: {=u8:?} }}",
+            self.D_CAL(),
+            self.TXCAL45DN(),
+            self.TXCAL45DP()
+        )
+    }
+}
+#[doc = "TX Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct TX_SET(pub u32);
+impl TX_SET {
+    #[doc = "HS TX Output Current Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn D_CAL(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "HS TX Output Current Trim."]
+    #[inline(always)]
+    pub const fn set_D_CAL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 0usize)) | (((val as u32) & 0x0f) << 0usize);
+    }
+    #[doc = "DM Series Termination Resistance Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXCAL45DN(&self) -> u8 {
+        let val = (self.0 >> 8usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DM Series Termination Resistance Trim."]
+    #[inline(always)]
+    pub const fn set_TXCAL45DN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 8usize)) | (((val as u32) & 0x0f) << 8usize);
+    }
+    #[doc = "DP Series Termination Resistance Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXCAL45DP(&self) -> u8 {
+        let val = (self.0 >> 16usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DP Series Termination Resistance Trim."]
+    #[inline(always)]
+    pub const fn set_TXCAL45DP(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 16usize)) | (((val as u32) & 0x0f) << 16usize);
+    }
+}
+impl Default for TX_SET {
+    #[inline(always)]
+    fn default() -> TX_SET {
+        TX_SET(0)
+    }
+}
+impl core::fmt::Debug for TX_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TX_SET")
+            .field("D_CAL", &self.D_CAL())
+            .field("TXCAL45DN", &self.TXCAL45DN())
+            .field("TXCAL45DP", &self.TXCAL45DP())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TX_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "TX_SET {{ D_CAL: {=u8:?}, TXCAL45DN: {=u8:?}, TXCAL45DP: {=u8:?} }}",
+            self.D_CAL(),
+            self.TXCAL45DN(),
+            self.TXCAL45DP()
+        )
+    }
+}
+#[doc = "TX Control."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct TX_TOG(pub u32);
+impl TX_TOG {
+    #[doc = "HS TX Output Current Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn D_CAL(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "HS TX Output Current Trim."]
+    #[inline(always)]
+    pub const fn set_D_CAL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 0usize)) | (((val as u32) & 0x0f) << 0usize);
+    }
+    #[doc = "DM Series Termination Resistance Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXCAL45DN(&self) -> u8 {
+        let val = (self.0 >> 8usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DM Series Termination Resistance Trim."]
+    #[inline(always)]
+    pub const fn set_TXCAL45DN(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 8usize)) | (((val as u32) & 0x0f) << 8usize);
+    }
+    #[doc = "DP Series Termination Resistance Trim."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn TXCAL45DP(&self) -> u8 {
+        let val = (self.0 >> 16usize) & 0x0f;
+        val as u8
+    }
+    #[doc = "DP Series Termination Resistance Trim."]
+    #[inline(always)]
+    pub const fn set_TXCAL45DP(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x0f << 16usize)) | (((val as u32) & 0x0f) << 16usize);
+    }
+}
+impl Default for TX_TOG {
+    #[inline(always)]
+    fn default() -> TX_TOG {
+        TX_TOG(0)
+    }
+}
+impl core::fmt::Debug for TX_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TX_TOG")
+            .field("D_CAL", &self.D_CAL())
+            .field("TXCAL45DN", &self.TXCAL45DN())
+            .field("TXCAL45DP", &self.TXCAL45DP())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TX_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "TX_TOG {{ D_CAL: {=u8:?}, TXCAL45DN: {=u8:?}, TXCAL45DP: {=u8:?} }}",
+            self.D_CAL(),
+            self.TXCAL45DN(),
+            self.TXCAL45DP()
+        )
+    }
+}
+#[doc = "Charger Detect."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_CHRG_DETECT(pub u32);
+impl USB1_CHRG_DETECT {
+    #[doc = "Secondary Detection Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DETECT_SEC(&self) -> DETECT_SEC {
+        let val = (self.0 >> 1usize) & 0x01;
+        DETECT_SEC::from_bits(val as u8)
+    }
+    #[doc = "Secondary Detection Function Enable."]
+    #[inline(always)]
+    pub const fn set_DETECT_SEC(&mut self, val: DETECT_SEC) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val.to_bits() as u32) & 0x01) << 1usize);
+    }
+    #[doc = "DP Pullup Resistor Enable Override Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PULLUP_DP(&self) -> PULLUP_DP {
+        let val = (self.0 >> 2usize) & 0x01;
+        PULLUP_DP::from_bits(val as u8)
+    }
+    #[doc = "DP Pullup Resistor Enable Override Control."]
+    #[inline(always)]
+    pub const fn set_PULLUP_DP(&mut self, val: PULLUP_DP) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val.to_bits() as u32) & 0x01) << 2usize);
+    }
+    #[doc = "VDM_SRC Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VDM_SRC_ENABLE(&self) -> VDM_SRC_ENABLE {
+        let val = (self.0 >> 4usize) & 0x01;
+        VDM_SRC_ENABLE::from_bits(val as u8)
+    }
+    #[doc = "VDM_SRC Function Enable."]
+    #[inline(always)]
+    pub const fn set_VDM_SRC_ENABLE(&mut self, val: VDM_SRC_ENABLE) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u32) & 0x01) << 4usize);
+    }
+    #[doc = "BC Data Contact Detect Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CHK_CONTACT(&self) -> CHK_CONTACT {
+        let val = (self.0 >> 18usize) & 0x01;
+        CHK_CONTACT::from_bits(val as u8)
+    }
+    #[doc = "BC Data Contact Detect Function Enable."]
+    #[inline(always)]
+    pub const fn set_CHK_CONTACT(&mut self, val: CHK_CONTACT) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val.to_bits() as u32) & 0x01) << 18usize);
+    }
+    #[doc = "BC Charger Detection Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CHK_CHRG_B(&self) -> CHK_CHRG_B {
+        let val = (self.0 >> 19usize) & 0x01;
+        CHK_CHRG_B::from_bits(val as u8)
+    }
+    #[doc = "BC Charger Detection Function Enable."]
+    #[inline(always)]
+    pub const fn set_CHK_CHRG_B(&mut self, val: CHK_CHRG_B) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val.to_bits() as u32) & 0x01) << 19usize);
+    }
+    #[doc = "Selection of BC v1.2 Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EN_B(&self) -> EN_B {
+        let val = (self.0 >> 20usize) & 0x01;
+        EN_B::from_bits(val as u8)
+    }
+    #[doc = "Selection of BC v1.2 Function Enable."]
+    #[inline(always)]
+    pub const fn set_EN_B(&mut self, val: EN_B) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val.to_bits() as u32) & 0x01) << 20usize);
+    }
+    #[doc = "DCD Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DCDSEL(&self) -> DCDSEL {
+        let val = (self.0 >> 31usize) & 0x01;
+        DCDSEL::from_bits(val as u8)
+    }
+    #[doc = "DCD Selection."]
+    #[inline(always)]
+    pub const fn set_DCDSEL(&mut self, val: DCDSEL) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val.to_bits() as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for USB1_CHRG_DETECT {
+    #[inline(always)]
+    fn default() -> USB1_CHRG_DETECT {
+        USB1_CHRG_DETECT(0)
+    }
+}
+impl core::fmt::Debug for USB1_CHRG_DETECT {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_CHRG_DETECT")
+            .field("DETECT_SEC", &self.DETECT_SEC())
+            .field("PULLUP_DP", &self.PULLUP_DP())
+            .field("VDM_SRC_ENABLE", &self.VDM_SRC_ENABLE())
+            .field("CHK_CONTACT", &self.CHK_CONTACT())
+            .field("CHK_CHRG_B", &self.CHK_CHRG_B())
+            .field("EN_B", &self.EN_B())
+            .field("DCDSEL", &self.DCDSEL())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_CHRG_DETECT {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_CHRG_DETECT {{ DETECT_SEC: {:?}, PULLUP_DP: {:?}, VDM_SRC_ENABLE: {:?}, CHK_CONTACT: {:?}, CHK_CHRG_B: {:?}, EN_B: {:?}, DCDSEL: {:?} }}",
+            self.DETECT_SEC(),
+            self.PULLUP_DP(),
+            self.VDM_SRC_ENABLE(),
+            self.CHK_CONTACT(),
+            self.CHK_CHRG_B(),
+            self.EN_B(),
+            self.DCDSEL()
+        )
+    }
+}
+#[doc = "Charger Detect."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_CHRG_DETECT_CLR(pub u32);
+impl USB1_CHRG_DETECT_CLR {
+    #[doc = "Secondary Detection Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DETECT_SEC(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Secondary Detection Function Enable."]
+    #[inline(always)]
+    pub const fn set_DETECT_SEC(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "DP Pullup Resistor Enable Override Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PULLUP_DP(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "DP Pullup Resistor Enable Override Control."]
+    #[inline(always)]
+    pub const fn set_PULLUP_DP(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "VDM_SRC Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VDM_SRC_ENABLE(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VDM_SRC Function Enable."]
+    #[inline(always)]
+    pub const fn set_VDM_SRC_ENABLE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "BC Data Contact Detect Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CHK_CONTACT(&self) -> bool {
+        let val = (self.0 >> 18usize) & 0x01;
+        val != 0
+    }
+    #[doc = "BC Data Contact Detect Function Enable."]
+    #[inline(always)]
+    pub const fn set_CHK_CONTACT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    }
+    #[doc = "BC Charger Detection Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CHK_CHRG_B(&self) -> bool {
+        let val = (self.0 >> 19usize) & 0x01;
+        val != 0
+    }
+    #[doc = "BC Charger Detection Function Enable."]
+    #[inline(always)]
+    pub const fn set_CHK_CHRG_B(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val as u32) & 0x01) << 19usize);
+    }
+    #[doc = "Selection of BC v1.2 Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EN_B(&self) -> bool {
+        let val = (self.0 >> 20usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Selection of BC v1.2 Function Enable."]
+    #[inline(always)]
+    pub const fn set_EN_B(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val as u32) & 0x01) << 20usize);
+    }
+    #[doc = "DCD Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DCDSEL(&self) -> bool {
+        let val = (self.0 >> 31usize) & 0x01;
+        val != 0
+    }
+    #[doc = "DCD Selection."]
+    #[inline(always)]
+    pub const fn set_DCDSEL(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for USB1_CHRG_DETECT_CLR {
+    #[inline(always)]
+    fn default() -> USB1_CHRG_DETECT_CLR {
+        USB1_CHRG_DETECT_CLR(0)
+    }
+}
+impl core::fmt::Debug for USB1_CHRG_DETECT_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_CHRG_DETECT_CLR")
+            .field("DETECT_SEC", &self.DETECT_SEC())
+            .field("PULLUP_DP", &self.PULLUP_DP())
+            .field("VDM_SRC_ENABLE", &self.VDM_SRC_ENABLE())
+            .field("CHK_CONTACT", &self.CHK_CONTACT())
+            .field("CHK_CHRG_B", &self.CHK_CHRG_B())
+            .field("EN_B", &self.EN_B())
+            .field("DCDSEL", &self.DCDSEL())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_CHRG_DETECT_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_CHRG_DETECT_CLR {{ DETECT_SEC: {=bool:?}, PULLUP_DP: {=bool:?}, VDM_SRC_ENABLE: {=bool:?}, CHK_CONTACT: {=bool:?}, CHK_CHRG_B: {=bool:?}, EN_B: {=bool:?}, DCDSEL: {=bool:?} }}",
+            self.DETECT_SEC(),
+            self.PULLUP_DP(),
+            self.VDM_SRC_ENABLE(),
+            self.CHK_CONTACT(),
+            self.CHK_CHRG_B(),
+            self.EN_B(),
+            self.DCDSEL()
+        )
+    }
+}
+#[doc = "Charger Detect."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_CHRG_DETECT_SET(pub u32);
+impl USB1_CHRG_DETECT_SET {
+    #[doc = "Secondary Detection Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DETECT_SEC(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Secondary Detection Function Enable."]
+    #[inline(always)]
+    pub const fn set_DETECT_SEC(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "DP Pullup Resistor Enable Override Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PULLUP_DP(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "DP Pullup Resistor Enable Override Control."]
+    #[inline(always)]
+    pub const fn set_PULLUP_DP(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "VDM_SRC Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VDM_SRC_ENABLE(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VDM_SRC Function Enable."]
+    #[inline(always)]
+    pub const fn set_VDM_SRC_ENABLE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "BC Data Contact Detect Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CHK_CONTACT(&self) -> bool {
+        let val = (self.0 >> 18usize) & 0x01;
+        val != 0
+    }
+    #[doc = "BC Data Contact Detect Function Enable."]
+    #[inline(always)]
+    pub const fn set_CHK_CONTACT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    }
+    #[doc = "BC Charger Detection Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CHK_CHRG_B(&self) -> bool {
+        let val = (self.0 >> 19usize) & 0x01;
+        val != 0
+    }
+    #[doc = "BC Charger Detection Function Enable."]
+    #[inline(always)]
+    pub const fn set_CHK_CHRG_B(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val as u32) & 0x01) << 19usize);
+    }
+    #[doc = "Selection of BC v1.2 Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EN_B(&self) -> bool {
+        let val = (self.0 >> 20usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Selection of BC v1.2 Function Enable."]
+    #[inline(always)]
+    pub const fn set_EN_B(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val as u32) & 0x01) << 20usize);
+    }
+    #[doc = "DCD Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DCDSEL(&self) -> bool {
+        let val = (self.0 >> 31usize) & 0x01;
+        val != 0
+    }
+    #[doc = "DCD Selection."]
+    #[inline(always)]
+    pub const fn set_DCDSEL(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for USB1_CHRG_DETECT_SET {
+    #[inline(always)]
+    fn default() -> USB1_CHRG_DETECT_SET {
+        USB1_CHRG_DETECT_SET(0)
+    }
+}
+impl core::fmt::Debug for USB1_CHRG_DETECT_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_CHRG_DETECT_SET")
+            .field("DETECT_SEC", &self.DETECT_SEC())
+            .field("PULLUP_DP", &self.PULLUP_DP())
+            .field("VDM_SRC_ENABLE", &self.VDM_SRC_ENABLE())
+            .field("CHK_CONTACT", &self.CHK_CONTACT())
+            .field("CHK_CHRG_B", &self.CHK_CHRG_B())
+            .field("EN_B", &self.EN_B())
+            .field("DCDSEL", &self.DCDSEL())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_CHRG_DETECT_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_CHRG_DETECT_SET {{ DETECT_SEC: {=bool:?}, PULLUP_DP: {=bool:?}, VDM_SRC_ENABLE: {=bool:?}, CHK_CONTACT: {=bool:?}, CHK_CHRG_B: {=bool:?}, EN_B: {=bool:?}, DCDSEL: {=bool:?} }}",
+            self.DETECT_SEC(),
+            self.PULLUP_DP(),
+            self.VDM_SRC_ENABLE(),
+            self.CHK_CONTACT(),
+            self.CHK_CHRG_B(),
+            self.EN_B(),
+            self.DCDSEL()
+        )
+    }
+}
+#[doc = "Charger Detect."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_CHRG_DETECT_TOG(pub u32);
+impl USB1_CHRG_DETECT_TOG {
+    #[doc = "Secondary Detection Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DETECT_SEC(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Secondary Detection Function Enable."]
+    #[inline(always)]
+    pub const fn set_DETECT_SEC(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "DP Pullup Resistor Enable Override Control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PULLUP_DP(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "DP Pullup Resistor Enable Override Control."]
+    #[inline(always)]
+    pub const fn set_PULLUP_DP(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "VDM_SRC Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VDM_SRC_ENABLE(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VDM_SRC Function Enable."]
+    #[inline(always)]
+    pub const fn set_VDM_SRC_ENABLE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "BC Data Contact Detect Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CHK_CONTACT(&self) -> bool {
+        let val = (self.0 >> 18usize) & 0x01;
+        val != 0
+    }
+    #[doc = "BC Data Contact Detect Function Enable."]
+    #[inline(always)]
+    pub const fn set_CHK_CONTACT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    }
+    #[doc = "BC Charger Detection Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CHK_CHRG_B(&self) -> bool {
+        let val = (self.0 >> 19usize) & 0x01;
+        val != 0
+    }
+    #[doc = "BC Charger Detection Function Enable."]
+    #[inline(always)]
+    pub const fn set_CHK_CHRG_B(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 19usize)) | (((val as u32) & 0x01) << 19usize);
+    }
+    #[doc = "Selection of BC v1.2 Function Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EN_B(&self) -> bool {
+        let val = (self.0 >> 20usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Selection of BC v1.2 Function Enable."]
+    #[inline(always)]
+    pub const fn set_EN_B(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 20usize)) | (((val as u32) & 0x01) << 20usize);
+    }
+    #[doc = "DCD Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DCDSEL(&self) -> bool {
+        let val = (self.0 >> 31usize) & 0x01;
+        val != 0
+    }
+    #[doc = "DCD Selection."]
+    #[inline(always)]
+    pub const fn set_DCDSEL(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 31usize)) | (((val as u32) & 0x01) << 31usize);
+    }
+}
+impl Default for USB1_CHRG_DETECT_TOG {
+    #[inline(always)]
+    fn default() -> USB1_CHRG_DETECT_TOG {
+        USB1_CHRG_DETECT_TOG(0)
+    }
+}
+impl core::fmt::Debug for USB1_CHRG_DETECT_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_CHRG_DETECT_TOG")
+            .field("DETECT_SEC", &self.DETECT_SEC())
+            .field("PULLUP_DP", &self.PULLUP_DP())
+            .field("VDM_SRC_ENABLE", &self.VDM_SRC_ENABLE())
+            .field("CHK_CONTACT", &self.CHK_CONTACT())
+            .field("CHK_CHRG_B", &self.CHK_CHRG_B())
+            .field("EN_B", &self.EN_B())
+            .field("DCDSEL", &self.DCDSEL())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_CHRG_DETECT_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_CHRG_DETECT_TOG {{ DETECT_SEC: {=bool:?}, PULLUP_DP: {=bool:?}, VDM_SRC_ENABLE: {=bool:?}, CHK_CONTACT: {=bool:?}, CHK_CHRG_B: {=bool:?}, EN_B: {=bool:?}, DCDSEL: {=bool:?} }}",
+            self.DETECT_SEC(),
+            self.PULLUP_DP(),
+            self.VDM_SRC_ENABLE(),
+            self.CHK_CONTACT(),
+            self.CHK_CHRG_B(),
+            self.EN_B(),
+            self.DCDSEL()
+        )
+    }
+}
+#[doc = "Charger Detect Status."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_CHRG_DET_STAT(pub u32);
+impl USB1_CHRG_DET_STAT {
+    #[doc = "Battery Charging Data Contact Detection Phase Output."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLUG_CONTACT(&self) -> PLUG_CONTACT {
+        let val = (self.0 >> 0usize) & 0x01;
+        PLUG_CONTACT::from_bits(val as u8)
+    }
+    #[doc = "Battery Charging Data Contact Detection Phase Output."]
+    #[inline(always)]
+    pub const fn set_PLUG_CONTACT(&mut self, val: PLUG_CONTACT) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Battery Charging Primary Detection Phase Output."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CHRG_DETECTED(&self) -> CHRG_DETECTED {
+        let val = (self.0 >> 1usize) & 0x01;
+        CHRG_DETECTED::from_bits(val as u8)
+    }
+    #[doc = "Battery Charging Primary Detection Phase Output."]
+    #[inline(always)]
+    pub const fn set_CHRG_DETECTED(&mut self, val: CHRG_DETECTED) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val.to_bits() as u32) & 0x01) << 1usize);
+    }
+    #[doc = "DM Voltage."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DM_STATE(&self) -> DM_STATE {
+        let val = (self.0 >> 2usize) & 0x01;
+        DM_STATE::from_bits(val as u8)
+    }
+    #[doc = "DM Voltage."]
+    #[inline(always)]
+    pub const fn set_DM_STATE(&mut self, val: DM_STATE) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val.to_bits() as u32) & 0x01) << 2usize);
+    }
+    #[doc = "DP Voltage."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DP_STATE(&self) -> DP_STATE {
+        let val = (self.0 >> 3usize) & 0x01;
+        DP_STATE::from_bits(val as u8)
+    }
+    #[doc = "DP Voltage."]
+    #[inline(always)]
+    pub const fn set_DP_STATE(&mut self, val: DP_STATE) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val.to_bits() as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Battery Charging Secondary Detection Phase Output."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SECDET_DCP(&self) -> SECDET_DCP {
+        let val = (self.0 >> 4usize) & 0x01;
+        SECDET_DCP::from_bits(val as u8)
+    }
+    #[doc = "Battery Charging Secondary Detection Phase Output."]
+    #[inline(always)]
+    pub const fn set_SECDET_DCP(&mut self, val: SECDET_DCP) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u32) & 0x01) << 4usize);
+    }
+}
+impl Default for USB1_CHRG_DET_STAT {
+    #[inline(always)]
+    fn default() -> USB1_CHRG_DET_STAT {
+        USB1_CHRG_DET_STAT(0)
+    }
+}
+impl core::fmt::Debug for USB1_CHRG_DET_STAT {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_CHRG_DET_STAT")
+            .field("PLUG_CONTACT", &self.PLUG_CONTACT())
+            .field("CHRG_DETECTED", &self.CHRG_DETECTED())
+            .field("DM_STATE", &self.DM_STATE())
+            .field("DP_STATE", &self.DP_STATE())
+            .field("SECDET_DCP", &self.SECDET_DCP())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_CHRG_DET_STAT {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_CHRG_DET_STAT {{ PLUG_CONTACT: {:?}, CHRG_DETECTED: {:?}, DM_STATE: {:?}, DP_STATE: {:?}, SECDET_DCP: {:?} }}",
+            self.PLUG_CONTACT(),
+            self.CHRG_DETECTED(),
+            self.DM_STATE(),
+            self.DP_STATE(),
+            self.SECDET_DCP()
+        )
+    }
+}
+#[doc = "Charger Detect Status."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_CHRG_DET_STAT_CLR(pub u32);
+impl USB1_CHRG_DET_STAT_CLR {
+    #[doc = "Battery Charging Data Contact Detection Phase Output."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLUG_CONTACT(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Battery Charging Data Contact Detection Phase Output."]
+    #[inline(always)]
+    pub const fn set_PLUG_CONTACT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Battery Charging Primary Detection Phase Output."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CHRG_DETECTED(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Battery Charging Primary Detection Phase Output."]
+    #[inline(always)]
+    pub const fn set_CHRG_DETECTED(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "DM Voltage."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DM_STATE(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "DM Voltage."]
+    #[inline(always)]
+    pub const fn set_DM_STATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "DP Voltage."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DP_STATE(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "DP Voltage."]
+    #[inline(always)]
+    pub const fn set_DP_STATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Battery Charging Secondary Detection Phase Output."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SECDET_DCP(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Battery Charging Secondary Detection Phase Output."]
+    #[inline(always)]
+    pub const fn set_SECDET_DCP(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+}
+impl Default for USB1_CHRG_DET_STAT_CLR {
+    #[inline(always)]
+    fn default() -> USB1_CHRG_DET_STAT_CLR {
+        USB1_CHRG_DET_STAT_CLR(0)
+    }
+}
+impl core::fmt::Debug for USB1_CHRG_DET_STAT_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_CHRG_DET_STAT_CLR")
+            .field("PLUG_CONTACT", &self.PLUG_CONTACT())
+            .field("CHRG_DETECTED", &self.CHRG_DETECTED())
+            .field("DM_STATE", &self.DM_STATE())
+            .field("DP_STATE", &self.DP_STATE())
+            .field("SECDET_DCP", &self.SECDET_DCP())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_CHRG_DET_STAT_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_CHRG_DET_STAT_CLR {{ PLUG_CONTACT: {=bool:?}, CHRG_DETECTED: {=bool:?}, DM_STATE: {=bool:?}, DP_STATE: {=bool:?}, SECDET_DCP: {=bool:?} }}",
+            self.PLUG_CONTACT(),
+            self.CHRG_DETECTED(),
+            self.DM_STATE(),
+            self.DP_STATE(),
+            self.SECDET_DCP()
+        )
+    }
+}
+#[doc = "Charger Detect Status."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_CHRG_DET_STAT_SET(pub u32);
+impl USB1_CHRG_DET_STAT_SET {
+    #[doc = "Battery Charging Data Contact Detection Phase Output."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLUG_CONTACT(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Battery Charging Data Contact Detection Phase Output."]
+    #[inline(always)]
+    pub const fn set_PLUG_CONTACT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Battery Charging Primary Detection Phase Output."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CHRG_DETECTED(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Battery Charging Primary Detection Phase Output."]
+    #[inline(always)]
+    pub const fn set_CHRG_DETECTED(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "DM Voltage."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DM_STATE(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "DM Voltage."]
+    #[inline(always)]
+    pub const fn set_DM_STATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "DP Voltage."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DP_STATE(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "DP Voltage."]
+    #[inline(always)]
+    pub const fn set_DP_STATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Battery Charging Secondary Detection Phase Output."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SECDET_DCP(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Battery Charging Secondary Detection Phase Output."]
+    #[inline(always)]
+    pub const fn set_SECDET_DCP(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+}
+impl Default for USB1_CHRG_DET_STAT_SET {
+    #[inline(always)]
+    fn default() -> USB1_CHRG_DET_STAT_SET {
+        USB1_CHRG_DET_STAT_SET(0)
+    }
+}
+impl core::fmt::Debug for USB1_CHRG_DET_STAT_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_CHRG_DET_STAT_SET")
+            .field("PLUG_CONTACT", &self.PLUG_CONTACT())
+            .field("CHRG_DETECTED", &self.CHRG_DETECTED())
+            .field("DM_STATE", &self.DM_STATE())
+            .field("DP_STATE", &self.DP_STATE())
+            .field("SECDET_DCP", &self.SECDET_DCP())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_CHRG_DET_STAT_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_CHRG_DET_STAT_SET {{ PLUG_CONTACT: {=bool:?}, CHRG_DETECTED: {=bool:?}, DM_STATE: {=bool:?}, DP_STATE: {=bool:?}, SECDET_DCP: {=bool:?} }}",
+            self.PLUG_CONTACT(),
+            self.CHRG_DETECTED(),
+            self.DM_STATE(),
+            self.DP_STATE(),
+            self.SECDET_DCP()
+        )
+    }
+}
+#[doc = "Charger Detect Status."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_CHRG_DET_STAT_TOG(pub u32);
+impl USB1_CHRG_DET_STAT_TOG {
+    #[doc = "Battery Charging Data Contact Detection Phase Output."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn PLUG_CONTACT(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Battery Charging Data Contact Detection Phase Output."]
+    #[inline(always)]
+    pub const fn set_PLUG_CONTACT(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "Battery Charging Primary Detection Phase Output."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn CHRG_DETECTED(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Battery Charging Primary Detection Phase Output."]
+    #[inline(always)]
+    pub const fn set_CHRG_DETECTED(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "DM Voltage."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DM_STATE(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "DM Voltage."]
+    #[inline(always)]
+    pub const fn set_DM_STATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "DP Voltage."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DP_STATE(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "DP Voltage."]
+    #[inline(always)]
+    pub const fn set_DP_STATE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Battery Charging Secondary Detection Phase Output."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SECDET_DCP(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Battery Charging Secondary Detection Phase Output."]
+    #[inline(always)]
+    pub const fn set_SECDET_DCP(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+}
+impl Default for USB1_CHRG_DET_STAT_TOG {
+    #[inline(always)]
+    fn default() -> USB1_CHRG_DET_STAT_TOG {
+        USB1_CHRG_DET_STAT_TOG(0)
+    }
+}
+impl core::fmt::Debug for USB1_CHRG_DET_STAT_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_CHRG_DET_STAT_TOG")
+            .field("PLUG_CONTACT", &self.PLUG_CONTACT())
+            .field("CHRG_DETECTED", &self.CHRG_DETECTED())
+            .field("DM_STATE", &self.DM_STATE())
+            .field("DP_STATE", &self.DP_STATE())
+            .field("SECDET_DCP", &self.SECDET_DCP())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_CHRG_DET_STAT_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_CHRG_DET_STAT_TOG {{ PLUG_CONTACT: {=bool:?}, CHRG_DETECTED: {=bool:?}, DM_STATE: {=bool:?}, DP_STATE: {=bool:?}, SECDET_DCP: {=bool:?} }}",
+            self.PLUG_CONTACT(),
+            self.CHRG_DETECTED(),
+            self.DM_STATE(),
+            self.DP_STATE(),
+            self.SECDET_DCP()
+        )
+    }
+}
+#[doc = "VBUS Detect."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_VBUS_DETECT(pub u32);
+impl USB1_VBUS_DETECT {
+    #[doc = "VBUS Comparator Threshold."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_THRESH(&self) -> VBUSVALID_THRESH {
+        let val = (self.0 >> 0usize) & 0x07;
+        VBUSVALID_THRESH::from_bits(val as u8)
+    }
+    #[doc = "VBUS Comparator Threshold."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_THRESH(&mut self, val: VBUSVALID_THRESH) {
+        self.0 = (self.0 & !(0x07 << 0usize)) | (((val.to_bits() as u32) & 0x07) << 0usize);
+    }
+    #[doc = "VBUS Detect Signal Local Override Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_OVERRIDE_EN(&self) -> VBUS_OVERRIDE_EN {
+        let val = (self.0 >> 3usize) & 0x01;
+        VBUS_OVERRIDE_EN::from_bits(val as u8)
+    }
+    #[doc = "VBUS Detect Signal Local Override Enable."]
+    #[inline(always)]
+    pub const fn set_VBUS_OVERRIDE_EN(&mut self, val: VBUS_OVERRIDE_EN) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val.to_bits() as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Override Value for SESSEND."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SESSEND_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for SESSEND."]
+    #[inline(always)]
+    pub const fn set_SESSEND_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "Override Value for B-Device Session Valid."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BVALID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for B-Device Session Valid."]
+    #[inline(always)]
+    pub const fn set_BVALID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+    #[doc = "Override Value for A-Device Session Valid."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AVALID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 6usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for A-Device Session Valid."]
+    #[inline(always)]
+    pub const fn set_AVALID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val as u32) & 0x01) << 6usize);
+    }
+    #[doc = "Override Value for the VBUS_VALID Signal."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 7usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for the VBUS_VALID Signal."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val as u32) & 0x01) << 7usize);
+    }
+    #[doc = "VBUS_VALID Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_SEL(&self) -> VBUSVALID_SEL {
+        let val = (self.0 >> 8usize) & 0x01;
+        VBUSVALID_SEL::from_bits(val as u8)
+    }
+    #[doc = "VBUS_VALID Selection."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_SEL(&mut self, val: VBUSVALID_SEL) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val.to_bits() as u32) & 0x01) << 8usize);
+    }
+    #[doc = "VBUS_VALID Source Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_SOURCE_SEL(&self) -> VBUS_SOURCE_SEL {
+        let val = (self.0 >> 9usize) & 0x03;
+        VBUS_SOURCE_SEL::from_bits(val as u8)
+    }
+    #[doc = "VBUS_VALID Source Selection."]
+    #[inline(always)]
+    pub const fn set_VBUS_SOURCE_SEL(&mut self, val: VBUS_SOURCE_SEL) {
+        self.0 = (self.0 & !(0x03 << 9usize)) | (((val.to_bits() as u32) & 0x03) << 9usize);
+    }
+    #[doc = "Enable Local ID Pin Status Override."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ID_OVERRIDE_EN(&self) -> ID_OVERRIDE_EN {
+        let val = (self.0 >> 11usize) & 0x01;
+        ID_OVERRIDE_EN::from_bits(val as u8)
+    }
+    #[doc = "Enable Local ID Pin Status Override."]
+    #[inline(always)]
+    pub const fn set_ID_OVERRIDE_EN(&mut self, val: ID_OVERRIDE_EN) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val.to_bits() as u32) & 0x01) << 11usize);
+    }
+    #[doc = "ID Pin Status Local Override."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "ID Pin Status Local Override."]
+    #[inline(always)]
+    pub const fn set_ID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "External ID Override Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EXT_ID_OVERRIDE_EN(&self) -> EXT_ID_OVERRIDE_EN {
+        let val = (self.0 >> 13usize) & 0x01;
+        EXT_ID_OVERRIDE_EN::from_bits(val as u8)
+    }
+    #[doc = "External ID Override Enable."]
+    #[inline(always)]
+    pub const fn set_EXT_ID_OVERRIDE_EN(&mut self, val: EXT_ID_OVERRIDE_EN) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val.to_bits() as u32) & 0x01) << 13usize);
+    }
+    #[doc = "External VBUS Override Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EXT_VBUS_OVERRIDE_EN(&self) -> EXT_VBUS_OVERRIDE_EN {
+        let val = (self.0 >> 14usize) & 0x01;
+        EXT_VBUS_OVERRIDE_EN::from_bits(val as u8)
+    }
+    #[doc = "External VBUS Override Enable."]
+    #[inline(always)]
+    pub const fn set_EXT_VBUS_OVERRIDE_EN(&mut self, val: EXT_VBUS_OVERRIDE_EN) {
+        self.0 = (self.0 & !(0x01 << 14usize)) | (((val.to_bits() as u32) & 0x01) << 14usize);
+    }
+    #[doc = "VBUS_VALID Comparator Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_TO_B(&self) -> VBUSVALID_TO_B {
+        let val = (self.0 >> 18usize) & 0x01;
+        VBUSVALID_TO_B::from_bits(val as u8)
+    }
+    #[doc = "VBUS_VALID Comparator Selection."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_TO_B(&mut self, val: VBUSVALID_TO_B) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val.to_bits() as u32) & 0x01) << 18usize);
+    }
+    #[doc = "VBUS_VALID Comparator Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_PWRUP_CMPS(&self) -> VBUSVALID_PWRUP_CMPS {
+        let val = (self.0 >> 20usize) & 0x07;
+        VBUSVALID_PWRUP_CMPS::from_bits(val as u8)
+    }
+    #[doc = "VBUS_VALID Comparator Enable."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_PWRUP_CMPS(&mut self, val: VBUSVALID_PWRUP_CMPS) {
+        self.0 = (self.0 & !(0x07 << 20usize)) | (((val.to_bits() as u32) & 0x07) << 20usize);
+    }
+    #[doc = "VBUS Discharge Resistor."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DISCHARGE_VBUS(&self) -> DISCHARGE_VBUS {
+        let val = (self.0 >> 26usize) & 0x01;
+        DISCHARGE_VBUS::from_bits(val as u8)
+    }
+    #[doc = "VBUS Discharge Resistor."]
+    #[inline(always)]
+    pub const fn set_DISCHARGE_VBUS(&mut self, val: DISCHARGE_VBUS) {
+        self.0 = (self.0 & !(0x01 << 26usize)) | (((val.to_bits() as u32) & 0x01) << 26usize);
+    }
+}
+impl Default for USB1_VBUS_DETECT {
+    #[inline(always)]
+    fn default() -> USB1_VBUS_DETECT {
+        USB1_VBUS_DETECT(0)
+    }
+}
+impl core::fmt::Debug for USB1_VBUS_DETECT {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_VBUS_DETECT")
+            .field("VBUSVALID_THRESH", &self.VBUSVALID_THRESH())
+            .field("VBUS_OVERRIDE_EN", &self.VBUS_OVERRIDE_EN())
+            .field("SESSEND_OVERRIDE", &self.SESSEND_OVERRIDE())
+            .field("BVALID_OVERRIDE", &self.BVALID_OVERRIDE())
+            .field("AVALID_OVERRIDE", &self.AVALID_OVERRIDE())
+            .field("VBUSVALID_OVERRIDE", &self.VBUSVALID_OVERRIDE())
+            .field("VBUSVALID_SEL", &self.VBUSVALID_SEL())
+            .field("VBUS_SOURCE_SEL", &self.VBUS_SOURCE_SEL())
+            .field("ID_OVERRIDE_EN", &self.ID_OVERRIDE_EN())
+            .field("ID_OVERRIDE", &self.ID_OVERRIDE())
+            .field("EXT_ID_OVERRIDE_EN", &self.EXT_ID_OVERRIDE_EN())
+            .field("EXT_VBUS_OVERRIDE_EN", &self.EXT_VBUS_OVERRIDE_EN())
+            .field("VBUSVALID_TO_B", &self.VBUSVALID_TO_B())
+            .field("VBUSVALID_PWRUP_CMPS", &self.VBUSVALID_PWRUP_CMPS())
+            .field("DISCHARGE_VBUS", &self.DISCHARGE_VBUS())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_VBUS_DETECT {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_VBUS_DETECT {{ VBUSVALID_THRESH: {:?}, VBUS_OVERRIDE_EN: {:?}, SESSEND_OVERRIDE: {=bool:?}, BVALID_OVERRIDE: {=bool:?}, AVALID_OVERRIDE: {=bool:?}, VBUSVALID_OVERRIDE: {=bool:?}, VBUSVALID_SEL: {:?}, VBUS_SOURCE_SEL: {:?}, ID_OVERRIDE_EN: {:?}, ID_OVERRIDE: {=bool:?}, EXT_ID_OVERRIDE_EN: {:?}, EXT_VBUS_OVERRIDE_EN: {:?}, VBUSVALID_TO_B: {:?}, VBUSVALID_PWRUP_CMPS: {:?}, DISCHARGE_VBUS: {:?} }}",
+            self.VBUSVALID_THRESH(),
+            self.VBUS_OVERRIDE_EN(),
+            self.SESSEND_OVERRIDE(),
+            self.BVALID_OVERRIDE(),
+            self.AVALID_OVERRIDE(),
+            self.VBUSVALID_OVERRIDE(),
+            self.VBUSVALID_SEL(),
+            self.VBUS_SOURCE_SEL(),
+            self.ID_OVERRIDE_EN(),
+            self.ID_OVERRIDE(),
+            self.EXT_ID_OVERRIDE_EN(),
+            self.EXT_VBUS_OVERRIDE_EN(),
+            self.VBUSVALID_TO_B(),
+            self.VBUSVALID_PWRUP_CMPS(),
+            self.DISCHARGE_VBUS()
+        )
+    }
+}
+#[doc = "VBUS Detect."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_VBUS_DETECT_CLR(pub u32);
+impl USB1_VBUS_DETECT_CLR {
+    #[doc = "VBUS Comparator Threshold."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_THRESH(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0x07;
+        val as u8
+    }
+    #[doc = "VBUS Comparator Threshold."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_THRESH(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 0usize)) | (((val as u32) & 0x07) << 0usize);
+    }
+    #[doc = "VBUS Detect Signal Local Override Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_OVERRIDE_EN(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS Detect Signal Local Override Enable."]
+    #[inline(always)]
+    pub const fn set_VBUS_OVERRIDE_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Override Value for SESSEND."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SESSEND_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for SESSEND."]
+    #[inline(always)]
+    pub const fn set_SESSEND_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "Override Value for B-Device Session Valid."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BVALID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for B-Device Session Valid."]
+    #[inline(always)]
+    pub const fn set_BVALID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+    #[doc = "Override Value for A-Device Session Valid."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AVALID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 6usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for A-Device Session Valid."]
+    #[inline(always)]
+    pub const fn set_AVALID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val as u32) & 0x01) << 6usize);
+    }
+    #[doc = "Override Value for the VBUS_VALID Signal."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 7usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for the VBUS_VALID Signal."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val as u32) & 0x01) << 7usize);
+    }
+    #[doc = "VBUS_VALID Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_SEL(&self) -> bool {
+        let val = (self.0 >> 8usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS_VALID Selection."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_SEL(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val as u32) & 0x01) << 8usize);
+    }
+    #[doc = "VBUS_VALID Source Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_SOURCE_SEL(&self) -> u8 {
+        let val = (self.0 >> 9usize) & 0x03;
+        val as u8
+    }
+    #[doc = "VBUS_VALID Source Selection."]
+    #[inline(always)]
+    pub const fn set_VBUS_SOURCE_SEL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 9usize)) | (((val as u32) & 0x03) << 9usize);
+    }
+    #[doc = "Enable Local ID Pin Status Override."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ID_OVERRIDE_EN(&self) -> bool {
+        let val = (self.0 >> 11usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Local ID Pin Status Override."]
+    #[inline(always)]
+    pub const fn set_ID_OVERRIDE_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val as u32) & 0x01) << 11usize);
+    }
+    #[doc = "ID Pin Status Local Override."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "ID Pin Status Local Override."]
+    #[inline(always)]
+    pub const fn set_ID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "External ID Override Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EXT_ID_OVERRIDE_EN(&self) -> bool {
+        let val = (self.0 >> 13usize) & 0x01;
+        val != 0
+    }
+    #[doc = "External ID Override Enable."]
+    #[inline(always)]
+    pub const fn set_EXT_ID_OVERRIDE_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val as u32) & 0x01) << 13usize);
+    }
+    #[doc = "External VBUS Override Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EXT_VBUS_OVERRIDE_EN(&self) -> bool {
+        let val = (self.0 >> 14usize) & 0x01;
+        val != 0
+    }
+    #[doc = "External VBUS Override Enable."]
+    #[inline(always)]
+    pub const fn set_EXT_VBUS_OVERRIDE_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 14usize)) | (((val as u32) & 0x01) << 14usize);
+    }
+    #[doc = "VBUS_VALID Comparator Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_TO_B(&self) -> bool {
+        let val = (self.0 >> 18usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS_VALID Comparator Selection."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_TO_B(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    }
+    #[doc = "VBUS_VALID Comparator Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_PWRUP_CMPS(&self) -> u8 {
+        let val = (self.0 >> 20usize) & 0x07;
+        val as u8
+    }
+    #[doc = "VBUS_VALID Comparator Enable."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_PWRUP_CMPS(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 20usize)) | (((val as u32) & 0x07) << 20usize);
+    }
+    #[doc = "VBUS Discharge Resistor."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DISCHARGE_VBUS(&self) -> bool {
+        let val = (self.0 >> 26usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS Discharge Resistor."]
+    #[inline(always)]
+    pub const fn set_DISCHARGE_VBUS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 26usize)) | (((val as u32) & 0x01) << 26usize);
+    }
+}
+impl Default for USB1_VBUS_DETECT_CLR {
+    #[inline(always)]
+    fn default() -> USB1_VBUS_DETECT_CLR {
+        USB1_VBUS_DETECT_CLR(0)
+    }
+}
+impl core::fmt::Debug for USB1_VBUS_DETECT_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_VBUS_DETECT_CLR")
+            .field("VBUSVALID_THRESH", &self.VBUSVALID_THRESH())
+            .field("VBUS_OVERRIDE_EN", &self.VBUS_OVERRIDE_EN())
+            .field("SESSEND_OVERRIDE", &self.SESSEND_OVERRIDE())
+            .field("BVALID_OVERRIDE", &self.BVALID_OVERRIDE())
+            .field("AVALID_OVERRIDE", &self.AVALID_OVERRIDE())
+            .field("VBUSVALID_OVERRIDE", &self.VBUSVALID_OVERRIDE())
+            .field("VBUSVALID_SEL", &self.VBUSVALID_SEL())
+            .field("VBUS_SOURCE_SEL", &self.VBUS_SOURCE_SEL())
+            .field("ID_OVERRIDE_EN", &self.ID_OVERRIDE_EN())
+            .field("ID_OVERRIDE", &self.ID_OVERRIDE())
+            .field("EXT_ID_OVERRIDE_EN", &self.EXT_ID_OVERRIDE_EN())
+            .field("EXT_VBUS_OVERRIDE_EN", &self.EXT_VBUS_OVERRIDE_EN())
+            .field("VBUSVALID_TO_B", &self.VBUSVALID_TO_B())
+            .field("VBUSVALID_PWRUP_CMPS", &self.VBUSVALID_PWRUP_CMPS())
+            .field("DISCHARGE_VBUS", &self.DISCHARGE_VBUS())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_VBUS_DETECT_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_VBUS_DETECT_CLR {{ VBUSVALID_THRESH: {=u8:?}, VBUS_OVERRIDE_EN: {=bool:?}, SESSEND_OVERRIDE: {=bool:?}, BVALID_OVERRIDE: {=bool:?}, AVALID_OVERRIDE: {=bool:?}, VBUSVALID_OVERRIDE: {=bool:?}, VBUSVALID_SEL: {=bool:?}, VBUS_SOURCE_SEL: {=u8:?}, ID_OVERRIDE_EN: {=bool:?}, ID_OVERRIDE: {=bool:?}, EXT_ID_OVERRIDE_EN: {=bool:?}, EXT_VBUS_OVERRIDE_EN: {=bool:?}, VBUSVALID_TO_B: {=bool:?}, VBUSVALID_PWRUP_CMPS: {=u8:?}, DISCHARGE_VBUS: {=bool:?} }}",
+            self.VBUSVALID_THRESH(),
+            self.VBUS_OVERRIDE_EN(),
+            self.SESSEND_OVERRIDE(),
+            self.BVALID_OVERRIDE(),
+            self.AVALID_OVERRIDE(),
+            self.VBUSVALID_OVERRIDE(),
+            self.VBUSVALID_SEL(),
+            self.VBUS_SOURCE_SEL(),
+            self.ID_OVERRIDE_EN(),
+            self.ID_OVERRIDE(),
+            self.EXT_ID_OVERRIDE_EN(),
+            self.EXT_VBUS_OVERRIDE_EN(),
+            self.VBUSVALID_TO_B(),
+            self.VBUSVALID_PWRUP_CMPS(),
+            self.DISCHARGE_VBUS()
+        )
+    }
+}
+#[doc = "VBUS Detect."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_VBUS_DETECT_SET(pub u32);
+impl USB1_VBUS_DETECT_SET {
+    #[doc = "VBUS Comparator Threshold."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_THRESH(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0x07;
+        val as u8
+    }
+    #[doc = "VBUS Comparator Threshold."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_THRESH(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 0usize)) | (((val as u32) & 0x07) << 0usize);
+    }
+    #[doc = "VBUS Detect Signal Local Override Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_OVERRIDE_EN(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS Detect Signal Local Override Enable."]
+    #[inline(always)]
+    pub const fn set_VBUS_OVERRIDE_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Override Value for SESSEND."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SESSEND_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for SESSEND."]
+    #[inline(always)]
+    pub const fn set_SESSEND_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "Override Value for B-Device Session Valid."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BVALID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for B-Device Session Valid."]
+    #[inline(always)]
+    pub const fn set_BVALID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+    #[doc = "Override Value for A-Device Session Valid."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AVALID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 6usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for A-Device Session Valid."]
+    #[inline(always)]
+    pub const fn set_AVALID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val as u32) & 0x01) << 6usize);
+    }
+    #[doc = "Override Value for the VBUS_VALID Signal."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 7usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for the VBUS_VALID Signal."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val as u32) & 0x01) << 7usize);
+    }
+    #[doc = "VBUS_VALID Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_SEL(&self) -> bool {
+        let val = (self.0 >> 8usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS_VALID Selection."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_SEL(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val as u32) & 0x01) << 8usize);
+    }
+    #[doc = "VBUS_VALID Source Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_SOURCE_SEL(&self) -> u8 {
+        let val = (self.0 >> 9usize) & 0x03;
+        val as u8
+    }
+    #[doc = "VBUS_VALID Source Selection."]
+    #[inline(always)]
+    pub const fn set_VBUS_SOURCE_SEL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 9usize)) | (((val as u32) & 0x03) << 9usize);
+    }
+    #[doc = "Enable Local ID Pin Status Override."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ID_OVERRIDE_EN(&self) -> bool {
+        let val = (self.0 >> 11usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Local ID Pin Status Override."]
+    #[inline(always)]
+    pub const fn set_ID_OVERRIDE_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val as u32) & 0x01) << 11usize);
+    }
+    #[doc = "ID Pin Status Local Override."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "ID Pin Status Local Override."]
+    #[inline(always)]
+    pub const fn set_ID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "External ID Override Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EXT_ID_OVERRIDE_EN(&self) -> bool {
+        let val = (self.0 >> 13usize) & 0x01;
+        val != 0
+    }
+    #[doc = "External ID Override Enable."]
+    #[inline(always)]
+    pub const fn set_EXT_ID_OVERRIDE_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val as u32) & 0x01) << 13usize);
+    }
+    #[doc = "External VBUS Override Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EXT_VBUS_OVERRIDE_EN(&self) -> bool {
+        let val = (self.0 >> 14usize) & 0x01;
+        val != 0
+    }
+    #[doc = "External VBUS Override Enable."]
+    #[inline(always)]
+    pub const fn set_EXT_VBUS_OVERRIDE_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 14usize)) | (((val as u32) & 0x01) << 14usize);
+    }
+    #[doc = "VBUS_VALID Comparator Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_TO_B(&self) -> bool {
+        let val = (self.0 >> 18usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS_VALID Comparator Selection."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_TO_B(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    }
+    #[doc = "VBUS_VALID Comparator Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_PWRUP_CMPS(&self) -> u8 {
+        let val = (self.0 >> 20usize) & 0x07;
+        val as u8
+    }
+    #[doc = "VBUS_VALID Comparator Enable."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_PWRUP_CMPS(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 20usize)) | (((val as u32) & 0x07) << 20usize);
+    }
+    #[doc = "VBUS Discharge Resistor."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DISCHARGE_VBUS(&self) -> bool {
+        let val = (self.0 >> 26usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS Discharge Resistor."]
+    #[inline(always)]
+    pub const fn set_DISCHARGE_VBUS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 26usize)) | (((val as u32) & 0x01) << 26usize);
+    }
+}
+impl Default for USB1_VBUS_DETECT_SET {
+    #[inline(always)]
+    fn default() -> USB1_VBUS_DETECT_SET {
+        USB1_VBUS_DETECT_SET(0)
+    }
+}
+impl core::fmt::Debug for USB1_VBUS_DETECT_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_VBUS_DETECT_SET")
+            .field("VBUSVALID_THRESH", &self.VBUSVALID_THRESH())
+            .field("VBUS_OVERRIDE_EN", &self.VBUS_OVERRIDE_EN())
+            .field("SESSEND_OVERRIDE", &self.SESSEND_OVERRIDE())
+            .field("BVALID_OVERRIDE", &self.BVALID_OVERRIDE())
+            .field("AVALID_OVERRIDE", &self.AVALID_OVERRIDE())
+            .field("VBUSVALID_OVERRIDE", &self.VBUSVALID_OVERRIDE())
+            .field("VBUSVALID_SEL", &self.VBUSVALID_SEL())
+            .field("VBUS_SOURCE_SEL", &self.VBUS_SOURCE_SEL())
+            .field("ID_OVERRIDE_EN", &self.ID_OVERRIDE_EN())
+            .field("ID_OVERRIDE", &self.ID_OVERRIDE())
+            .field("EXT_ID_OVERRIDE_EN", &self.EXT_ID_OVERRIDE_EN())
+            .field("EXT_VBUS_OVERRIDE_EN", &self.EXT_VBUS_OVERRIDE_EN())
+            .field("VBUSVALID_TO_B", &self.VBUSVALID_TO_B())
+            .field("VBUSVALID_PWRUP_CMPS", &self.VBUSVALID_PWRUP_CMPS())
+            .field("DISCHARGE_VBUS", &self.DISCHARGE_VBUS())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_VBUS_DETECT_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_VBUS_DETECT_SET {{ VBUSVALID_THRESH: {=u8:?}, VBUS_OVERRIDE_EN: {=bool:?}, SESSEND_OVERRIDE: {=bool:?}, BVALID_OVERRIDE: {=bool:?}, AVALID_OVERRIDE: {=bool:?}, VBUSVALID_OVERRIDE: {=bool:?}, VBUSVALID_SEL: {=bool:?}, VBUS_SOURCE_SEL: {=u8:?}, ID_OVERRIDE_EN: {=bool:?}, ID_OVERRIDE: {=bool:?}, EXT_ID_OVERRIDE_EN: {=bool:?}, EXT_VBUS_OVERRIDE_EN: {=bool:?}, VBUSVALID_TO_B: {=bool:?}, VBUSVALID_PWRUP_CMPS: {=u8:?}, DISCHARGE_VBUS: {=bool:?} }}",
+            self.VBUSVALID_THRESH(),
+            self.VBUS_OVERRIDE_EN(),
+            self.SESSEND_OVERRIDE(),
+            self.BVALID_OVERRIDE(),
+            self.AVALID_OVERRIDE(),
+            self.VBUSVALID_OVERRIDE(),
+            self.VBUSVALID_SEL(),
+            self.VBUS_SOURCE_SEL(),
+            self.ID_OVERRIDE_EN(),
+            self.ID_OVERRIDE(),
+            self.EXT_ID_OVERRIDE_EN(),
+            self.EXT_VBUS_OVERRIDE_EN(),
+            self.VBUSVALID_TO_B(),
+            self.VBUSVALID_PWRUP_CMPS(),
+            self.DISCHARGE_VBUS()
+        )
+    }
+}
+#[doc = "VBUS Detect."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_VBUS_DETECT_TOG(pub u32);
+impl USB1_VBUS_DETECT_TOG {
+    #[doc = "VBUS Comparator Threshold."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_THRESH(&self) -> u8 {
+        let val = (self.0 >> 0usize) & 0x07;
+        val as u8
+    }
+    #[doc = "VBUS Comparator Threshold."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_THRESH(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 0usize)) | (((val as u32) & 0x07) << 0usize);
+    }
+    #[doc = "VBUS Detect Signal Local Override Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_OVERRIDE_EN(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS Detect Signal Local Override Enable."]
+    #[inline(always)]
+    pub const fn set_VBUS_OVERRIDE_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "Override Value for SESSEND."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SESSEND_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for SESSEND."]
+    #[inline(always)]
+    pub const fn set_SESSEND_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "Override Value for B-Device Session Valid."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BVALID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for B-Device Session Valid."]
+    #[inline(always)]
+    pub const fn set_BVALID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+    #[doc = "Override Value for A-Device Session Valid."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AVALID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 6usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for A-Device Session Valid."]
+    #[inline(always)]
+    pub const fn set_AVALID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 6usize)) | (((val as u32) & 0x01) << 6usize);
+    }
+    #[doc = "Override Value for the VBUS_VALID Signal."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 7usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Override Value for the VBUS_VALID Signal."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 7usize)) | (((val as u32) & 0x01) << 7usize);
+    }
+    #[doc = "VBUS_VALID Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_SEL(&self) -> bool {
+        let val = (self.0 >> 8usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS_VALID Selection."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_SEL(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 8usize)) | (((val as u32) & 0x01) << 8usize);
+    }
+    #[doc = "VBUS_VALID Source Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_SOURCE_SEL(&self) -> u8 {
+        let val = (self.0 >> 9usize) & 0x03;
+        val as u8
+    }
+    #[doc = "VBUS_VALID Source Selection."]
+    #[inline(always)]
+    pub const fn set_VBUS_SOURCE_SEL(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x03 << 9usize)) | (((val as u32) & 0x03) << 9usize);
+    }
+    #[doc = "Enable Local ID Pin Status Override."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ID_OVERRIDE_EN(&self) -> bool {
+        let val = (self.0 >> 11usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Enable Local ID Pin Status Override."]
+    #[inline(always)]
+    pub const fn set_ID_OVERRIDE_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 11usize)) | (((val as u32) & 0x01) << 11usize);
+    }
+    #[doc = "ID Pin Status Local Override."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn ID_OVERRIDE(&self) -> bool {
+        let val = (self.0 >> 12usize) & 0x01;
+        val != 0
+    }
+    #[doc = "ID Pin Status Local Override."]
+    #[inline(always)]
+    pub const fn set_ID_OVERRIDE(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 12usize)) | (((val as u32) & 0x01) << 12usize);
+    }
+    #[doc = "External ID Override Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EXT_ID_OVERRIDE_EN(&self) -> bool {
+        let val = (self.0 >> 13usize) & 0x01;
+        val != 0
+    }
+    #[doc = "External ID Override Enable."]
+    #[inline(always)]
+    pub const fn set_EXT_ID_OVERRIDE_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 13usize)) | (((val as u32) & 0x01) << 13usize);
+    }
+    #[doc = "External VBUS Override Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EXT_VBUS_OVERRIDE_EN(&self) -> bool {
+        let val = (self.0 >> 14usize) & 0x01;
+        val != 0
+    }
+    #[doc = "External VBUS Override Enable."]
+    #[inline(always)]
+    pub const fn set_EXT_VBUS_OVERRIDE_EN(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 14usize)) | (((val as u32) & 0x01) << 14usize);
+    }
+    #[doc = "VBUS_VALID Comparator Selection."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_TO_B(&self) -> bool {
+        let val = (self.0 >> 18usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS_VALID Comparator Selection."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_TO_B(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 18usize)) | (((val as u32) & 0x01) << 18usize);
+    }
+    #[doc = "VBUS_VALID Comparator Enable."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUSVALID_PWRUP_CMPS(&self) -> u8 {
+        let val = (self.0 >> 20usize) & 0x07;
+        val as u8
+    }
+    #[doc = "VBUS_VALID Comparator Enable."]
+    #[inline(always)]
+    pub const fn set_VBUSVALID_PWRUP_CMPS(&mut self, val: u8) {
+        self.0 = (self.0 & !(0x07 << 20usize)) | (((val as u32) & 0x07) << 20usize);
+    }
+    #[doc = "VBUS Discharge Resistor."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn DISCHARGE_VBUS(&self) -> bool {
+        let val = (self.0 >> 26usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS Discharge Resistor."]
+    #[inline(always)]
+    pub const fn set_DISCHARGE_VBUS(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 26usize)) | (((val as u32) & 0x01) << 26usize);
+    }
+}
+impl Default for USB1_VBUS_DETECT_TOG {
+    #[inline(always)]
+    fn default() -> USB1_VBUS_DETECT_TOG {
+        USB1_VBUS_DETECT_TOG(0)
+    }
+}
+impl core::fmt::Debug for USB1_VBUS_DETECT_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_VBUS_DETECT_TOG")
+            .field("VBUSVALID_THRESH", &self.VBUSVALID_THRESH())
+            .field("VBUS_OVERRIDE_EN", &self.VBUS_OVERRIDE_EN())
+            .field("SESSEND_OVERRIDE", &self.SESSEND_OVERRIDE())
+            .field("BVALID_OVERRIDE", &self.BVALID_OVERRIDE())
+            .field("AVALID_OVERRIDE", &self.AVALID_OVERRIDE())
+            .field("VBUSVALID_OVERRIDE", &self.VBUSVALID_OVERRIDE())
+            .field("VBUSVALID_SEL", &self.VBUSVALID_SEL())
+            .field("VBUS_SOURCE_SEL", &self.VBUS_SOURCE_SEL())
+            .field("ID_OVERRIDE_EN", &self.ID_OVERRIDE_EN())
+            .field("ID_OVERRIDE", &self.ID_OVERRIDE())
+            .field("EXT_ID_OVERRIDE_EN", &self.EXT_ID_OVERRIDE_EN())
+            .field("EXT_VBUS_OVERRIDE_EN", &self.EXT_VBUS_OVERRIDE_EN())
+            .field("VBUSVALID_TO_B", &self.VBUSVALID_TO_B())
+            .field("VBUSVALID_PWRUP_CMPS", &self.VBUSVALID_PWRUP_CMPS())
+            .field("DISCHARGE_VBUS", &self.DISCHARGE_VBUS())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_VBUS_DETECT_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_VBUS_DETECT_TOG {{ VBUSVALID_THRESH: {=u8:?}, VBUS_OVERRIDE_EN: {=bool:?}, SESSEND_OVERRIDE: {=bool:?}, BVALID_OVERRIDE: {=bool:?}, AVALID_OVERRIDE: {=bool:?}, VBUSVALID_OVERRIDE: {=bool:?}, VBUSVALID_SEL: {=bool:?}, VBUS_SOURCE_SEL: {=u8:?}, ID_OVERRIDE_EN: {=bool:?}, ID_OVERRIDE: {=bool:?}, EXT_ID_OVERRIDE_EN: {=bool:?}, EXT_VBUS_OVERRIDE_EN: {=bool:?}, VBUSVALID_TO_B: {=bool:?}, VBUSVALID_PWRUP_CMPS: {=u8:?}, DISCHARGE_VBUS: {=bool:?} }}",
+            self.VBUSVALID_THRESH(),
+            self.VBUS_OVERRIDE_EN(),
+            self.SESSEND_OVERRIDE(),
+            self.BVALID_OVERRIDE(),
+            self.AVALID_OVERRIDE(),
+            self.VBUSVALID_OVERRIDE(),
+            self.VBUSVALID_SEL(),
+            self.VBUS_SOURCE_SEL(),
+            self.ID_OVERRIDE_EN(),
+            self.ID_OVERRIDE(),
+            self.EXT_ID_OVERRIDE_EN(),
+            self.EXT_VBUS_OVERRIDE_EN(),
+            self.VBUSVALID_TO_B(),
+            self.VBUSVALID_PWRUP_CMPS(),
+            self.DISCHARGE_VBUS()
+        )
+    }
+}
+#[doc = "VBUS Detect Status."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_VBUS_DET_STAT(pub u32);
+impl USB1_VBUS_DET_STAT {
+    #[doc = "Session End Indicator."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SESSEND(&self) -> SESSEND {
+        let val = (self.0 >> 0usize) & 0x01;
+        SESSEND::from_bits(val as u8)
+    }
+    #[doc = "Session End Indicator."]
+    #[inline(always)]
+    pub const fn set_SESSEND(&mut self, val: SESSEND) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val.to_bits() as u32) & 0x01) << 0usize);
+    }
+    #[doc = "B-Device Session Valid Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BVALID(&self) -> BVALID {
+        let val = (self.0 >> 1usize) & 0x01;
+        BVALID::from_bits(val as u8)
+    }
+    #[doc = "B-Device Session Valid Status."]
+    #[inline(always)]
+    pub const fn set_BVALID(&mut self, val: BVALID) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val.to_bits() as u32) & 0x01) << 1usize);
+    }
+    #[doc = "A-Device Session Valid Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AVALID(&self) -> AVALID {
+        let val = (self.0 >> 2usize) & 0x01;
+        AVALID::from_bits(val as u8)
+    }
+    #[doc = "A-Device Session Valid Status."]
+    #[inline(always)]
+    pub const fn set_AVALID(&mut self, val: AVALID) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val.to_bits() as u32) & 0x01) << 2usize);
+    }
+    #[doc = "VBUS Voltage Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_VALID(&self) -> VBUS_VALID {
+        let val = (self.0 >> 3usize) & 0x01;
+        VBUS_VALID::from_bits(val as u8)
+    }
+    #[doc = "VBUS Voltage Status."]
+    #[inline(always)]
+    pub const fn set_VBUS_VALID(&mut self, val: VBUS_VALID) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val.to_bits() as u32) & 0x01) << 3usize);
+    }
+    #[doc = "VBUS_VALID_3V Detector Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_VALID_3V(&self) -> VBUS_VALID_3V {
+        let val = (self.0 >> 4usize) & 0x01;
+        VBUS_VALID_3V::from_bits(val as u8)
+    }
+    #[doc = "VBUS_VALID_3V Detector Status."]
+    #[inline(always)]
+    pub const fn set_VBUS_VALID_3V(&mut self, val: VBUS_VALID_3V) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val.to_bits() as u32) & 0x01) << 4usize);
+    }
+    #[doc = "OTG ID External Override Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EXT_ID(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG ID External Override Status."]
+    #[inline(always)]
+    pub const fn set_EXT_ID(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+}
+impl Default for USB1_VBUS_DET_STAT {
+    #[inline(always)]
+    fn default() -> USB1_VBUS_DET_STAT {
+        USB1_VBUS_DET_STAT(0)
+    }
+}
+impl core::fmt::Debug for USB1_VBUS_DET_STAT {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_VBUS_DET_STAT")
+            .field("SESSEND", &self.SESSEND())
+            .field("BVALID", &self.BVALID())
+            .field("AVALID", &self.AVALID())
+            .field("VBUS_VALID", &self.VBUS_VALID())
+            .field("VBUS_VALID_3V", &self.VBUS_VALID_3V())
+            .field("EXT_ID", &self.EXT_ID())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_VBUS_DET_STAT {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_VBUS_DET_STAT {{ SESSEND: {:?}, BVALID: {:?}, AVALID: {:?}, VBUS_VALID: {:?}, VBUS_VALID_3V: {:?}, EXT_ID: {=bool:?} }}",
+            self.SESSEND(),
+            self.BVALID(),
+            self.AVALID(),
+            self.VBUS_VALID(),
+            self.VBUS_VALID_3V(),
+            self.EXT_ID()
+        )
+    }
+}
+#[doc = "VBUS Detect Status."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_VBUS_DET_STAT_CLR(pub u32);
+impl USB1_VBUS_DET_STAT_CLR {
+    #[doc = "Session End Indicator."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SESSEND(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Session End Indicator."]
+    #[inline(always)]
+    pub const fn set_SESSEND(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "B-Device Session Valid Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BVALID(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "B-Device Session Valid Status."]
+    #[inline(always)]
+    pub const fn set_BVALID(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "A-Device Session Valid Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AVALID(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "A-Device Session Valid Status."]
+    #[inline(always)]
+    pub const fn set_AVALID(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "VBUS Voltage Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_VALID(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS Voltage Status."]
+    #[inline(always)]
+    pub const fn set_VBUS_VALID(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "VBUS_VALID_3V Detector Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_VALID_3V(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS_VALID_3V Detector Status."]
+    #[inline(always)]
+    pub const fn set_VBUS_VALID_3V(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "OTG ID External Override Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EXT_ID(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG ID External Override Status."]
+    #[inline(always)]
+    pub const fn set_EXT_ID(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+}
+impl Default for USB1_VBUS_DET_STAT_CLR {
+    #[inline(always)]
+    fn default() -> USB1_VBUS_DET_STAT_CLR {
+        USB1_VBUS_DET_STAT_CLR(0)
+    }
+}
+impl core::fmt::Debug for USB1_VBUS_DET_STAT_CLR {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_VBUS_DET_STAT_CLR")
+            .field("SESSEND", &self.SESSEND())
+            .field("BVALID", &self.BVALID())
+            .field("AVALID", &self.AVALID())
+            .field("VBUS_VALID", &self.VBUS_VALID())
+            .field("VBUS_VALID_3V", &self.VBUS_VALID_3V())
+            .field("EXT_ID", &self.EXT_ID())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_VBUS_DET_STAT_CLR {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_VBUS_DET_STAT_CLR {{ SESSEND: {=bool:?}, BVALID: {=bool:?}, AVALID: {=bool:?}, VBUS_VALID: {=bool:?}, VBUS_VALID_3V: {=bool:?}, EXT_ID: {=bool:?} }}",
+            self.SESSEND(),
+            self.BVALID(),
+            self.AVALID(),
+            self.VBUS_VALID(),
+            self.VBUS_VALID_3V(),
+            self.EXT_ID()
+        )
+    }
+}
+#[doc = "VBUS Detect Status."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_VBUS_DET_STAT_SET(pub u32);
+impl USB1_VBUS_DET_STAT_SET {
+    #[doc = "Session End Indicator."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SESSEND(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Session End Indicator."]
+    #[inline(always)]
+    pub const fn set_SESSEND(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "B-Device Session Valid Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BVALID(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "B-Device Session Valid Status."]
+    #[inline(always)]
+    pub const fn set_BVALID(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "A-Device Session Valid Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AVALID(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "A-Device Session Valid Status."]
+    #[inline(always)]
+    pub const fn set_AVALID(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "VBUS Voltage Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_VALID(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS Voltage Status."]
+    #[inline(always)]
+    pub const fn set_VBUS_VALID(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "VBUS_VALID_3V Detector Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_VALID_3V(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS_VALID_3V Detector Status."]
+    #[inline(always)]
+    pub const fn set_VBUS_VALID_3V(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "OTG ID External Override Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EXT_ID(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG ID External Override Status."]
+    #[inline(always)]
+    pub const fn set_EXT_ID(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+}
+impl Default for USB1_VBUS_DET_STAT_SET {
+    #[inline(always)]
+    fn default() -> USB1_VBUS_DET_STAT_SET {
+        USB1_VBUS_DET_STAT_SET(0)
+    }
+}
+impl core::fmt::Debug for USB1_VBUS_DET_STAT_SET {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_VBUS_DET_STAT_SET")
+            .field("SESSEND", &self.SESSEND())
+            .field("BVALID", &self.BVALID())
+            .field("AVALID", &self.AVALID())
+            .field("VBUS_VALID", &self.VBUS_VALID())
+            .field("VBUS_VALID_3V", &self.VBUS_VALID_3V())
+            .field("EXT_ID", &self.EXT_ID())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_VBUS_DET_STAT_SET {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_VBUS_DET_STAT_SET {{ SESSEND: {=bool:?}, BVALID: {=bool:?}, AVALID: {=bool:?}, VBUS_VALID: {=bool:?}, VBUS_VALID_3V: {=bool:?}, EXT_ID: {=bool:?} }}",
+            self.SESSEND(),
+            self.BVALID(),
+            self.AVALID(),
+            self.VBUS_VALID(),
+            self.VBUS_VALID_3V(),
+            self.EXT_ID()
+        )
+    }
+}
+#[doc = "VBUS Detect Status."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct USB1_VBUS_DET_STAT_TOG(pub u32);
+impl USB1_VBUS_DET_STAT_TOG {
+    #[doc = "Session End Indicator."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn SESSEND(&self) -> bool {
+        let val = (self.0 >> 0usize) & 0x01;
+        val != 0
+    }
+    #[doc = "Session End Indicator."]
+    #[inline(always)]
+    pub const fn set_SESSEND(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
+    }
+    #[doc = "B-Device Session Valid Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn BVALID(&self) -> bool {
+        let val = (self.0 >> 1usize) & 0x01;
+        val != 0
+    }
+    #[doc = "B-Device Session Valid Status."]
+    #[inline(always)]
+    pub const fn set_BVALID(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
+    }
+    #[doc = "A-Device Session Valid Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn AVALID(&self) -> bool {
+        let val = (self.0 >> 2usize) & 0x01;
+        val != 0
+    }
+    #[doc = "A-Device Session Valid Status."]
+    #[inline(always)]
+    pub const fn set_AVALID(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+    }
+    #[doc = "VBUS Voltage Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_VALID(&self) -> bool {
+        let val = (self.0 >> 3usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS Voltage Status."]
+    #[inline(always)]
+    pub const fn set_VBUS_VALID(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
+    }
+    #[doc = "VBUS_VALID_3V Detector Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn VBUS_VALID_3V(&self) -> bool {
+        let val = (self.0 >> 4usize) & 0x01;
+        val != 0
+    }
+    #[doc = "VBUS_VALID_3V Detector Status."]
+    #[inline(always)]
+    pub const fn set_VBUS_VALID_3V(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
+    }
+    #[doc = "OTG ID External Override Status."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn EXT_ID(&self) -> bool {
+        let val = (self.0 >> 5usize) & 0x01;
+        val != 0
+    }
+    #[doc = "OTG ID External Override Status."]
+    #[inline(always)]
+    pub const fn set_EXT_ID(&mut self, val: bool) {
+        self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+    }
+}
+impl Default for USB1_VBUS_DET_STAT_TOG {
+    #[inline(always)]
+    fn default() -> USB1_VBUS_DET_STAT_TOG {
+        USB1_VBUS_DET_STAT_TOG(0)
+    }
+}
+impl core::fmt::Debug for USB1_VBUS_DET_STAT_TOG {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("USB1_VBUS_DET_STAT_TOG")
+            .field("SESSEND", &self.SESSEND())
+            .field("BVALID", &self.BVALID())
+            .field("AVALID", &self.AVALID())
+            .field("VBUS_VALID", &self.VBUS_VALID())
+            .field("VBUS_VALID_3V", &self.VBUS_VALID_3V())
+            .field("EXT_ID", &self.EXT_ID())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for USB1_VBUS_DET_STAT_TOG {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "USB1_VBUS_DET_STAT_TOG {{ SESSEND: {=bool:?}, BVALID: {=bool:?}, AVALID: {=bool:?}, VBUS_VALID: {=bool:?}, VBUS_VALID_3V: {=bool:?}, EXT_ID: {=bool:?} }}",
+            self.SESSEND(),
+            self.BVALID(),
+            self.AVALID(),
+            self.VBUS_VALID(),
+            self.VBUS_VALID_3V(),
+            self.EXT_ID()
+        )
+    }
+}
+#[doc = "Version."]
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct VERSION(pub u32);
+impl VERSION {
+    #[doc = "Step."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn STEP(&self) -> u16 {
+        let val = (self.0 >> 0usize) & 0xffff;
+        val as u16
+    }
+    #[doc = "Step."]
+    #[inline(always)]
+    pub const fn set_STEP(&mut self, val: u16) {
+        self.0 = (self.0 & !(0xffff << 0usize)) | (((val as u32) & 0xffff) << 0usize);
+    }
+    #[doc = "Minor."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn MINOR(&self) -> u8 {
+        let val = (self.0 >> 16usize) & 0xff;
+        val as u8
+    }
+    #[doc = "Minor."]
+    #[inline(always)]
+    pub const fn set_MINOR(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 16usize)) | (((val as u32) & 0xff) << 16usize);
+    }
+    #[doc = "Major."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn MAJOR(&self) -> u8 {
+        let val = (self.0 >> 24usize) & 0xff;
+        val as u8
+    }
+    #[doc = "Major."]
+    #[inline(always)]
+    pub const fn set_MAJOR(&mut self, val: u8) {
+        self.0 = (self.0 & !(0xff << 24usize)) | (((val as u32) & 0xff) << 24usize);
+    }
+}
+impl Default for VERSION {
+    #[inline(always)]
+    fn default() -> VERSION {
+        VERSION(0)
+    }
+}
+impl core::fmt::Debug for VERSION {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("VERSION")
+            .field("STEP", &self.STEP())
+            .field("MINOR", &self.MINOR())
+            .field("MAJOR", &self.MAJOR())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for VERSION {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "VERSION {{ STEP: {=u16:?}, MINOR: {=u8:?}, MAJOR: {=u8:?} }}",
+            self.STEP(),
+            self.MINOR(),
+            self.MAJOR()
+        )
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum AUTORESUME_EN {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl AUTORESUME_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> AUTORESUME_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for AUTORESUME_EN {
+    #[inline(always)]
+    fn from(val: u8) -> AUTORESUME_EN {
+        AUTORESUME_EN::from_bits(val)
+    }
+}
+impl From<AUTORESUME_EN> for u8 {
+    #[inline(always)]
+    fn from(val: AUTORESUME_EN) -> u8 {
+        AUTORESUME_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum AVALID {
+    #[doc = "Below threshold."]
+    AVALID_LO = 0x0,
+    #[doc = "Above threshold."]
+    AVALID_HI = 0x01,
+}
+impl AVALID {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> AVALID {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for AVALID {
+    #[inline(always)]
+    fn from(val: u8) -> AVALID {
+        AVALID::from_bits(val)
+    }
+}
+impl From<AVALID> for u8 {
+    #[inline(always)]
+    fn from(val: AVALID) -> u8 {
+        AVALID::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum BVALID {
+    #[doc = "Below threshold."]
+    BVALID_LO = 0x0,
+    #[doc = "Above threshold."]
+    BVALID_HI = 0x01,
+}
+impl BVALID {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> BVALID {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for BVALID {
+    #[inline(always)]
+    fn from(val: u8) -> BVALID {
+        BVALID::from_bits(val)
+    }
+}
+impl From<BVALID> for u8 {
+    #[inline(always)]
+    fn from(val: BVALID) -> u8 {
+        BVALID::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CHK_CHRG_B {
+    #[doc = "Enable."]
+    BC_CHRGDET_ENABLE = 0x0,
+    #[doc = "Disable."]
+    BC_CHRGDET_DISABLE = 0x01,
+}
+impl CHK_CHRG_B {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> CHK_CHRG_B {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for CHK_CHRG_B {
+    #[inline(always)]
+    fn from(val: u8) -> CHK_CHRG_B {
+        CHK_CHRG_B::from_bits(val)
+    }
+}
+impl From<CHK_CHRG_B> for u8 {
+    #[inline(always)]
+    fn from(val: CHK_CHRG_B) -> u8 {
+        CHK_CHRG_B::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CHK_CONTACT {
+    #[doc = "Disable."]
+    BC_DCD_DISABLE = 0x0,
+    #[doc = "Enable."]
+    BC_DCD_ENABLE = 0x01,
+}
+impl CHK_CONTACT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> CHK_CONTACT {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for CHK_CONTACT {
+    #[inline(always)]
+    fn from(val: u8) -> CHK_CONTACT {
+        CHK_CONTACT::from_bits(val)
+    }
+}
+impl From<CHK_CONTACT> for u8 {
+    #[inline(always)]
+    fn from(val: CHK_CONTACT) -> u8 {
+        CHK_CONTACT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CHRG_DETECTED {
+    #[doc = "SDP detected."]
+    SDP_DETECT = 0x0,
+    #[doc = "Charging port detected."]
+    CHRG_PORT_DETECT = 0x01,
+}
+impl CHRG_DETECTED {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> CHRG_DETECTED {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for CHRG_DETECTED {
+    #[inline(always)]
+    fn from(val: u8) -> CHRG_DETECTED {
+        CHRG_DETECTED::from_bits(val)
+    }
+}
+impl From<CHRG_DETECTED> for u8 {
+    #[inline(always)]
+    fn from(val: CHRG_DETECTED) -> u8 {
+        CHRG_DETECTED::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CLKGATE {
+    #[doc = "Run clocks."]
+    RUN_CLOCKS = 0x0,
+    #[doc = "Gate clocks."]
+    GATE_CLOCKS = 0x01,
+}
+impl CLKGATE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> CLKGATE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for CLKGATE {
+    #[inline(always)]
+    fn from(val: u8) -> CLKGATE {
+        CLKGATE::from_bits(val)
+    }
+}
+impl From<CLKGATE> for u8 {
+    #[inline(always)]
+    fn from(val: CLKGATE) -> u8 {
+        CLKGATE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DCDSEL {
+    #[doc = "Fields in USB1_CHRG_DETECT."]
+    CHRGDET_CTRL = 0x0,
+    #[doc = "Fields and state machines in the USBHSDCD module."]
+    USBHSDCD_CTRL = 0x01,
+}
+impl DCDSEL {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> DCDSEL {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for DCDSEL {
+    #[inline(always)]
+    fn from(val: u8) -> DCDSEL {
+        DCDSEL::from_bits(val)
+    }
+}
+impl From<DCDSEL> for u8 {
+    #[inline(always)]
+    fn from(val: DCDSEL) -> u8 {
+        DCDSEL::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DETECT_SEC {
+    #[doc = "Disable."]
+    BC_SECDET_DISABLE = 0x0,
+    #[doc = "Enable."]
+    BC_SECDET_ENABLE = 0x01,
+}
+impl DETECT_SEC {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> DETECT_SEC {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for DETECT_SEC {
+    #[inline(always)]
+    fn from(val: u8) -> DETECT_SEC {
+        DETECT_SEC::from_bits(val)
+    }
+}
+impl From<DETECT_SEC> for u8 {
+    #[inline(always)]
+    fn from(val: DETECT_SEC) -> u8 {
+        DETECT_SEC::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DEVPLUGIN_POLARITY {
+    #[doc = "Plugged in."]
+    PLUGGED_IN = 0x0,
+    #[doc = "Unplugged."]
+    UNPLUGGED = 0x01,
+}
+impl DEVPLUGIN_POLARITY {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> DEVPLUGIN_POLARITY {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for DEVPLUGIN_POLARITY {
+    #[inline(always)]
+    fn from(val: u8) -> DEVPLUGIN_POLARITY {
+        DEVPLUGIN_POLARITY::from_bits(val)
+    }
+}
+impl From<DEVPLUGIN_POLARITY> for u8 {
+    #[inline(always)]
+    fn from(val: DEVPLUGIN_POLARITY) -> u8 {
+        DEVPLUGIN_POLARITY::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DEVPLUGIN_STATUS {
+    #[doc = "No attachment detected."]
+    NO_CABLE = 0x0,
+    #[doc = "Cable attachment detected."]
+    CABLE_ATTACH = 0x01,
+}
+impl DEVPLUGIN_STATUS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> DEVPLUGIN_STATUS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for DEVPLUGIN_STATUS {
+    #[inline(always)]
+    fn from(val: u8) -> DEVPLUGIN_STATUS {
+        DEVPLUGIN_STATUS::from_bits(val)
+    }
+}
+impl From<DEVPLUGIN_STATUS> for u8 {
+    #[inline(always)]
+    fn from(val: DEVPLUGIN_STATUS) -> u8 {
+        DEVPLUGIN_STATUS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DEV_PULLDOWN {
+    #[doc = "Disable."]
+    DEV_PULLDOWN_DIS = 0x0,
+    #[doc = "Enable."]
+    DEV_PULLDOWN_EN = 0x01,
+}
+impl DEV_PULLDOWN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> DEV_PULLDOWN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for DEV_PULLDOWN {
+    #[inline(always)]
+    fn from(val: u8) -> DEV_PULLDOWN {
+        DEV_PULLDOWN::from_bits(val)
+    }
+}
+impl From<DEV_PULLDOWN> for u8 {
+    #[inline(always)]
+    fn from(val: DEV_PULLDOWN) -> u8 {
+        DEV_PULLDOWN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DISCHARGE_VBUS {
+    #[doc = "Disable."]
+    VBUS_DCHG_OFF = 0x0,
+    #[doc = "Enable."]
+    VBUS_DCHG_ON = 0x01,
+}
+impl DISCHARGE_VBUS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> DISCHARGE_VBUS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for DISCHARGE_VBUS {
+    #[inline(always)]
+    fn from(val: u8) -> DISCHARGE_VBUS {
+        DISCHARGE_VBUS::from_bits(val)
+    }
+}
+impl From<DISCHARGE_VBUS> for u8 {
+    #[inline(always)]
+    fn from(val: DISCHARGE_VBUS) -> u8 {
+        DISCHARGE_VBUS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DISCONADJ {
+    #[doc = "0.56875 V."]
+    DISCON_TRIM_NOM = 0x0,
+    #[doc = "0.55000 V."]
+    DISCON_TRIM_LO = 0x01,
+    #[doc = "0.58125 V."]
+    DISCON_TRIM_MEDHI = 0x02,
+    #[doc = "0.60000 V."]
+    DISCON_TRIM_HI = 0x03,
+    _RESERVED_4 = 0x04,
+    _RESERVED_5 = 0x05,
+    _RESERVED_6 = 0x06,
+    _RESERVED_7 = 0x07,
+}
+impl DISCONADJ {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> DISCONADJ {
+        unsafe { core::mem::transmute(val & 0x07) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for DISCONADJ {
+    #[inline(always)]
+    fn from(val: u8) -> DISCONADJ {
+        DISCONADJ::from_bits(val)
+    }
+}
+impl From<DISCONADJ> for u8 {
+    #[inline(always)]
+    fn from(val: DISCONADJ) -> u8 {
+        DISCONADJ::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DIV_SEL_OVERRIDE {
+    #[doc = "TRIM_OVERRIDE_EN."]
+    USE_TRIM0_PLLDIV = 0x0,
+    #[doc = "PLL_SIC."]
+    USE_PLL_SIC_PLLDIV = 0x01,
+}
+impl DIV_SEL_OVERRIDE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> DIV_SEL_OVERRIDE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for DIV_SEL_OVERRIDE {
+    #[inline(always)]
+    fn from(val: u8) -> DIV_SEL_OVERRIDE {
+        DIV_SEL_OVERRIDE::from_bits(val)
+    }
+}
+impl From<DIV_SEL_OVERRIDE> for u8 {
+    #[inline(always)]
+    fn from(val: DIV_SEL_OVERRIDE) -> u8 {
+        DIV_SEL_OVERRIDE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DM_STATE {
+    #[doc = "USB_DM pin voltage is <= 0.8 V."]
+    DM_SERX_LO = 0x0,
+    #[doc = "USB_DM pin voltage is >= 2.0 V."]
+    DM_SERX_HI = 0x01,
+}
+impl DM_STATE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> DM_STATE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for DM_STATE {
+    #[inline(always)]
+    fn from(val: u8) -> DM_STATE {
+        DM_STATE::from_bits(val)
+    }
+}
+impl From<DM_STATE> for u8 {
+    #[inline(always)]
+    fn from(val: DM_STATE) -> u8 {
+        DM_STATE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DP_STATE {
+    #[doc = "USB_DP pin voltage is <= 0.8 V."]
+    DP_SERX_LO = 0x0,
+    #[doc = "USB_DP pin voltage is >= 2.0 V."]
+    DP_SERX_HI = 0x01,
+}
+impl DP_STATE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> DP_STATE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for DP_STATE {
+    #[inline(always)]
+    fn from(val: u8) -> DP_STATE {
+        DP_STATE::from_bits(val)
+    }
+}
+impl From<DP_STATE> for u8 {
+    #[inline(always)]
+    fn from(val: DP_STATE) -> u8 {
+        DP_STATE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum D_CAL {
+    #[doc = "Maximum current, approximately 19% above nominal."]
+    MAX_CURRENT = 0x0,
+    _RESERVED_1 = 0x01,
+    _RESERVED_2 = 0x02,
+    _RESERVED_3 = 0x03,
+    _RESERVED_4 = 0x04,
+    _RESERVED_5 = 0x05,
+    _RESERVED_6 = 0x06,
+    #[doc = "Nominal."]
+    NOMINAL = 0x07,
+    _RESERVED_8 = 0x08,
+    _RESERVED_9 = 0x09,
+    _RESERVED_a = 0x0a,
+    _RESERVED_b = 0x0b,
+    _RESERVED_c = 0x0c,
+    _RESERVED_d = 0x0d,
+    _RESERVED_e = 0x0e,
+    #[doc = "Minimum current, approximately 19% below nominal."]
+    MIN_CURRENT = 0x0f,
+}
+impl D_CAL {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> D_CAL {
+        unsafe { core::mem::transmute(val & 0x0f) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for D_CAL {
+    #[inline(always)]
+    fn from(val: u8) -> D_CAL {
+        D_CAL::from_bits(val)
+    }
+}
+impl From<D_CAL> for u8 {
+    #[inline(always)]
+    fn from(val: D_CAL) -> u8 {
+        D_CAL::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENAUTOCLR_CLKGATE {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENAUTOCLR_CLKGATE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENAUTOCLR_CLKGATE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENAUTOCLR_CLKGATE {
+    #[inline(always)]
+    fn from(val: u8) -> ENAUTOCLR_CLKGATE {
+        ENAUTOCLR_CLKGATE::from_bits(val)
+    }
+}
+impl From<ENAUTOCLR_CLKGATE> for u8 {
+    #[inline(always)]
+    fn from(val: ENAUTOCLR_CLKGATE) -> u8 {
+        ENAUTOCLR_CLKGATE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENAUTOCLR_PHY_PWD {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENAUTOCLR_PHY_PWD {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENAUTOCLR_PHY_PWD {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENAUTOCLR_PHY_PWD {
+    #[inline(always)]
+    fn from(val: u8) -> ENAUTOCLR_PHY_PWD {
+        ENAUTOCLR_PHY_PWD::from_bits(val)
+    }
+}
+impl From<ENAUTOCLR_PHY_PWD> for u8 {
+    #[inline(always)]
+    fn from(val: ENAUTOCLR_PHY_PWD) -> u8 {
+        ENAUTOCLR_PHY_PWD::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENDEVPLUGINDETECT {
+    #[doc = "Disable."]
+    PLUGIN_DISABLE = 0x0,
+    #[doc = "Enable."]
+    PLUGIN_ENABLE = 0x01,
+}
+impl ENDEVPLUGINDETECT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENDEVPLUGINDETECT {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENDEVPLUGINDETECT {
+    #[inline(always)]
+    fn from(val: u8) -> ENDEVPLUGINDETECT {
+        ENDEVPLUGINDETECT::from_bits(val)
+    }
+}
+impl From<ENDEVPLUGINDETECT> for u8 {
+    #[inline(always)]
+    fn from(val: ENDEVPLUGINDETECT) -> u8 {
+        ENDEVPLUGINDETECT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENHOSTDISCONDETECT {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENHOSTDISCONDETECT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENHOSTDISCONDETECT {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENHOSTDISCONDETECT {
+    #[inline(always)]
+    fn from(val: u8) -> ENHOSTDISCONDETECT {
+        ENHOSTDISCONDETECT::from_bits(val)
+    }
+}
+impl From<ENHOSTDISCONDETECT> for u8 {
+    #[inline(always)]
+    fn from(val: ENHOSTDISCONDETECT) -> u8 {
+        ENHOSTDISCONDETECT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENHSTPULLDOWN {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+    _RESERVED_2 = 0x02,
+    _RESERVED_3 = 0x03,
+}
+impl ENHSTPULLDOWN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENHSTPULLDOWN {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENHSTPULLDOWN {
+    #[inline(always)]
+    fn from(val: u8) -> ENHSTPULLDOWN {
+        ENHSTPULLDOWN::from_bits(val)
+    }
+}
+impl From<ENHSTPULLDOWN> for u8 {
+    #[inline(always)]
+    fn from(val: ENHSTPULLDOWN) -> u8 {
+        ENHSTPULLDOWN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENIRQDEVPLUGIN {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENIRQDEVPLUGIN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENIRQDEVPLUGIN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENIRQDEVPLUGIN {
+    #[inline(always)]
+    fn from(val: u8) -> ENIRQDEVPLUGIN {
+        ENIRQDEVPLUGIN::from_bits(val)
+    }
+}
+impl From<ENIRQDEVPLUGIN> for u8 {
+    #[inline(always)]
+    fn from(val: ENIRQDEVPLUGIN) -> u8 {
+        ENIRQDEVPLUGIN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENIRQHOSTDISCON {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENIRQHOSTDISCON {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENIRQHOSTDISCON {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENIRQHOSTDISCON {
+    #[inline(always)]
+    fn from(val: u8) -> ENIRQHOSTDISCON {
+        ENIRQHOSTDISCON::from_bits(val)
+    }
+}
+impl From<ENIRQHOSTDISCON> for u8 {
+    #[inline(always)]
+    fn from(val: ENIRQHOSTDISCON) -> u8 {
+        ENIRQHOSTDISCON::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENIRQRESUMEDETECT {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENIRQRESUMEDETECT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENIRQRESUMEDETECT {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENIRQRESUMEDETECT {
+    #[inline(always)]
+    fn from(val: u8) -> ENIRQRESUMEDETECT {
+        ENIRQRESUMEDETECT::from_bits(val)
+    }
+}
+impl From<ENIRQRESUMEDETECT> for u8 {
+    #[inline(always)]
+    fn from(val: ENIRQRESUMEDETECT) -> u8 {
+        ENIRQRESUMEDETECT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENIRQWAKEUP {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENIRQWAKEUP {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENIRQWAKEUP {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENIRQWAKEUP {
+    #[inline(always)]
+    fn from(val: u8) -> ENIRQWAKEUP {
+        ENIRQWAKEUP::from_bits(val)
+    }
+}
+impl From<ENIRQWAKEUP> for u8 {
+    #[inline(always)]
+    fn from(val: ENIRQWAKEUP) -> u8 {
+        ENIRQWAKEUP::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENOTGIDDETECT {
+    #[doc = "Disable."]
+    ID_DET_DISABLE = 0x0,
+    #[doc = "Enable."]
+    ID_DET_ENABLE = 0x01,
+}
+impl ENOTGIDDETECT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENOTGIDDETECT {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENOTGIDDETECT {
+    #[inline(always)]
+    fn from(val: u8) -> ENOTGIDDETECT {
+        ENOTGIDDETECT::from_bits(val)
+    }
+}
+impl From<ENOTGIDDETECT> for u8 {
+    #[inline(always)]
+    fn from(val: ENOTGIDDETECT) -> u8 {
+        ENOTGIDDETECT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENOTG_ID_CHG_IRQ {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENOTG_ID_CHG_IRQ {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENOTG_ID_CHG_IRQ {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENOTG_ID_CHG_IRQ {
+    #[inline(always)]
+    fn from(val: u8) -> ENOTG_ID_CHG_IRQ {
+        ENOTG_ID_CHG_IRQ::from_bits(val)
+    }
+}
+impl From<ENOTG_ID_CHG_IRQ> for u8 {
+    #[inline(always)]
+    fn from(val: ENOTG_ID_CHG_IRQ) -> u8 {
+        ENOTG_ID_CHG_IRQ::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENUTMILEVEL2 {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENUTMILEVEL2 {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENUTMILEVEL2 {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENUTMILEVEL2 {
+    #[inline(always)]
+    fn from(val: u8) -> ENUTMILEVEL2 {
+        ENUTMILEVEL2::from_bits(val)
+    }
+}
+impl From<ENUTMILEVEL2> for u8 {
+    #[inline(always)]
+    fn from(val: ENUTMILEVEL2) -> u8 {
+        ENUTMILEVEL2::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENUTMILEVEL3 {
+    #[doc = "Disable."]
+    DISABLE = 0x0,
+    #[doc = "Enable."]
+    ENABLE = 0x01,
+}
+impl ENUTMILEVEL3 {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENUTMILEVEL3 {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENUTMILEVEL3 {
+    #[inline(always)]
+    fn from(val: u8) -> ENUTMILEVEL3 {
+        ENUTMILEVEL3::from_bits(val)
+    }
+}
+impl From<ENUTMILEVEL3> for u8 {
+    #[inline(always)]
+    fn from(val: ENUTMILEVEL3) -> u8 {
+        ENUTMILEVEL3::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ENVADJ {
+    #[doc = "0.1000 V."]
+    ENV_TRIM_NOM = 0x0,
+    #[doc = "0.1125 V."]
+    ENV_TRIM_MEDHI = 0x01,
+    #[doc = "0.1250 V."]
+    ENV_TRIM_HI = 0x02,
+    #[doc = "0.0875 V."]
+    ENV_TRIM_LO = 0x03,
+    _RESERVED_4 = 0x04,
+    _RESERVED_5 = 0x05,
+    _RESERVED_6 = 0x06,
+    _RESERVED_7 = 0x07,
+}
+impl ENVADJ {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ENVADJ {
+        unsafe { core::mem::transmute(val & 0x07) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ENVADJ {
+    #[inline(always)]
+    fn from(val: u8) -> ENVADJ {
+        ENVADJ::from_bits(val)
+    }
+}
+impl From<ENVADJ> for u8 {
+    #[inline(always)]
+    fn from(val: ENVADJ) -> u8 {
+        ENVADJ::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum EN_B {
+    #[doc = "Enable."]
+    BC_ENABLE = 0x0,
+    #[doc = "Disable."]
+    BC_DISABLE = 0x01,
+}
+impl EN_B {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> EN_B {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for EN_B {
+    #[inline(always)]
+    fn from(val: u8) -> EN_B {
+        EN_B::from_bits(val)
+    }
+}
+impl From<EN_B> for u8 {
+    #[inline(always)]
+    fn from(val: EN_B) -> u8 {
+        EN_B::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum EXT_ID_OVERRIDE_EN {
+    #[doc = "Internal detector or local override."]
+    USE_PHY_ID = 0x0,
+    #[doc = "External ID signal value."]
+    USE_EXT_ID = 0x01,
+}
+impl EXT_ID_OVERRIDE_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> EXT_ID_OVERRIDE_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for EXT_ID_OVERRIDE_EN {
+    #[inline(always)]
+    fn from(val: u8) -> EXT_ID_OVERRIDE_EN {
+        EXT_ID_OVERRIDE_EN::from_bits(val)
+    }
+}
+impl From<EXT_ID_OVERRIDE_EN> for u8 {
+    #[inline(always)]
+    fn from(val: EXT_ID_OVERRIDE_EN) -> u8 {
+        EXT_ID_OVERRIDE_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum EXT_VBUS_OVERRIDE_EN {
+    #[doc = "Internal detector or local override."]
+    USE_PHY_VBUS = 0x0,
+    #[doc = "External VBUS_VALID value."]
+    USB_EXT_VBUS = 0x01,
+}
+impl EXT_VBUS_OVERRIDE_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> EXT_VBUS_OVERRIDE_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for EXT_VBUS_OVERRIDE_EN {
+    #[inline(always)]
+    fn from(val: u8) -> EXT_VBUS_OVERRIDE_EN {
+        EXT_VBUS_OVERRIDE_EN::from_bits(val)
+    }
+}
+impl From<EXT_VBUS_OVERRIDE_EN> for u8 {
+    #[inline(always)]
+    fn from(val: EXT_VBUS_OVERRIDE_EN) -> u8 {
+        EXT_VBUS_OVERRIDE_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum HOSTDISCONDETECT_IRQ {
+    #[doc = "Connected."]
+    CONNECTED = 0x0,
+    #[doc = "Disconnected."]
+    DISCONNECTED = 0x01,
+}
+impl HOSTDISCONDETECT_IRQ {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> HOSTDISCONDETECT_IRQ {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for HOSTDISCONDETECT_IRQ {
+    #[inline(always)]
+    fn from(val: u8) -> HOSTDISCONDETECT_IRQ {
+        HOSTDISCONDETECT_IRQ::from_bits(val)
+    }
+}
+impl From<HOSTDISCONDETECT_IRQ> for u8 {
+    #[inline(always)]
+    fn from(val: HOSTDISCONDETECT_IRQ) -> u8 {
+        HOSTDISCONDETECT_IRQ::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum HOSTDISCONDETECT_STATUS {
+    #[doc = "Not detected."]
+    NO_DISCONNECT = 0x0,
+    #[doc = "Detected."]
+    DISCONNECT = 0x01,
+}
+impl HOSTDISCONDETECT_STATUS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> HOSTDISCONDETECT_STATUS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for HOSTDISCONDETECT_STATUS {
+    #[inline(always)]
+    fn from(val: u8) -> HOSTDISCONDETECT_STATUS {
+        HOSTDISCONDETECT_STATUS::from_bits(val)
+    }
+}
+impl From<HOSTDISCONDETECT_STATUS> for u8 {
+    #[inline(always)]
+    fn from(val: HOSTDISCONDETECT_STATUS) -> u8 {
+        HOSTDISCONDETECT_STATUS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum HSTPULLDOWN {
+    #[doc = "Disconnect."]
+    DISCONNECT = 0x0,
+    #[doc = "Connect."]
+    CONNECT = 0x01,
+    _RESERVED_2 = 0x02,
+    _RESERVED_3 = 0x03,
+}
+impl HSTPULLDOWN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> HSTPULLDOWN {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for HSTPULLDOWN {
+    #[inline(always)]
+    fn from(val: u8) -> HSTPULLDOWN {
+        HSTPULLDOWN::from_bits(val)
+    }
+}
+impl From<HSTPULLDOWN> for u8 {
+    #[inline(always)]
+    fn from(val: HSTPULLDOWN) -> u8 {
+        HSTPULLDOWN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ID_OVERRIDE_EN {
+    #[doc = "Use ID pin detector or external override."]
+    NO_PHY_ID_OVERRIDE = 0x0,
+    #[doc = "Allow local override of ID pin detection status."]
+    USE_PHY_ID_OVERRIDE = 0x01,
+}
+impl ID_OVERRIDE_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> ID_OVERRIDE_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for ID_OVERRIDE_EN {
+    #[inline(always)]
+    fn from(val: u8) -> ID_OVERRIDE_EN {
+        ID_OVERRIDE_EN::from_bits(val)
+    }
+}
+impl From<ID_OVERRIDE_EN> for u8 {
+    #[inline(always)]
+    fn from(val: ID_OVERRIDE_EN) -> u8 {
+        ID_OVERRIDE_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LVI_EN {
+    #[doc = "Disable."]
+    LVI_3V_DISABLE = 0x0,
+    #[doc = "Enable."]
+    LVI_3V_ENABLE = 0x01,
+}
+impl LVI_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> LVI_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for LVI_EN {
+    #[inline(always)]
+    fn from(val: u8) -> LVI_EN {
+        LVI_EN::from_bits(val)
+    }
+}
+impl From<LVI_EN> for u8 {
+    #[inline(always)]
+    fn from(val: LVI_EN) -> u8 {
+        LVI_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum MISC2_CONTROL0 {
+    #[doc = "Power up PLL."]
+    PLL_ON_SUSPEND = 0x0,
+    #[doc = "Power down PLL."]
+    PLL_OFF_SUSPEND = 0x01,
+}
+impl MISC2_CONTROL0 {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> MISC2_CONTROL0 {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for MISC2_CONTROL0 {
+    #[inline(always)]
+    fn from(val: u8) -> MISC2_CONTROL0 {
+        MISC2_CONTROL0::from_bits(val)
+    }
+}
+impl From<MISC2_CONTROL0> for u8 {
+    #[inline(always)]
+    fn from(val: MISC2_CONTROL0) -> u8 {
+        MISC2_CONTROL0::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OK_STATUS_3V {
+    #[doc = "Not powered."]
+    POWER_3_1P8_OK = 0x0,
+    #[doc = "Powered."]
+    POWER_3_1P8_BAD = 0x01,
+}
+impl OK_STATUS_3V {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> OK_STATUS_3V {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for OK_STATUS_3V {
+    #[inline(always)]
+    fn from(val: u8) -> OK_STATUS_3V {
+        OK_STATUS_3V::from_bits(val)
+    }
+}
+impl From<OK_STATUS_3V> for u8 {
+    #[inline(always)]
+    fn from(val: OK_STATUS_3V) -> u8 {
+        OK_STATUS_3V::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OTGID_STATUS {
+    #[doc = "Host."]
+    ID_HOST = 0x0,
+    #[doc = "Device."]
+    ID_DEVICE = 0x01,
+}
+impl OTGID_STATUS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> OTGID_STATUS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for OTGID_STATUS {
+    #[inline(always)]
+    fn from(val: u8) -> OTGID_STATUS {
+        OTGID_STATUS::from_bits(val)
+    }
+}
+impl From<OTGID_STATUS> for u8 {
+    #[inline(always)]
+    fn from(val: OTGID_STATUS) -> u8 {
+        OTGID_STATUS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OTG_ID_CHG_IRQ {
+    #[doc = "No ID change interrupt."]
+    No_ID_CHG_IRQ = 0x0,
+    #[doc = "ID change interrupt."]
+    ID_CHG_IRQ = 0x01,
+}
+impl OTG_ID_CHG_IRQ {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> OTG_ID_CHG_IRQ {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for OTG_ID_CHG_IRQ {
+    #[inline(always)]
+    fn from(val: u8) -> OTG_ID_CHG_IRQ {
+        OTG_ID_CHG_IRQ::from_bits(val)
+    }
+}
+impl From<OTG_ID_CHG_IRQ> for u8 {
+    #[inline(always)]
+    fn from(val: OTG_ID_CHG_IRQ) -> u8 {
+        OTG_ID_CHG_IRQ::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OTG_ID_VALUE {
+    #[doc = "Host."]
+    ID_HOST = 0x0,
+    #[doc = "Device."]
+    ID_DEVICE = 0x01,
+}
+impl OTG_ID_VALUE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> OTG_ID_VALUE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for OTG_ID_VALUE {
+    #[inline(always)]
+    fn from(val: u8) -> OTG_ID_VALUE {
+        OTG_ID_VALUE::from_bits(val)
+    }
+}
+impl From<OTG_ID_VALUE> for u8 {
+    #[inline(always)]
+    fn from(val: OTG_ID_VALUE) -> u8 {
+        OTG_ID_VALUE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PFD0_CLKGATE {
+    #[doc = "Enable."]
+    PFD0_CLK_EN = 0x0,
+    #[doc = "Disable."]
+    PFD0_CLK_DIS = 0x01,
+}
+impl PFD0_CLKGATE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PFD0_CLKGATE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PFD0_CLKGATE {
+    #[inline(always)]
+    fn from(val: u8) -> PFD0_CLKGATE {
+        PFD0_CLKGATE::from_bits(val)
+    }
+}
+impl From<PFD0_CLKGATE> for u8 {
+    #[inline(always)]
+    fn from(val: PFD0_CLKGATE) -> u8 {
+        PFD0_CLKGATE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PFD0_STABLE {
+    #[doc = "Not stable."]
+    NOT_STABLE = 0x0,
+    #[doc = "Stable."]
+    STABLE = 0x01,
+}
+impl PFD0_STABLE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PFD0_STABLE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PFD0_STABLE {
+    #[inline(always)]
+    fn from(val: u8) -> PFD0_STABLE {
+        PFD0_STABLE::from_bits(val)
+    }
+}
+impl From<PFD0_STABLE> for u8 {
+    #[inline(always)]
+    fn from(val: PFD0_STABLE) -> u8 {
+        PFD0_STABLE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PFD_CLK_SEL {
+    #[doc = "USB1PFDCLK = USB PLL reference clock."]
+    PFD_CLK_BYPASS = 0x0,
+    #[doc = "USB1PFDCLK = pfd_clk / 4."]
+    PFD_CLK_DIV_4 = 0x01,
+    #[doc = "USB1PFDCLK frequency = pfd_clk / 2."]
+    PFD_CLK_DIV_2 = 0x02,
+    #[doc = "USB1PFDCLK = pfd_clk."]
+    PFD_CLK_DIV_1 = 0x03,
+}
+impl PFD_CLK_SEL {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PFD_CLK_SEL {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PFD_CLK_SEL {
+    #[inline(always)]
+    fn from(val: u8) -> PFD_CLK_SEL {
+        PFD_CLK_SEL::from_bits(val)
+    }
+}
+impl From<PFD_CLK_SEL> for u8 {
+    #[inline(always)]
+    fn from(val: PFD_CLK_SEL) -> u8 {
+        PFD_CLK_SEL::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PLL_BYPASS {
+    #[doc = "480 MHz output clock."]
+    PLL_NO_BYPASS = 0x0,
+    #[doc = "Input reference clock."]
+    PLL_BYPASS = 0x01,
+}
+impl PLL_BYPASS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PLL_BYPASS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PLL_BYPASS {
+    #[inline(always)]
+    fn from(val: u8) -> PLL_BYPASS {
+        PLL_BYPASS::from_bits(val)
+    }
+}
+impl From<PLL_BYPASS> for u8 {
+    #[inline(always)]
+    fn from(val: PLL_BYPASS) -> u8 {
+        PLL_BYPASS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PLL_DIV_SEL {
+    #[doc = "Configure for a 32 MHz input clock (divide by 15)."]
+    PLL_DIV_15 = 0x0,
+    #[doc = "Configure for a 30 MHz input clock (divide by 16)."]
+    PLL_DIV_16 = 0x01,
+    #[doc = "Configure for a 24 MHz input clock (divide by 20)."]
+    PLL_DIV_20 = 0x02,
+    _RESERVED_3 = 0x03,
+    #[doc = "Configure for a 20 MHz input clock (divide by 24)."]
+    PLL_DIV_24 = 0x04,
+    #[doc = "Configure for a 19.2 MHz input clock (divide by 25)."]
+    PLL_DIV_25 = 0x05,
+    #[doc = "Configure for a 16 MHz input clock (divide by 30)."]
+    PLL_DIV_30 = 0x06,
+    #[doc = "Configure for a 12 MHz input clock (divide by 40)."]
+    PLL_DIV_32 = 0x07,
+}
+impl PLL_DIV_SEL {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PLL_DIV_SEL {
+        unsafe { core::mem::transmute(val & 0x07) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PLL_DIV_SEL {
+    #[inline(always)]
+    fn from(val: u8) -> PLL_DIV_SEL {
+        PLL_DIV_SEL::from_bits(val)
+    }
+}
+impl From<PLL_DIV_SEL> for u8 {
+    #[inline(always)]
+    fn from(val: PLL_DIV_SEL) -> u8 {
+        PLL_DIV_SEL::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PLL_ENABLE {
+    #[doc = "Disable."]
+    PLL_OUT_DISABLE = 0x0,
+    #[doc = "Enable."]
+    PLL_OUT_ENABLE = 0x01,
+}
+impl PLL_ENABLE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PLL_ENABLE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PLL_ENABLE {
+    #[inline(always)]
+    fn from(val: u8) -> PLL_ENABLE {
+        PLL_ENABLE::from_bits(val)
+    }
+}
+impl From<PLL_ENABLE> for u8 {
+    #[inline(always)]
+    fn from(val: PLL_ENABLE) -> u8 {
+        PLL_ENABLE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PLL_EN_USB_CLKS {
+    #[doc = "Disable."]
+    PLL_MP_DISABLE = 0x0,
+    #[doc = "Enable."]
+    PLL_MP_ENABLE = 0x01,
+}
+impl PLL_EN_USB_CLKS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PLL_EN_USB_CLKS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PLL_EN_USB_CLKS {
+    #[inline(always)]
+    fn from(val: u8) -> PLL_EN_USB_CLKS {
+        PLL_EN_USB_CLKS::from_bits(val)
+    }
+}
+impl From<PLL_EN_USB_CLKS> for u8 {
+    #[inline(always)]
+    fn from(val: PLL_EN_USB_CLKS) -> u8 {
+        PLL_EN_USB_CLKS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PLL_LOCK {
+    #[doc = "Not locked."]
+    PLL_NOT_LOCKED = 0x0,
+    #[doc = "Locked."]
+    PLL_LOCKED = 0x01,
+}
+impl PLL_LOCK {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PLL_LOCK {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PLL_LOCK {
+    #[inline(always)]
+    fn from(val: u8) -> PLL_LOCK {
+        PLL_LOCK::from_bits(val)
+    }
+}
+impl From<PLL_LOCK> for u8 {
+    #[inline(always)]
+    fn from(val: PLL_LOCK) -> u8 {
+        PLL_LOCK::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PLL_POWER {
+    #[doc = "Power down."]
+    PLL_FORCE_PWD = 0x0,
+    #[doc = "Allow powerup."]
+    PLL_ALLOW_POWERUP = 0x01,
+}
+impl PLL_POWER {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PLL_POWER {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PLL_POWER {
+    #[inline(always)]
+    fn from(val: u8) -> PLL_POWER {
+        PLL_POWER::from_bits(val)
+    }
+}
+impl From<PLL_POWER> for u8 {
+    #[inline(always)]
+    fn from(val: PLL_POWER) -> u8 {
+        PLL_POWER::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PLL_PREDIV {
+    #[doc = "Uses the undivided reference clock for PLL loop."]
+    PREDIV_1 = 0x0,
+    #[doc = "Divides the reference clock by two for PLL loop."]
+    PREDIV_2 = 0x01,
+}
+impl PLL_PREDIV {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PLL_PREDIV {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PLL_PREDIV {
+    #[inline(always)]
+    fn from(val: u8) -> PLL_PREDIV {
+        PLL_PREDIV::from_bits(val)
+    }
+}
+impl From<PLL_PREDIV> for u8 {
+    #[inline(always)]
+    fn from(val: PLL_PREDIV) -> u8 {
+        PLL_PREDIV::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PLL_REG_ENABLE {
+    #[doc = "Disable."]
+    PLL_REG_DISABLE = 0x0,
+    #[doc = "Enable."]
+    PLL_REG_ENABLE = 0x01,
+}
+impl PLL_REG_ENABLE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PLL_REG_ENABLE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PLL_REG_ENABLE {
+    #[inline(always)]
+    fn from(val: u8) -> PLL_REG_ENABLE {
+        PLL_REG_ENABLE::from_bits(val)
+    }
+}
+impl From<PLL_REG_ENABLE> for u8 {
+    #[inline(always)]
+    fn from(val: PLL_REG_ENABLE) -> u8 {
+        PLL_REG_ENABLE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PLUG_CONTACT {
+    #[doc = "Not detected."]
+    NO_DC_DETECTED = 0x0,
+    #[doc = "Detected."]
+    DC_DETECED = 0x01,
+}
+impl PLUG_CONTACT {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PLUG_CONTACT {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PLUG_CONTACT {
+    #[inline(always)]
+    fn from(val: u8) -> PLUG_CONTACT {
+        PLUG_CONTACT::from_bits(val)
+    }
+}
+impl From<PLUG_CONTACT> for u8 {
+    #[inline(always)]
+    fn from(val: PLUG_CONTACT) -> u8 {
+        PLUG_CONTACT::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PULLUP_DP {
+    #[doc = "Disable."]
+    DP_PUE_NORMAL = 0x0,
+    #[doc = "Enable."]
+    DP_PUE_OVERRIDE = 0x01,
+}
+impl PULLUP_DP {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PULLUP_DP {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PULLUP_DP {
+    #[inline(always)]
+    fn from(val: u8) -> PULLUP_DP {
+        PULLUP_DP::from_bits(val)
+    }
+}
+impl From<PULLUP_DP> for u8 {
+    #[inline(always)]
+    fn from(val: PULLUP_DP) -> u8 {
+        PULLUP_DP::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum REFBIAS_PWD {
+    #[doc = "Enable."]
+    REFBIAS_ENABLED = 0x0,
+    #[doc = "Disable or power down."]
+    REFBIAS_PWD = 0x01,
+}
+impl REFBIAS_PWD {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> REFBIAS_PWD {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for REFBIAS_PWD {
+    #[inline(always)]
+    fn from(val: u8) -> REFBIAS_PWD {
+        REFBIAS_PWD::from_bits(val)
+    }
+}
+impl From<REFBIAS_PWD> for u8 {
+    #[inline(always)]
+    fn from(val: REFBIAS_PWD) -> u8 {
+        REFBIAS_PWD::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum REFBIAS_PWD_SEL {
+    #[doc = "PLL_POWER internal state signal."]
+    BIAS_PLLPOWER = 0x0,
+    #[doc = "REFBIAS_PWD."]
+    BIAS_REFBIAS_PWD = 0x01,
+}
+impl REFBIAS_PWD_SEL {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> REFBIAS_PWD_SEL {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for REFBIAS_PWD_SEL {
+    #[inline(always)]
+    fn from(val: u8) -> REFBIAS_PWD_SEL {
+        REFBIAS_PWD_SEL::from_bits(val)
+    }
+}
+impl From<REFBIAS_PWD_SEL> for u8 {
+    #[inline(always)]
+    fn from(val: REFBIAS_PWD_SEL) -> u8 {
+        REFBIAS_PWD_SEL::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RESUMEIRQSTICKY {
+    #[doc = "During the resume or reset state signaling period."]
+    DISABLE = 0x0,
+    #[doc = "Until you write 0 to it."]
+    ENABLE = 0x01,
+}
+impl RESUMEIRQSTICKY {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> RESUMEIRQSTICKY {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for RESUMEIRQSTICKY {
+    #[inline(always)]
+    fn from(val: u8) -> RESUMEIRQSTICKY {
+        RESUMEIRQSTICKY::from_bits(val)
+    }
+}
+impl From<RESUMEIRQSTICKY> for u8 {
+    #[inline(always)]
+    fn from(val: RESUMEIRQSTICKY) -> u8 {
+        RESUMEIRQSTICKY::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RESUME_IRQ {
+    #[doc = "No resume interrupt."]
+    NORESIRQ = 0x0,
+    #[doc = "Resume interrupt."]
+    RESIRQ = 0x01,
+}
+impl RESUME_IRQ {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> RESUME_IRQ {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for RESUME_IRQ {
+    #[inline(always)]
+    fn from(val: u8) -> RESUME_IRQ {
+        RESUME_IRQ::from_bits(val)
+    }
+}
+impl From<RESUME_IRQ> for u8 {
+    #[inline(always)]
+    fn from(val: RESUME_IRQ) -> u8 {
+        RESUME_IRQ::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RXPWD1PT1 {
+    #[doc = "Enable."]
+    FS_RXDIFF_ENABLE = 0x0,
+    #[doc = "Disable or power down."]
+    FS_RXDIFF_PWD = 0x01,
+}
+impl RXPWD1PT1 {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> RXPWD1PT1 {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for RXPWD1PT1 {
+    #[inline(always)]
+    fn from(val: u8) -> RXPWD1PT1 {
+        RXPWD1PT1::from_bits(val)
+    }
+}
+impl From<RXPWD1PT1> for u8 {
+    #[inline(always)]
+    fn from(val: RXPWD1PT1) -> u8 {
+        RXPWD1PT1::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RXPWDDIFF {
+    #[doc = "Enable."]
+    HS_RXDIFF_ENABLE = 0x0,
+    #[doc = "Disable or power down."]
+    HS_RXDIFF_PWD = 0x01,
+}
+impl RXPWDDIFF {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> RXPWDDIFF {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for RXPWDDIFF {
+    #[inline(always)]
+    fn from(val: u8) -> RXPWDDIFF {
+        RXPWDDIFF::from_bits(val)
+    }
+}
+impl From<RXPWDDIFF> for u8 {
+    #[inline(always)]
+    fn from(val: RXPWDDIFF) -> u8 {
+        RXPWDDIFF::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RXPWDENV {
+    #[doc = "Enable."]
+    RX_ENVHD_ENABLE = 0x0,
+    #[doc = "Disable or power down."]
+    RX_ENVHD_PWD = 0x01,
+}
+impl RXPWDENV {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> RXPWDENV {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for RXPWDENV {
+    #[inline(always)]
+    fn from(val: u8) -> RXPWDENV {
+        RXPWDENV::from_bits(val)
+    }
+}
+impl From<RXPWDENV> for u8 {
+    #[inline(always)]
+    fn from(val: RXPWDENV) -> u8 {
+        RXPWDENV::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RXPWDRX {
+    #[doc = "Enable."]
+    RX_BIAS_ENABLE = 0x0,
+    #[doc = "Disable or power down."]
+    RX_BIAS_PWD = 0x01,
+}
+impl RXPWDRX {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> RXPWDRX {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for RXPWDRX {
+    #[inline(always)]
+    fn from(val: u8) -> RXPWDRX {
+        RXPWDRX::from_bits(val)
+    }
+}
+impl From<RXPWDRX> for u8 {
+    #[inline(always)]
+    fn from(val: RXPWDRX) -> u8 {
+        RXPWDRX::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SECDET_DCP {
+    #[doc = "CDP detected."]
+    SECDET_CDP = 0x0,
+    #[doc = "DCP detected."]
+    SECDET_DCP = 0x01,
+}
+impl SECDET_DCP {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> SECDET_DCP {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for SECDET_DCP {
+    #[inline(always)]
+    fn from(val: u8) -> SECDET_DCP {
+        SECDET_DCP::from_bits(val)
+    }
+}
+impl From<SECDET_DCP> for u8 {
+    #[inline(always)]
+    fn from(val: SECDET_DCP) -> u8 {
+        SECDET_DCP::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SESSEND {
+    #[doc = "Above threshold."]
+    SESSEND_LO = 0x0,
+    #[doc = "Below threshold."]
+    SESSEND_HI = 0x01,
+}
+impl SESSEND {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> SESSEND {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for SESSEND {
+    #[inline(always)]
+    fn from(val: u8) -> SESSEND {
+        SESSEND::from_bits(val)
+    }
+}
+impl From<SESSEND> for u8 {
+    #[inline(always)]
+    fn from(val: SESSEND) -> u8 {
+        SESSEND::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SFTRST {
+    #[doc = "Release from reset."]
+    RELEASE_RESET = 0x0,
+    #[doc = "Soft-reset."]
+    SOFT_RESET = 0x01,
+}
+impl SFTRST {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> SFTRST {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for SFTRST {
+    #[inline(always)]
+    fn from(val: u8) -> SFTRST {
+        SFTRST::from_bits(val)
+    }
+}
+impl From<SFTRST> for u8 {
+    #[inline(always)]
+    fn from(val: SFTRST) -> u8 {
+        SFTRST::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TXPWDFS {
+    #[doc = "Provide bias to enable."]
+    FSTX_BIAS_ENABLE = 0x0,
+    #[doc = "Disable or power down."]
+    FSTX_BIAS_PWD = 0x01,
+}
+impl TXPWDFS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> TXPWDFS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for TXPWDFS {
+    #[inline(always)]
+    fn from(val: u8) -> TXPWDFS {
+        TXPWDFS::from_bits(val)
+    }
+}
+impl From<TXPWDFS> for u8 {
+    #[inline(always)]
+    fn from(val: TXPWDFS) -> u8 {
+        TXPWDFS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TXPWDIBIAS {
+    #[doc = "Enable."]
+    IBIAS_ENABLE = 0x0,
+    #[doc = "Disable or power down."]
+    IBIAS_PWD = 0x01,
+}
+impl TXPWDIBIAS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> TXPWDIBIAS {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for TXPWDIBIAS {
+    #[inline(always)]
+    fn from(val: u8) -> TXPWDIBIAS {
+        TXPWDIBIAS::from_bits(val)
+    }
+}
+impl From<TXPWDIBIAS> for u8 {
+    #[inline(always)]
+    fn from(val: TXPWDIBIAS) -> u8 {
+        TXPWDIBIAS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TXPWDV2I {
+    #[doc = "Enable."]
+    V2I_BIAS_ENABLE = 0x0,
+    #[doc = "Disable or power down."]
+    V2I_BIAS_PWD = 0x01,
+}
+impl TXPWDV2I {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> TXPWDV2I {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for TXPWDV2I {
+    #[inline(always)]
+    fn from(val: u8) -> TXPWDV2I {
+        TXPWDV2I::from_bits(val)
+    }
+}
+impl From<TXPWDV2I> for u8 {
+    #[inline(always)]
+    fn from(val: TXPWDV2I) -> u8 {
+        TXPWDV2I::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TX_CAL45DM_OVERRIDE {
+    #[doc = "TRIM_OVERRIDE_EN."]
+    USE_TRIM0_CAL45DN = 0x0,
+    #[doc = "TX."]
+    USE_TX_CAL45DN = 0x01,
+}
+impl TX_CAL45DM_OVERRIDE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> TX_CAL45DM_OVERRIDE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for TX_CAL45DM_OVERRIDE {
+    #[inline(always)]
+    fn from(val: u8) -> TX_CAL45DM_OVERRIDE {
+        TX_CAL45DM_OVERRIDE::from_bits(val)
+    }
+}
+impl From<TX_CAL45DM_OVERRIDE> for u8 {
+    #[inline(always)]
+    fn from(val: TX_CAL45DM_OVERRIDE) -> u8 {
+        TX_CAL45DM_OVERRIDE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TX_CAL45DP_OVERRIDE {
+    #[doc = "TRIM_OVERRIDE_EN."]
+    USE_TRIM0_CAL45DP = 0x0,
+    #[doc = "TX."]
+    USE_TX_CAL45DP = 0x01,
+}
+impl TX_CAL45DP_OVERRIDE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> TX_CAL45DP_OVERRIDE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for TX_CAL45DP_OVERRIDE {
+    #[inline(always)]
+    fn from(val: u8) -> TX_CAL45DP_OVERRIDE {
+        TX_CAL45DP_OVERRIDE::from_bits(val)
+    }
+}
+impl From<TX_CAL45DP_OVERRIDE> for u8 {
+    #[inline(always)]
+    fn from(val: TX_CAL45DP_OVERRIDE) -> u8 {
+        TX_CAL45DP_OVERRIDE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TX_D_CAL_OVERRIDE {
+    #[doc = "TRIM_OVERRIDE_EN."]
+    USE_TRIM0_DCAL = 0x0,
+    #[doc = "TX."]
+    USE_TX_DCAL = 0x01,
+}
+impl TX_D_CAL_OVERRIDE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> TX_D_CAL_OVERRIDE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for TX_D_CAL_OVERRIDE {
+    #[inline(always)]
+    fn from(val: u8) -> TX_D_CAL_OVERRIDE {
+        TX_D_CAL_OVERRIDE::from_bits(val)
+    }
+}
+impl From<TX_D_CAL_OVERRIDE> for u8 {
+    #[inline(always)]
+    fn from(val: TX_D_CAL_OVERRIDE) -> u8 {
+        TX_D_CAL_OVERRIDE::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum USBPHY_TX_D_CAL {
+    #[doc = "Maximum current, approximately 19% above nominal."]
+    MAX_CURRENT = 0x0,
+    _RESERVED_1 = 0x01,
+    _RESERVED_2 = 0x02,
+    _RESERVED_3 = 0x03,
+    _RESERVED_4 = 0x04,
+    _RESERVED_5 = 0x05,
+    _RESERVED_6 = 0x06,
+    #[doc = "Nominal."]
+    NOMINAL = 0x07,
+    _RESERVED_8 = 0x08,
+    _RESERVED_9 = 0x09,
+    _RESERVED_a = 0x0a,
+    _RESERVED_b = 0x0b,
+    _RESERVED_c = 0x0c,
+    _RESERVED_d = 0x0d,
+    _RESERVED_e = 0x0e,
+    #[doc = "Minimum current, approximately 19% below nominal."]
+    MIN_CURRENT = 0x0f,
+}
+impl USBPHY_TX_D_CAL {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> USBPHY_TX_D_CAL {
+        unsafe { core::mem::transmute(val & 0x0f) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for USBPHY_TX_D_CAL {
+    #[inline(always)]
+    fn from(val: u8) -> USBPHY_TX_D_CAL {
+        USBPHY_TX_D_CAL::from_bits(val)
+    }
+}
+impl From<USBPHY_TX_D_CAL> for u8 {
+    #[inline(always)]
+    fn from(val: USBPHY_TX_D_CAL) -> u8 {
+        USBPHY_TX_D_CAL::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum UTMI_SUSPENDM {
+    #[doc = "Not suspended."]
+    NOT_SUSPENDED = 0x0,
+    #[doc = "Suspended."]
+    SUSPENDED = 0x01,
+}
+impl UTMI_SUSPENDM {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> UTMI_SUSPENDM {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for UTMI_SUSPENDM {
+    #[inline(always)]
+    fn from(val: u8) -> UTMI_SUSPENDM {
+        UTMI_SUSPENDM::from_bits(val)
+    }
+}
+impl From<UTMI_SUSPENDM> for u8 {
+    #[inline(always)]
+    fn from(val: UTMI_SUSPENDM) -> u8 {
+        UTMI_SUSPENDM::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum VBUSVALID_PWRUP_CMPS {
+    #[doc = "Disable or power down the VBUS_VALID comparator."]
+    VBUS_VALID_DISABLE = 0x0,
+    #[doc = "Enable the VBUS_VALID comparator."]
+    VBUS_VALID_ENABLE = 0x01,
+    #[doc = "Enable the session valid detector."]
+    SESS_VLD_ENABLE = 0x02,
+    _RESERVED_3 = 0x03,
+    #[doc = "Enable the VBUS_VALID_3V detector."]
+    V3V_ENABLE = 0x04,
+    _RESERVED_5 = 0x05,
+    _RESERVED_6 = 0x06,
+    _RESERVED_7 = 0x07,
+}
+impl VBUSVALID_PWRUP_CMPS {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> VBUSVALID_PWRUP_CMPS {
+        unsafe { core::mem::transmute(val & 0x07) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for VBUSVALID_PWRUP_CMPS {
+    #[inline(always)]
+    fn from(val: u8) -> VBUSVALID_PWRUP_CMPS {
+        VBUSVALID_PWRUP_CMPS::from_bits(val)
+    }
+}
+impl From<VBUSVALID_PWRUP_CMPS> for u8 {
+    #[inline(always)]
+    fn from(val: VBUSVALID_PWRUP_CMPS) -> u8 {
+        VBUSVALID_PWRUP_CMPS::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum VBUSVALID_SEL {
+    #[doc = "VBUS_VALID comparator result."]
+    VBUS_VLD_OUT = 0x0,
+    #[doc = "VBUS_VALID_3V comparator result."]
+    VBUS_VLD_3V_OUT = 0x01,
+}
+impl VBUSVALID_SEL {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> VBUSVALID_SEL {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for VBUSVALID_SEL {
+    #[inline(always)]
+    fn from(val: u8) -> VBUSVALID_SEL {
+        VBUSVALID_SEL::from_bits(val)
+    }
+}
+impl From<VBUSVALID_SEL> for u8 {
+    #[inline(always)]
+    fn from(val: VBUSVALID_SEL) -> u8 {
+        VBUSVALID_SEL::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum VBUSVALID_THRESH {
+    #[doc = "4.0 V."]
+    VBUS_VLD_4P0 = 0x0,
+    #[doc = "4.1 V."]
+    VBUS_VLD_4P1 = 0x01,
+    #[doc = "4.2 V."]
+    VBUS_VLD_4P2 = 0x02,
+    #[doc = "4.3 V."]
+    VBUS_VLD_4P3 = 0x03,
+    #[doc = "4.4 V."]
+    VBUS_VLD_4P4 = 0x04,
+    #[doc = "4.5 V."]
+    VBUS_VLD_4P5 = 0x05,
+    #[doc = "4.6 V."]
+    VBUS_VLD_4P6 = 0x06,
+    #[doc = "4.7 V."]
+    VBUS_VLD_4P7 = 0x07,
+}
+impl VBUSVALID_THRESH {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> VBUSVALID_THRESH {
+        unsafe { core::mem::transmute(val & 0x07) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for VBUSVALID_THRESH {
+    #[inline(always)]
+    fn from(val: u8) -> VBUSVALID_THRESH {
+        VBUSVALID_THRESH::from_bits(val)
+    }
+}
+impl From<VBUSVALID_THRESH> for u8 {
+    #[inline(always)]
+    fn from(val: VBUSVALID_THRESH) -> u8 {
+        VBUSVALID_THRESH::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum VBUSVALID_TO_B {
+    #[doc = "VBUS_VALID comparator."]
+    USE_VBUS_VLD = 0x0,
+    #[doc = "Session valid detector."]
+    USE_SESS_VLD = 0x01,
+}
+impl VBUSVALID_TO_B {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> VBUSVALID_TO_B {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for VBUSVALID_TO_B {
+    #[inline(always)]
+    fn from(val: u8) -> VBUSVALID_TO_B {
+        VBUSVALID_TO_B::from_bits(val)
+    }
+}
+impl From<VBUSVALID_TO_B> for u8 {
+    #[inline(always)]
+    fn from(val: VBUSVALID_TO_B) -> u8 {
+        VBUSVALID_TO_B::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum VBUS_OVERRIDE_EN {
+    #[doc = "Results of VBUS_VALID and session valid comparators for VBUS_VALID, AVALID, BVALID, and SESSEND."]
+    VBUS_NO_OVERRIDE = 0x0,
+    #[doc = "Override values for VBUS_VALID, AVALID, BVALID, and SESSEND."]
+    VBUS_OVERRIDE = 0x01,
+}
+impl VBUS_OVERRIDE_EN {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> VBUS_OVERRIDE_EN {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for VBUS_OVERRIDE_EN {
+    #[inline(always)]
+    fn from(val: u8) -> VBUS_OVERRIDE_EN {
+        VBUS_OVERRIDE_EN::from_bits(val)
+    }
+}
+impl From<VBUS_OVERRIDE_EN> for u8 {
+    #[inline(always)]
+    fn from(val: VBUS_OVERRIDE_EN) -> u8 {
+        VBUS_OVERRIDE_EN::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum VBUS_SOURCE_SEL {
+    #[doc = "VBUS_VALID comparator result."]
+    USE_VBUS_VLD = 0x0,
+    #[doc = "Session valid comparator result."]
+    USE_ASESS_VLD = 0x01,
+    #[doc = "Session valid comparator result."]
+    USE_BSESS_VLD = 0x02,
+    _RESERVED_3 = 0x03,
+}
+impl VBUS_SOURCE_SEL {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> VBUS_SOURCE_SEL {
+        unsafe { core::mem::transmute(val & 0x03) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for VBUS_SOURCE_SEL {
+    #[inline(always)]
+    fn from(val: u8) -> VBUS_SOURCE_SEL {
+        VBUS_SOURCE_SEL::from_bits(val)
+    }
+}
+impl From<VBUS_SOURCE_SEL> for u8 {
+    #[inline(always)]
+    fn from(val: VBUS_SOURCE_SEL) -> u8 {
+        VBUS_SOURCE_SEL::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum VBUS_VALID {
+    #[doc = "Below threshold."]
+    VBUS_LO = 0x0,
+    #[doc = "Above threshold."]
+    VBUS_HI = 0x01,
+}
+impl VBUS_VALID {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> VBUS_VALID {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for VBUS_VALID {
+    #[inline(always)]
+    fn from(val: u8) -> VBUS_VALID {
+        VBUS_VALID::from_bits(val)
+    }
+}
+impl From<VBUS_VALID> for u8 {
+    #[inline(always)]
+    fn from(val: VBUS_VALID) -> u8 {
+        VBUS_VALID::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum VBUS_VALID_3V {
+    #[doc = "Below threshold."]
+    VBUS_VLD3V_LO = 0x0,
+    #[doc = "Above threshold."]
+    VBUS_VLD3V_HI = 0x01,
+}
+impl VBUS_VALID_3V {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> VBUS_VALID_3V {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for VBUS_VALID_3V {
+    #[inline(always)]
+    fn from(val: u8) -> VBUS_VALID_3V {
+        VBUS_VALID_3V::from_bits(val)
+    }
+}
+impl From<VBUS_VALID_3V> for u8 {
+    #[inline(always)]
+    fn from(val: VBUS_VALID_3V) -> u8 {
+        VBUS_VALID_3V::to_bits(val)
+    }
+}
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum VDM_SRC_ENABLE {
+    #[doc = "Disable."]
+    DCD_VDM_SRC_DISABLE = 0x0,
+    #[doc = "Enable."]
+    DCD_VDM_SRC_ENABLE = 0x01,
+}
+impl VDM_SRC_ENABLE {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> VDM_SRC_ENABLE {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for VDM_SRC_ENABLE {
+    #[inline(always)]
+    fn from(val: u8) -> VDM_SRC_ENABLE {
+        VDM_SRC_ENABLE::from_bits(val)
+    }
+}
+impl From<VDM_SRC_ENABLE> for u8 {
+    #[inline(always)]
+    fn from(val: VDM_SRC_ENABLE) -> u8 {
+        VDM_SRC_ENABLE::to_bits(val)
+    }
+}


### PR DESCRIPTION
## Summary

Adds MCXA577 USBHS, USBNC, and USBPHY PAC register support generated from the NXP MCXA577 DFP SVD.

## Details

- Adds `USB1` at `0x4002E000` using `mcxa/USBHS`
- Adds `USBNC` at `0x4002E200`
- Adds `USB1_HS_PHY` at `0x4002F000`
- Adds generated MetaPAC YAML and Rust register blocks
- Curates a few SVD enum names to avoid generated Rust type-name collisions

## Validation

- `cargo check -p nxp-pac --features mcxa577`
- Consumed from Embassy MCXA USBHS driver via commit `1a3fd38855dc1d9c81c3ecdf7be2188e363180f0`