### PR TITLE
metadata: add HASHCRYPT peripheral for LPC55S6x

### DIFF
--- a/data/metadata/LPC55S16.json
+++ b/data/metadata/LPC55S16.json
@@ -593,6 +593,11 @@
       "name": "USB0",
       "address": "0x4008_4000",
       "signals": []
+    },
+    {
+      "name": "HASHCRYPT",
+      "address": "0x400A_4000",
+      "signals": []
     }
   ]
 }

--- a/data/metadata/LPC55S6x.json
+++ b/data/metadata/LPC55S6x.json
@@ -561,6 +561,11 @@
       "name": "USB0",
       "address": "0x4008_4000",
       "signals": []
+    },
+    {
+      "name": "HASHCRYPT",
+      "address": "0x400A_4000",
+      "signals": []
     }
   ]
 }

--- a/nxp-pac/src/chips/lpc55s16/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s16/metadata.rs
@@ -2049,6 +2049,15 @@ pub const PERIPHERALS: &[Peripheral] = &[
         dma_muxing: &[],
         gate: None,
     },
+    Peripheral {
+        name: "HASHCRYPT",
+        address: 0x400A_4000,
+        driver_name: "",
+        signals: &[],
+        flexcomm: None,
+        dma_muxing: &[],
+        gate: None,
+    },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[
     ("WDT_BOD", 0u32),

--- a/nxp-pac/src/chips/lpc55s69_cm33_core0/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s69_cm33_core0/metadata.rs
@@ -1972,6 +1972,15 @@ pub const PERIPHERALS: &[Peripheral] = &[
         dma_muxing: &[],
         gate: None,
     },
+    Peripheral {
+        name: "HASHCRYPT",
+        address: 0x400A_4000,
+        driver_name: "",
+        signals: &[],
+        flexcomm: None,
+        dma_muxing: &[],
+        gate: None,
+    },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[
     ("WDT_BOD", 0u32),

--- a/nxp-pac/src/chips/lpc55s69_cm33_core1/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s69_cm33_core1/metadata.rs
@@ -1972,6 +1972,15 @@ pub const PERIPHERALS: &[Peripheral] = &[
         dma_muxing: &[],
         gate: None,
     },
+    Peripheral {
+        name: "HASHCRYPT",
+        address: 0x400A_4000,
+        driver_name: "",
+        signals: &[],
+        flexcomm: None,
+        dma_muxing: &[],
+        gate: None,
+    },
 ];
 pub const INTERRUPTS: &[(&str, u32)] = &[
     ("WDT_BOD", 0u32),


### PR DESCRIPTION
### Summary
This PR adds the HASHCRYPT peripheral metadata for the LPC55S6x family. 

### Changes:
- Add the HASHCRYPT peripheral to the LPC55S6x metadata.
- Generate the corresponding metadata for both LPC55S69 CM33 core0 and core1.

@eva-cosma 