### PR TITLE
Add ADC pins for LPC55 family

### DIFF
--- a/data/metadata/LPC55S16.json
+++ b/data/metadata/LPC55S16.json
@@ -126,7 +126,21 @@
     { "name": "VREFN" }
   ],
   "peripherals": [
-    {"name": "ADC0", "signals": []},
+    {
+      "name": "ADC0",
+      "signals": [
+        { "name": "CH0_A", "pins": [{ "pin": "PIO0_23", "alt": 0 }] },
+        { "name": "CH0_B", "pins": [{ "pin": "PIO0_16", "alt": 0 }] },
+        { "name": "CH1_A", "pins": [{ "pin": "PIO0_10", "alt": 0 }] },
+        { "name": "CH1_B", "pins": [{ "pin": "PIO0_11", "alt": 0 }] },
+        { "name": "CH2_A", "pins": [{ "pin": "PIO0_15", "alt": 0 }] },
+        { "name": "CH2_B", "pins": [{ "pin": "PIO0_12", "alt": 0 }] },
+        { "name": "CH3_A", "pins": [{ "pin": "PIO0_31", "alt": 0 }] },
+        { "name": "CH3_B", "pins": [{ "pin": "PIO1_0", "alt": 0 }] },
+        { "name": "CH4_A", "pins": [{ "pin": "PIO1_8", "alt": 0 }] },
+        { "name": "CH4_B", "pins": [{ "pin": "PIO1_9", "alt": 0 }] }
+      ]
+    },
     {
       "name": "DMA0",
       "signals": [

--- a/data/metadata/LPC55S6x.json
+++ b/data/metadata/LPC55S6x.json
@@ -126,7 +126,21 @@
     { "name": "VREFN" }
   ],
   "peripherals": [
-    {"name": "ADC0", "signals": []},
+    {
+      "name": "ADC0",
+      "signals": [
+        { "name": "CH0_A", "pins": [{ "pin": "PIO0_23", "alt": 0 }] },
+        { "name": "CH0_B", "pins": [{ "pin": "PIO0_16", "alt": 0 }] },
+        { "name": "CH1_A", "pins": [{ "pin": "PIO0_10", "alt": 0 }] },
+        { "name": "CH1_B", "pins": [{ "pin": "PIO0_11", "alt": 0 }] },
+        { "name": "CH2_A", "pins": [{ "pin": "PIO0_15", "alt": 0 }] },
+        { "name": "CH2_B", "pins": [{ "pin": "PIO0_12", "alt": 0 }] },
+        { "name": "CH3_A", "pins": [{ "pin": "PIO0_31", "alt": 0 }] },
+        { "name": "CH3_B", "pins": [{ "pin": "PIO1_0", "alt": 0 }] },
+        { "name": "CH4_A", "pins": [{ "pin": "PIO1_8", "alt": 0 }] },
+        { "name": "CH4_B", "pins": [{ "pin": "PIO1_9", "alt": 0 }] }
+      ]
+    },
     {
       "name": "DMA0",
       "signals": [

--- a/data/transforms/lpc55s16.yaml
+++ b/data/transforms/lpc55s16.yaml
@@ -96,6 +96,9 @@ transforms:
     from: syscon::regs::Presetctrlx\d
 
   - !MergeEnums
+    from: iocon::vals::Pio\d+Asw
+    to: iocon::vals::PioAsw
+  - !MergeEnums
     from: iocon::vals::Pio\d+Digimode
     to: iocon::vals::PioDigimode
   - !MergeEnums
@@ -128,6 +131,28 @@ transforms:
     to: iocon::regs::Pio
     main: iocon::regs::Pio013
     check: NoCheck
+
+  - !Add
+    ir:
+      enum/iocon::vals::PioAsw:
+        description: Analog switch input control.
+        bit_size: 1
+        variants:
+          - name: disabled
+            description: Analog switch is disabled.
+            value: 0
+          - name: enabled
+            description: Analog switch is enabled.
+            value: 1
+
+  - !AddFields
+    fieldset: iocon::regs::Pio
+    fields:
+      - name: asw
+        description: "Analog switch input control."
+        bit_offset: 10
+        bit_size: 1
+        enum: iocon::vals::PioAsw
 
   - !MakeRegisterArray
     blocks: iocon::Iocon

--- a/nxp-pac/src/chips/lpc55s16/iocon/regs.rs
+++ b/nxp-pac/src/chips/lpc55s16/iocon/regs.rs
@@ -75,6 +75,18 @@ impl Pio {
     pub const fn set_od(&mut self, val: super::vals::PioOd) {
         self.0 = (self.0 & !(0x01 << 9usize)) | (((val.to_bits() as u32) & 0x01) << 9usize);
     }
+    #[doc = "Analog switch input control."]
+    #[must_use]
+    #[inline(always)]
+    pub const fn asw(&self) -> super::vals::PioAsw {
+        let val = (self.0 >> 10usize) & 0x01;
+        super::vals::PioAsw::from_bits(val as u8)
+    }
+    #[doc = "Analog switch input control."]
+    #[inline(always)]
+    pub const fn set_asw(&mut self, val: super::vals::PioAsw) {
+        self.0 = (self.0 & !(0x01 << 10usize)) | (((val.to_bits() as u32) & 0x01) << 10usize);
+    }
     #[doc = "Supply Selection bit."]
     #[must_use]
     #[inline(always)]
@@ -151,6 +163,7 @@ impl core::fmt::Debug for Pio {
             .field("invert", &self.invert())
             .field("digimode", &self.digimode())
             .field("od", &self.od())
+            .field("asw", &self.asw())
             .field("ssel", &self.ssel())
             .field("filteroff", &self.filteroff())
             .field("ecs", &self.ecs())
@@ -164,13 +177,14 @@ impl defmt::Format for Pio {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "Pio {{ func: {:?}, mode: {:?}, slew: {:?}, invert: {=bool:?}, digimode: {:?}, od: {:?}, ssel: {:?}, filteroff: {:?}, ecs: {=bool:?}, egp: {:?}, i2cfilter: {:?} }}",
+            "Pio {{ func: {:?}, mode: {:?}, slew: {:?}, invert: {=bool:?}, digimode: {:?}, od: {:?}, asw: {:?}, ssel: {:?}, filteroff: {:?}, ecs: {=bool:?}, egp: {:?}, i2cfilter: {:?} }}",
             self.func(),
             self.mode(),
             self.slew(),
             self.invert(),
             self.digimode(),
             self.od(),
+            self.asw(),
             self.ssel(),
             self.filteroff(),
             self.ecs(),

--- a/nxp-pac/src/chips/lpc55s16/iocon/vals.rs
+++ b/nxp-pac/src/chips/lpc55s16/iocon/vals.rs
@@ -1,3 +1,35 @@
+#[doc = "Analog switch input control."]
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PioAsw {
+    #[doc = "Analog switch is disabled."]
+    disabled = 0x0,
+    #[doc = "Analog switch is enabled."]
+    enabled = 0x01,
+}
+impl PioAsw {
+    #[inline(always)]
+    pub const fn from_bits(val: u8) -> PioAsw {
+        unsafe { core::mem::transmute(val & 0x01) }
+    }
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl From<u8> for PioAsw {
+    #[inline(always)]
+    fn from(val: u8) -> PioAsw {
+        PioAsw::from_bits(val)
+    }
+}
+impl From<PioAsw> for u8 {
+    #[inline(always)]
+    fn from(val: PioAsw) -> u8 {
+        PioAsw::to_bits(val)
+    }
+}
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/nxp-pac/src/chips/lpc55s16/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s16/metadata.rs
@@ -342,7 +342,98 @@ pub const PERIPHERALS: &[Peripheral] = &[
         name: "ADC0",
         address: 0,
         driver_name: "",
-        signals: &[],
+        signals: &[
+            Signal {
+                name: "CH0_A",
+                pins: &[SignalPin {
+                    pin: "PIO0_23",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH0_B",
+                pins: &[SignalPin {
+                    pin: "PIO0_16",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH1_A",
+                pins: &[SignalPin {
+                    pin: "PIO0_10",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH1_B",
+                pins: &[SignalPin {
+                    pin: "PIO0_11",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH2_A",
+                pins: &[SignalPin {
+                    pin: "PIO0_15",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH2_B",
+                pins: &[SignalPin {
+                    pin: "PIO0_12",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH3_A",
+                pins: &[SignalPin {
+                    pin: "PIO0_31",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH3_B",
+                pins: &[SignalPin {
+                    pin: "PIO1_0",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH4_A",
+                pins: &[SignalPin {
+                    pin: "PIO1_8",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH4_B",
+                pins: &[SignalPin {
+                    pin: "PIO1_9",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+        ],
         flexcomm: None,
         dma_muxing: &[],
         gate: None,

--- a/nxp-pac/src/chips/lpc55s69_cm33_core0/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s69_cm33_core0/metadata.rs
@@ -342,7 +342,98 @@ pub const PERIPHERALS: &[Peripheral] = &[
         name: "ADC0",
         address: 0,
         driver_name: "",
-        signals: &[],
+        signals: &[
+            Signal {
+                name: "CH0_A",
+                pins: &[SignalPin {
+                    pin: "PIO0_23",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH0_B",
+                pins: &[SignalPin {
+                    pin: "PIO0_16",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH1_A",
+                pins: &[SignalPin {
+                    pin: "PIO0_10",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH1_B",
+                pins: &[SignalPin {
+                    pin: "PIO0_11",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH2_A",
+                pins: &[SignalPin {
+                    pin: "PIO0_15",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH2_B",
+                pins: &[SignalPin {
+                    pin: "PIO0_12",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH3_A",
+                pins: &[SignalPin {
+                    pin: "PIO0_31",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH3_B",
+                pins: &[SignalPin {
+                    pin: "PIO1_0",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH4_A",
+                pins: &[SignalPin {
+                    pin: "PIO1_8",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH4_B",
+                pins: &[SignalPin {
+                    pin: "PIO1_9",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+        ],
         flexcomm: None,
         dma_muxing: &[],
         gate: None,

--- a/nxp-pac/src/chips/lpc55s69_cm33_core1/metadata.rs
+++ b/nxp-pac/src/chips/lpc55s69_cm33_core1/metadata.rs
@@ -342,7 +342,98 @@ pub const PERIPHERALS: &[Peripheral] = &[
         name: "ADC0",
         address: 0,
         driver_name: "",
-        signals: &[],
+        signals: &[
+            Signal {
+                name: "CH0_A",
+                pins: &[SignalPin {
+                    pin: "PIO0_23",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH0_B",
+                pins: &[SignalPin {
+                    pin: "PIO0_16",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH1_A",
+                pins: &[SignalPin {
+                    pin: "PIO0_10",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH1_B",
+                pins: &[SignalPin {
+                    pin: "PIO0_11",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH2_A",
+                pins: &[SignalPin {
+                    pin: "PIO0_15",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH2_B",
+                pins: &[SignalPin {
+                    pin: "PIO0_12",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH3_A",
+                pins: &[SignalPin {
+                    pin: "PIO0_31",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH3_B",
+                pins: &[SignalPin {
+                    pin: "PIO1_0",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH4_A",
+                pins: &[SignalPin {
+                    pin: "PIO1_8",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+            Signal {
+                name: "CH4_B",
+                pins: &[SignalPin {
+                    pin: "PIO1_9",
+                    alt: 0u8,
+                    iomuxc_daisy: None,
+                }],
+                iomuxc_daisy: None,
+            },
+        ],
         flexcomm: None,
         dma_muxing: &[],
         gate: None,


### PR DESCRIPTION
This PR adds ADC pins initialization to LPC55S69 and LPC55S16 boards. For LPC55S16 it also ads access to ASW (analog switch) bit of IOCON register