### PR TITLE
metadata: add USB0 peripheral for LPC55

### DIFF
--- a/data/metadata/LPC55S16.json
+++ b/data/metadata/LPC55S16.json
@@ -515,6 +515,11 @@
       "name": "USBHSD",
       "address": "0x4009_4000",
       "signals": []
+    },
+    {
+      "name": "USB0",
+      "address": "0x4008_4000",
+      "signals": []
     }
   ]
 }

--- a/data/metadata/LPC55S6x.json
+++ b/data/metadata/LPC55S6x.json
@@ -555,6 +555,11 @@
       "name": "USBHSD",
       "address": "0x4009_4000",
       "signals": []
+    },
+    {
+      "name": "USB0",
+      "address": "0x4008_4000",
+      "signals": []
     }
   ]
 }

--- a/nxp-pac/src/chips/lpc55s16/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s16/metadata.rs
@@ -1735,6 +1735,15 @@ pub const PERIPHERALS: &[Peripheral] = &[
         dma_muxing: &[],
         gate: None,
     },
+    Peripheral {
+        name: "USB0",
+        address: 0x4008_4000,
+        driver_name: "",
+        signals: &[],
+        flexcomm: None,
+        dma_muxing: &[],
+        gate: None,
+    },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[
     ("WDT_BOD", 0u32),

--- a/nxp-pac/src/chips/lpc55s69_cm33_core0/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s69_cm33_core0/metadata.rs
@@ -1954,6 +1954,15 @@ pub const PERIPHERALS: &[Peripheral] = &[
         dma_muxing: &[],
         gate: None,
     },
+    Peripheral {
+        name: "USB0",
+        address: 0x4008_4000,
+        driver_name: "",
+        signals: &[],
+        flexcomm: None,
+        dma_muxing: &[],
+        gate: None,
+    },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[
     ("WDT_BOD", 0u32),

--- a/nxp-pac/src/chips/lpc55s69_cm33_core1/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s69_cm33_core1/metadata.rs
@@ -1954,6 +1954,15 @@ pub const PERIPHERALS: &[Peripheral] = &[
         dma_muxing: &[],
         gate: None,
     },
+    Peripheral {
+        name: "USB0",
+        address: 0x4008_4000,
+        driver_name: "",
+        signals: &[],
+        flexcomm: None,
+        dma_muxing: &[],
+        gate: None,
+    },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[
     ("WDT_BOD", 0u32),


### PR DESCRIPTION
Adds the `USB0` (full-speed device/host) peripheral to the LPC55S6x/LPC55S16 metadata, so `embassy-nxp` can generate the `USB0` singleton and `interrupt::typelevel::USB0` binding for the LPC55 full-speed USB device driver (embassy-rs/embassy#6559).

Rebased onto main (`8512ece`) and regenerated. The `USBHSD` half of this PR is no longer needed — main already carries that peripheral — so only the `USB0` entry remains.

`address` is `0x4008_4000`, matching `pub const USB0` in the generated PACs for both LPC55S6x cores and LPC55S16.