### PR TITLE
LPC55S6x: add ADC0 peripheral

### DIFF
--- a/data/metadata/LPC55S6x.json
+++ b/data/metadata/LPC55S6x.json
@@ -126,6 +126,7 @@
     { "name": "VREFN" }
   ],
   "peripherals": [
+    {"name": "ADC0", "signals": []},
     {
       "name": "DMA0",
       "signals": [

--- a/nxp-pac/src/chips/lpc55s69_cm33_core0/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s69_cm33_core0/metadata.rs
@@ -339,6 +339,15 @@ pub const PINS: &[Pin] = &[
 ];
 pub const PERIPHERALS: &[Peripheral] = &[
     Peripheral {
+        name: "ADC0",
+        address: 0,
+        driver_name: "",
+        signals: &[],
+        flexcomm: None,
+        dma_muxing: &[],
+        gate: None,
+    },
+    Peripheral {
         name: "DMA0",
         address: 0,
         driver_name: "",

--- a/nxp-pac/src/chips/lpc55s69_cm33_core1/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s69_cm33_core1/metadata.rs
@@ -339,6 +339,15 @@ pub const PINS: &[Pin] = &[
 ];
 pub const PERIPHERALS: &[Peripheral] = &[
     Peripheral {
+        name: "ADC0",
+        address: 0,
+        driver_name: "",
+        signals: &[],
+        flexcomm: None,
+        dma_muxing: &[],
+        gate: None,
+    },
+    Peripheral {
         name: "DMA0",
         address: 0,
         driver_name: "",


### PR DESCRIPTION
Added ADC0 peripheral to the board metadata and regenerated the PAC