### PR TITLE
Add FlexCAN Enhanced RX FIFO Registers + Add Optional "bit" Field to "gate" in JSON Schema

### DIFF
--- a/data/metadata/MCXA2xx.json
+++ b/data/metadata/MCXA2xx.json
@@ -1131,7 +1131,8 @@
       "gate": {
         "enable": "mrcc_glb_cc1",
         "reset": "mrcc_glb_rst1",
-        "config": "CanConfig"
+        "config": "CanConfig",
+        "bit": "flexcan0"
       }
     },
     {
@@ -1208,7 +1209,8 @@
       "gate": {
         "enable": "mrcc_glb_cc1",
         "reset": "mrcc_glb_rst1",
-        "config": "CanConfig"
+        "config": "CanConfig",
+        "bit": "flexcan1"
       }
     },
     {

--- a/data/metadata/MCXA5xx.json
+++ b/data/metadata/MCXA5xx.json
@@ -1230,7 +1230,8 @@
       "gate": {
         "enable": "mrcc_glb_cc2",
         "reset": "mrcc_glb_rst2",
-        "config": "CanConfig"
+        "config": "CanConfig",
+        "bit": "flexcan0"
       }
     },
     {
@@ -1307,7 +1308,8 @@
       "gate": {
         "enable": "mrcc_glb_cc2",
         "reset": "mrcc_glb_rst2",
-        "config": "CanConfig"
+        "config": "CanConfig",
+        "bit": "flexcan1"
       }
     },
     {

--- a/data/metadata/peripherals/mcxa/CAN.yaml
+++ b/data/metadata/peripherals/mcxa/CAN.yaml
@@ -252,6 +252,23 @@ block/Can:
       stride: 4
     byte_offset: 12288
     fieldset: Erffel
+  - name: erfifo_cs
+    description: Enhanced RX FIFO output element CS field. Reads the CS word of the oldest element in the Enhanced RX FIFO.
+    byte_offset: 8192
+    access: Read
+    fieldset: Cs
+  - name: erfifo_id
+    description: Enhanced RX FIFO output element ID field. Reads the ID word of the oldest element in the Enhanced RX FIFO.
+    byte_offset: 8196
+    access: Read
+    fieldset: Id
+  - name: erfifo_data
+    description: Enhanced RX FIFO output element DATA words. Reads the payload of the oldest element in the Enhanced RX FIFO (up to 16 words / 64 bytes).
+    array:
+      len: 16
+      stride: 4
+    byte_offset: 8200
+    access: Read
 block/Wmb:
   description: 'Array of registers: WMB_CS, WMB_D03, WMB_D47, WMB_ID.'
   items:

--- a/data/metadata/schema.json
+++ b/data/metadata/schema.json
@@ -148,6 +148,10 @@
             "config": {
               "description": "The name of the config type used for setting up the clocks",
               "type": "string"
+            },
+            "bit": {
+              "description": "The name of the bit field inside the MRCC registers. Defaults to the lowercased peripheral name if not manually specified.",
+              "type": "string"
             }
           },
           "required": [

--- a/generator/src/metadata.rs
+++ b/generator/src/metadata.rs
@@ -136,6 +136,8 @@ pub struct Gate {
     pub enable: String,
     pub reset: Option<String>,
     pub config: Option<String>,
+    #[serde(default)]
+    pub bit: Option<String>,
 }
 
 fn generate_metadata(name: &str, metadata: &Metadata) -> TokenStream {
@@ -260,6 +262,7 @@ fn generate_metadata(name: &str, metadata: &Metadata) -> TokenStream {
                 enable,
                 reset,
                 config,
+                bit,
             }) => {
                 let reset = match reset {
                     Some(reset) => quote! { Some(#reset) },
@@ -269,12 +272,17 @@ fn generate_metadata(name: &str, metadata: &Metadata) -> TokenStream {
                     Some(config) => quote! { Some(#config) },
                     None => quote! { None },
                 };
+                let bit = match bit.clone() {
+                    Some(bit) => { bit },
+                    None => { name.to_lowercase() }
+                };
 
                 quote! {
                     Some(Gate {
                         enable: #enable,
                         reset: #reset,
                         config: #config,
+                        bit: #bit,
                     })
                 }
             }

--- a/nxp-pac/src/chips/mcxa256/metadata.rs
+++ b/nxp-pac/src/chips/mcxa256/metadata.rs
@@ -810,6 +810,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("AdcConfig"),
+            bit: "adc0",
         }),
     },
     Peripheral {
@@ -1017,6 +1018,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("AdcConfig"),
+            bit: "adc1",
         }),
     },
     Peripheral {
@@ -1131,6 +1133,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("CanConfig"),
+            bit: "flexcan0",
         }),
     },
     Peripheral {
@@ -1221,6 +1224,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("CanConfig"),
+            bit: "flexcan1",
         }),
     },
     Peripheral {
@@ -1469,6 +1473,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc0",
             reset: Some("mrcc_glb_rst0"),
             config: None,
+            bit: "crc0",
         }),
     },
     Peripheral {
@@ -2036,6 +2041,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("CTimerConfig"),
+            bit: "ctimer0",
         }),
     },
     Peripheral {
@@ -2528,6 +2534,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("CTimerConfig"),
+            bit: "ctimer1",
         }),
     },
     Peripheral {
@@ -3040,6 +3047,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("CTimerConfig"),
+            bit: "ctimer2",
         }),
     },
     Peripheral {
@@ -3547,6 +3555,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("CTimerConfig"),
+            bit: "ctimer3",
         }),
     },
     Peripheral {
@@ -4049,6 +4058,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("CTimerConfig"),
+            bit: "ctimer4",
         }),
     },
     Peripheral {
@@ -4074,6 +4084,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("DacConfig"),
+            bit: "dac0",
         }),
     },
     Peripheral {
@@ -4133,6 +4144,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: None,
+            bit: "dma0",
         }),
     },
     Peripheral {
@@ -6101,6 +6113,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc2",
             reset: Some("mrcc_glb_rst2"),
             config: None,
+            bit: "gpio0",
         }),
     },
     Peripheral {
@@ -6326,6 +6339,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc2",
             reset: Some("mrcc_glb_rst2"),
             config: None,
+            bit: "gpio1",
         }),
     },
     Peripheral {
@@ -6587,6 +6601,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc2",
             reset: Some("mrcc_glb_rst2"),
             config: None,
+            bit: "gpio2",
         }),
     },
     Peripheral {
@@ -6893,6 +6908,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc2",
             reset: Some("mrcc_glb_rst2"),
             config: None,
+            bit: "gpio3",
         }),
     },
     Peripheral {
@@ -6983,6 +6999,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc2",
             reset: Some("mrcc_glb_rst2"),
             config: None,
+            bit: "gpio4",
         }),
     },
     Peripheral {
@@ -7066,6 +7083,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("I3cConfig"),
+            bit: "i3c0",
         }),
     },
     Peripheral {
@@ -7079,6 +7097,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc0",
             reset: Some("mrcc_glb_rst0"),
             config: None,
+            bit: "inputmux0",
         }),
     },
     Peripheral {
@@ -7187,6 +7206,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("Lpi2cConfig"),
+            bit: "lpi2c0",
         }),
     },
     Peripheral {
@@ -7276,6 +7296,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("Lpi2cConfig"),
+            bit: "lpi2c1",
         }),
     },
     Peripheral {
@@ -7374,6 +7395,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("Lpi2cConfig"),
+            bit: "lpi2c2",
         }),
     },
     Peripheral {
@@ -7458,6 +7480,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("Lpi2cConfig"),
+            bit: "lpi2c3",
         }),
     },
     Peripheral {
@@ -7595,6 +7618,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("LpspiConfig"),
+            bit: "lpspi0",
         }),
     },
     Peripheral {
@@ -7737,6 +7761,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("LpspiConfig"),
+            bit: "lpspi1",
         }),
     },
     Peripheral {
@@ -7878,6 +7903,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("LpuartConfig"),
+            bit: "lpuart0",
         }),
     },
     Peripheral {
@@ -8012,6 +8038,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("LpuartConfig"),
+            bit: "lpuart1",
         }),
     },
     Peripheral {
@@ -8151,6 +8178,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("LpuartConfig"),
+            bit: "lpuart2",
         }),
     },
     Peripheral {
@@ -8260,6 +8288,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("LpuartConfig"),
+            bit: "lpuart3",
         }),
     },
     Peripheral {
@@ -8379,6 +8408,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("LpuartConfig"),
+            bit: "lpuart4",
         }),
     },
     Peripheral {
@@ -8508,6 +8538,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("LpuartConfig"),
+            bit: "lpuart5",
         }),
     },
     Peripheral {
@@ -8598,6 +8629,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("OsTimerConfig"),
+            bit: "ostimer0",
         }),
     },
     Peripheral {
@@ -8620,6 +8652,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: None,
+            bit: "port0",
         }),
     },
     Peripheral {
@@ -8633,6 +8666,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: None,
+            bit: "port1",
         }),
     },
     Peripheral {
@@ -8646,6 +8680,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: None,
+            bit: "port2",
         }),
     },
     Peripheral {
@@ -8659,6 +8694,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: None,
+            bit: "port3",
         }),
     },
     Peripheral {
@@ -8672,6 +8708,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: None,
+            bit: "port4",
         }),
     },
     Peripheral {
@@ -8764,6 +8801,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: None,
             config: Some("Clk1MConfig"),
+            bit: "sgi0",
         }),
     },
     Peripheral {
@@ -10352,6 +10390,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: None,
+            bit: "trng0",
         }),
     },
     Peripheral {
@@ -10775,6 +10814,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: None,
             config: Some("Clk1MConfig"),
+            bit: "wwdt0",
         }),
     },
     Peripheral {

--- a/nxp-pac/src/chips/mcxa577/metadata.rs
+++ b/nxp-pac/src/chips/mcxa577/metadata.rs
@@ -968,6 +968,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("AdcConfig"),
+            bit: "adc0",
         }),
     },
     Peripheral {
@@ -1166,6 +1167,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("AdcConfig"),
+            bit: "adc1",
         }),
     },
     Peripheral {
@@ -1254,6 +1256,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc2",
             reset: Some("mrcc_glb_rst2"),
             config: Some("CanConfig"),
+            bit: "flexcan0",
         }),
     },
     Peripheral {
@@ -1344,6 +1347,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc2",
             reset: Some("mrcc_glb_rst2"),
             config: Some("CanConfig"),
+            bit: "flexcan1",
         }),
     },
     Peripheral {
@@ -1506,6 +1510,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc0",
             reset: Some("mrcc_glb_rst0"),
             config: None,
+            bit: "crc0",
         }),
     },
     Peripheral {
@@ -2105,6 +2110,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("CTimerConfig"),
+            bit: "ctimer0",
         }),
     },
     Peripheral {
@@ -2629,6 +2635,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("CTimerConfig"),
+            bit: "ctimer1",
         }),
     },
     Peripheral {
@@ -3173,6 +3180,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("CTimerConfig"),
+            bit: "ctimer2",
         }),
     },
     Peripheral {
@@ -3722,6 +3730,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("CTimerConfig"),
+            bit: "ctimer3",
         }),
     },
     Peripheral {
@@ -4256,6 +4265,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("CTimerConfig"),
+            bit: "ctimer4",
         }),
     },
     Peripheral {
@@ -4281,6 +4291,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("DacConfig"),
+            bit: "dac0",
         }),
     },
     Peripheral {
@@ -4306,6 +4317,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("DacConfig"),
+            bit: "dac1",
         }),
     },
     Peripheral {
@@ -4374,6 +4386,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: None,
+            bit: "dma0",
         }),
     },
     Peripheral {
@@ -4387,6 +4400,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: None,
+            bit: "dma1",
         }),
     },
     Peripheral {
@@ -5606,6 +5620,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc2",
             reset: Some("mrcc_glb_rst2"),
             config: Some("FlexspiConfig"),
+            bit: "flexspi0",
         }),
     },
     Peripheral {
@@ -5955,6 +5970,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc3",
             reset: Some("mrcc_glb_rst3"),
             config: None,
+            bit: "gpio0",
         }),
     },
     Peripheral {
@@ -6180,6 +6196,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc3",
             reset: Some("mrcc_glb_rst3"),
             config: None,
+            bit: "gpio1",
         }),
     },
     Peripheral {
@@ -6477,6 +6494,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc3",
             reset: Some("mrcc_glb_rst3"),
             config: None,
+            bit: "gpio2",
         }),
     },
     Peripheral {
@@ -6747,6 +6765,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc3",
             reset: Some("mrcc_glb_rst3"),
             config: None,
+            bit: "gpio3",
         }),
     },
     Peripheral {
@@ -6891,6 +6910,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc3",
             reset: Some("mrcc_glb_rst3"),
             config: None,
+            bit: "gpio4",
         }),
     },
     Peripheral {
@@ -6999,6 +7019,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc3",
             reset: None,
             config: None,
+            bit: "gpio5",
         }),
     },
     Peripheral {
@@ -7072,6 +7093,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc2",
             reset: Some("mrcc_glb_rst2"),
             config: Some("I3cConfig"),
+            bit: "i3c0",
         }),
     },
     Peripheral {
@@ -7186,6 +7208,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc2",
             reset: Some("mrcc_glb_rst2"),
             config: Some("I3cConfig"),
+            bit: "i3c1",
         }),
     },
     Peripheral {
@@ -7259,6 +7282,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc2",
             reset: Some("mrcc_glb_rst2"),
             config: Some("I3cConfig"),
+            bit: "i3c2",
         }),
     },
     Peripheral {
@@ -7332,6 +7356,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc2",
             reset: Some("mrcc_glb_rst2"),
             config: Some("I3cConfig"),
+            bit: "i3c3",
         }),
     },
     Peripheral {
@@ -7345,6 +7370,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc0",
             reset: Some("mrcc_glb_rst0"),
             config: None,
+            bit: "inputmux0",
         }),
     },
     Peripheral {
@@ -7479,6 +7505,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("Lpi2cConfig"),
+            bit: "lpi2c0",
         }),
     },
     Peripheral {
@@ -7568,6 +7595,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("Lpi2cConfig"),
+            bit: "lpi2c1",
         }),
     },
     Peripheral {
@@ -7666,6 +7694,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("Lpi2cConfig"),
+            bit: "lpi2c2",
         }),
     },
     Peripheral {
@@ -7801,6 +7830,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("Lpi2cConfig"),
+            bit: "lpi2c3",
         }),
     },
     Peripheral {
@@ -7946,6 +7976,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("Lpi2cConfig"),
+            bit: "lpi2c4",
         }),
     },
     Peripheral {
@@ -8083,6 +8114,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("LpspiConfig"),
+            bit: "lpspi0",
         }),
     },
     Peripheral {
@@ -8225,6 +8257,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("LpspiConfig"),
+            bit: "lpspi1",
         }),
     },
     Peripheral {
@@ -8362,6 +8395,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("LpspiConfig"),
+            bit: "lpspi2",
         }),
     },
     Peripheral {
@@ -8534,6 +8568,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("LpspiConfig"),
+            bit: "lpspi3",
         }),
     },
     Peripheral {
@@ -8671,6 +8706,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("LpspiConfig"),
+            bit: "lpspi4",
         }),
     },
     Peripheral {
@@ -8808,6 +8844,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc1",
             reset: Some("mrcc_glb_rst1"),
             config: Some("LpspiConfig"),
+            bit: "lpspi5",
         }),
     },
     Peripheral {
@@ -8976,6 +9013,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("LpuartConfig"),
+            bit: "lpuart0",
         }),
     },
     Peripheral {
@@ -9110,6 +9148,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("LpuartConfig"),
+            bit: "lpuart1",
         }),
     },
     Peripheral {
@@ -9249,6 +9288,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("LpuartConfig"),
+            bit: "lpuart2",
         }),
     },
     Peripheral {
@@ -9358,6 +9398,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("LpuartConfig"),
+            bit: "lpuart3",
         }),
     },
     Peripheral {
@@ -9462,6 +9503,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("LpuartConfig"),
+            bit: "lpuart4",
         }),
     },
     Peripheral {
@@ -9591,6 +9633,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("LpuartConfig"),
+            bit: "lpuart5",
         }),
     },
     Peripheral {
@@ -9613,6 +9656,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc0",
             reset: Some("mrcc_glb_rst0"),
             config: Some("OsTimerConfig"),
+            bit: "ostimer0",
         }),
     },
     Peripheral {
@@ -9762,6 +9806,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: None,
+            bit: "port0",
         }),
     },
     Peripheral {
@@ -9775,6 +9820,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: None,
+            bit: "port1",
         }),
     },
     Peripheral {
@@ -9788,6 +9834,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: None,
+            bit: "port2",
         }),
     },
     Peripheral {
@@ -9801,6 +9848,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: None,
+            bit: "port3",
         }),
     },
     Peripheral {
@@ -9814,6 +9862,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: Some("mrcc_glb_rst1"),
             config: None,
+            bit: "port4",
         }),
     },
     Peripheral {
@@ -9827,6 +9876,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc1",
             reset: None,
             config: None,
+            bit: "port5",
         }),
     },
     Peripheral {
@@ -9910,6 +9960,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_cc4",
             reset: None,
             config: Some("Clk1MConfig"),
+            bit: "sgi0",
         }),
     },
     Peripheral {
@@ -11110,6 +11161,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc4",
             reset: Some("mrcc_glb_rst4"),
             config: None,
+            bit: "trng0",
         }),
     },
     Peripheral {
@@ -12690,6 +12742,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: None,
             config: Some("Clk1MConfig"),
+            bit: "wwdt0",
         }),
     },
     Peripheral {
@@ -12703,6 +12756,7 @@ pub const PERIPHERALS: &[Peripheral] = &[
             enable: "mrcc_glb_acc0",
             reset: None,
             config: Some("Clk1MConfig"),
+            bit: "wwdt1",
         }),
     },
     Peripheral {

--- a/nxp-pac/src/meta_peripherals/mcxa/CAN.rs
+++ b/nxp-pac/src/meta_peripherals/mcxa/CAN.rs
@@ -338,6 +338,27 @@ impl Can {
     pub const fn erfsr(self) -> crate::pac::common::Reg<Erfsr, crate::pac::common::RW> {
         unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x0c14usize) as _) }
     }
+    #[doc = "Enhanced RX FIFO output element CS field. Reads the CS word of the oldest element in the Enhanced RX FIFO."]
+    #[inline(always)]
+    pub const fn erfifo_cs(self) -> crate::pac::common::Reg<Cs, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x2000usize) as _) }
+    }
+    #[doc = "Enhanced RX FIFO output element ID field. Reads the ID word of the oldest element in the Enhanced RX FIFO."]
+    #[inline(always)]
+    pub const fn erfifo_id(self) -> crate::pac::common::Reg<Id, crate::pac::common::R> {
+        unsafe { crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x2004usize) as _) }
+    }
+    #[doc = "Enhanced RX FIFO output element DATA words. Reads the payload of the oldest element in the Enhanced RX FIFO (up to 16 words / 64 bytes)."]
+    #[inline(always)]
+    pub const fn erfifo_data(
+        self,
+        n: usize,
+    ) -> crate::pac::common::Reg<u32, crate::pac::common::R> {
+        assert!(n < 16usize);
+        unsafe {
+            crate::pac::common::Reg::from_ptr(self.ptr.wrapping_add(0x2008usize + n * 4usize) as _)
+        }
+    }
     #[doc = "Enhanced RX FIFO Filter Element."]
     #[inline(always)]
     pub const fn erffel(self, n: usize) -> crate::pac::common::Reg<Erffel, crate::pac::common::RW> {

--- a/nxp-pac/src/metadata.rs
+++ b/nxp-pac/src/metadata.rs
@@ -79,6 +79,7 @@ pub struct Gate {
     pub enable: &'static str,
     pub reset: Option<&'static str>,
     pub config: Option<&'static str>,
+    pub bit: &'static str,
 }
 
 pub use _generated::*;


### PR DESCRIPTION
This PR adds PAC access to the FlexCAN Enhanced RX FIFO memory area (2000h - 2048h, ref page 1556 of the [datasheet](https://www.nxp.com/webapp/Download?colCode=MCXAP144M240F61RM)).

This PR also adds an optional "bit" field to "gate" inside `schema.rs`. Additions to `generator/src/metadata.rs` were also made to support this new field. Mainly, when unspecified in the JSON, this field will default to `peripheral.name.to_lowercase()`, which was the default behavior used in embassy-mcxa's `build.rs` for `bit`. Unfortunately, while the assumption that `bit == peripheral.name.to_lowercase()` holds for most peripherals, it doesn't for all, which results in build errors (mentioned [here](https://github.com/embassy-rs/embassy/pull/6524) and [here](https://github.com/embassy-rs/embassy/pull/6525/changes)) due to the FlexCAN additions. So, it made the most sense to move the name->bit mapping into the PAC. This way, the old behavior (where `bit == peripheral.name.to_lowercase()` is assumed across the board) is still the default, but can be manually overridden in the JSON for peripherals that diverge from that convention (like CAN0 and CAN1).

Following the above, this PR also uses the new `bit` field to correct the FlexCAN bit names for mcxa2xx and mcxa5xx. For now, FlexCAN is the only peripheral where `bit` doesn't follow `bit == peripheral.name.to_lowercase()`  and needs to be overwritten. However, there also seem to be inconsistencies between the Peripheral Name and the MRCC gate bit name for `FREQME0`, `FMC0`, `EQDC0`, `EQDC1`, `SPI_Filter0`, and `ROMCP`. These peripherals don't seem to have `gate` populated right now and don't currently break anything like `CAN0` and `CAN1` do, but manual `bit` names may need to be specified in the future if that ever changes.

Note: Due to these changes, `generate_cc_gates()` in embassy-mcxa can look something like this now:
```rust
fn generate_cc_gates() -> TokenStream {
    let mut generated = TokenStream::new();

    for peripheral in METADATA.peripherals {
        let Some(gate) = peripheral.gate.as_ref() else {
            continue;
        };

        let peripheral_name = format_ident!("{}", peripheral.name);
        let enable = format_ident!("{}", gate.enable);
        let reset = gate.reset.map(|reset| format_ident!("{reset}"));
        let config = gate
            .config
            .map(|config| format_ident!("{config}"))
            .unwrap_or_else(|| format_ident!("NoConfig"));
        let bit = format_ident!("{}", gate.bit);

        match reset {
            Some(reset) => generated.extend(quote! {
                crate::impl_cc_gate!(#peripheral_name, #enable, #reset, #bit, #config);
            }),
            None => generated.extend(quote! {
                crate::impl_cc_gate!(#peripheral_name, #enable, #bit, #config);
            }),
        }
    }

    generated
}
```
(...since `bit` is now provided via the PAC)